### PR TITLE
fix(s3s/auth): compare signatures in constant time

### DIFF
--- a/crates/s3s/src/http/aws_chunked_stream.rs
+++ b/crates/s3s/src/http/aws_chunked_stream.rs
@@ -20,6 +20,7 @@ use futures::pin_mut;
 use futures::stream::{Stream, StreamExt};
 use hyper::body::{Buf, Bytes};
 use memchr::memchr;
+use subtle::ConstantTimeEq;
 
 /// Maximum size for chunk metadata
 /// Prevents `DoS` via oversized chunk size declarations
@@ -138,13 +139,17 @@ fn parse_chunk_meta(mut input: &[u8]) -> nom::IResult<&[u8], ChunkMeta<'_>> {
 }
 
 /// check signature
+fn signature_bytes_match(actual: &[u8], expected: &[u8]) -> bool {
+    actual.ct_eq(expected).into()
+}
+
 fn check_signature(ctx: &SignatureCtx, expected_signature: &[u8], chunk_data: &[Bytes]) -> Option<Box<str>> {
     let string_to_sign =
         sig_v4::create_chunk_string_to_sign(&ctx.amz_date, &ctx.region, &ctx.service, &ctx.prev_signature, chunk_data);
 
     let chunk_signature = sig_v4::calculate_signature(&string_to_sign, &ctx.secret_key, &ctx.amz_date, &ctx.region, &ctx.service);
 
-    (chunk_signature.as_bytes() == expected_signature).then(|| chunk_signature.into())
+    signature_bytes_match(chunk_signature.as_bytes(), expected_signature).then(|| chunk_signature.into())
 }
 
 impl AwsChunkedStream {
@@ -325,7 +330,7 @@ impl AwsChunkedStream {
                 create_trailer_string_to_sign(&ctx.amz_date, &ctx.region, &ctx.service, &ctx.prev_signature, &canonical_trailers);
             let trailer_signature =
                 sig_v4::calculate_signature(&string_to_sign, &ctx.secret_key, &ctx.amz_date, &ctx.region, &ctx.service);
-            if trailer_signature.as_bytes() != provided.as_slice() {
+            if !signature_bytes_match(trailer_signature.as_bytes(), provided.as_slice()) {
                 return Some(Err(AwsChunkedStreamError::SignatureMismatch));
             }
         } else if !unsigned {
@@ -604,6 +609,21 @@ mod tests {
             buf.extend_from_slice(b);
         }
         buf.into()
+    }
+
+    #[test]
+    fn signature_bytes_match_reports_match_and_mismatch() {
+        assert!(signature_bytes_match(b"abcd", b"abcd"));
+        assert!(!signature_bytes_match(b"xbcd", b"abcd"));
+        assert!(!signature_bytes_match(b"abcx", b"abcd"));
+        assert!(!signature_bytes_match(b"abcd", b"abc"));
+    }
+
+    #[test]
+    fn chunk_signature_verifiers_do_not_use_ordinary_comparison() {
+        let source = include_str!("aws_chunked_stream.rs");
+        assert!(!source.contains("chunk_signature.as_bytes() == expected_signature"));
+        assert!(!source.contains("trailer_signature.as_bytes() != provided.as_slice()"));
     }
 
     #[tokio::test]

--- a/crates/s3s/src/http/aws_chunked_stream.rs
+++ b/crates/s3s/src/http/aws_chunked_stream.rs
@@ -622,8 +622,8 @@ mod tests {
     #[test]
     fn chunk_signature_verifiers_do_not_use_ordinary_comparison() {
         let source = include_str!("aws_chunked_stream.rs");
-        assert!(!source.contains("chunk_signature.as_bytes() == expected_signature"));
-        assert!(!source.contains("trailer_signature.as_bytes() != provided.as_slice()"));
+        assert!(!source.contains(concat!("chunk_signature.as_bytes()", " == expected_signature")));
+        assert!(!source.contains(concat!("trailer_signature.as_bytes()", " != provided.as_slice()")));
     }
 
     #[tokio::test]

--- a/crates/s3s/src/http/aws_chunked_stream.rs
+++ b/crates/s3s/src/http/aws_chunked_stream.rs
@@ -621,9 +621,22 @@ mod tests {
 
     #[test]
     fn chunk_signature_verifiers_do_not_use_ordinary_comparison() {
-        let source = include_str!("aws_chunked_stream.rs");
-        assert!(!source.contains(concat!("chunk_signature.as_bytes()", " == expected_signature")));
-        assert!(!source.contains(concat!("trailer_signature.as_bytes()", " != provided.as_slice()")));
+        let source: String = include_str!("aws_chunked_stream.rs")
+            .chars()
+            .filter(|ch| !ch.is_whitespace())
+            .collect();
+
+        for (actual, expected) in [
+            ("chunk_signature.as_bytes()", "expected_signature"),
+            ("trailer_signature.as_bytes()", "provided.as_slice()"),
+        ] {
+            for operator in ["==", "!="] {
+                for (left, right) in [(actual, expected), (expected, actual)] {
+                    let comparison = format!("{left}{operator}{right}");
+                    assert!(!source.contains(&comparison), "ordinary signature comparison: {comparison}");
+                }
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -1798,8 +1798,17 @@ file content\r\n\
 
     #[test]
     fn sig_v2_verifiers_do_not_use_ordinary_signature_comparison() {
-        let source = include_str!("signature.rs");
-        assert!(!source.contains(concat!("signature !", "= expected_signature")));
+        let source: String = include_str!("signature.rs")
+            .chars()
+            .filter(|ch| !ch.is_whitespace())
+            .collect();
+
+        for operator in ["==", "!="] {
+            for (left, right) in [("signature", "expected_signature"), ("expected_signature", "signature")] {
+                let comparison = format!("{left}{operator}{right}");
+                assert!(!source.contains(&comparison), "ordinary signature comparison: {comparison}");
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -745,7 +745,7 @@ impl SignatureContext<'_> {
         let signature = sig_v2::calculate_signature(&secret_key, &string_to_sign);
 
         let expected_signature = presigned_url.signature;
-        if !signatures_match(&signature, expected_signature) {
+        if !signatures_match(&signature, &expected_signature) {
             debug!(?signature, expected=?expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -115,7 +115,7 @@ struct SignatureVerificationContext<'a> {
     service: &'a str,
 }
 
-fn sig_v4_signatures_match(actual_signature: &str, expected_signature: &str) -> bool {
+fn signatures_match(actual_signature: &str, expected_signature: &str) -> bool {
     actual_signature.as_bytes().ct_eq(expected_signature.as_bytes()).into()
 }
 
@@ -140,7 +140,7 @@ impl SignatureVerificationContext<'_> {
         let string_to_sign = sig_v4::create_string_to_sign(canonical_request, self.amz_date, self.region, self.service);
         let signature = sig_v4::calculate_signature(&string_to_sign, self.secret_key, self.amz_date, self.region, self.service);
 
-        if sig_v4_signatures_match(&signature, self.expected_signature) {
+        if signatures_match(&signature, self.expected_signature) {
             return Ok(signature);
         }
 
@@ -154,7 +154,7 @@ impl SignatureVerificationContext<'_> {
         let raw_signature =
             sig_v4::calculate_signature(&string_to_sign, self.secret_key, self.amz_date, self.region, self.service);
 
-        if !sig_v4_signatures_match(&raw_signature, self.expected_signature) {
+        if !signatures_match(&raw_signature, self.expected_signature) {
             debug!(?signature, ?raw_signature, expected=?self.expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }
@@ -317,7 +317,7 @@ impl SignatureContext<'_> {
         let signature = sig_v4::calculate_signature(string_to_sign, &secret_key, &amz_date, region, service);
 
         let expected_signature = info.x_amz_signature;
-        if !sig_v4_signatures_match(&signature, expected_signature) {
+        if !signatures_match(&signature, expected_signature) {
             debug!(?signature, expected=?expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }
@@ -678,7 +678,7 @@ impl SignatureContext<'_> {
         debug!(?string_to_sign, "sig_v2 header_auth");
 
         let expected_signature = auth_v2.signature;
-        if signature != expected_signature {
+        if !signatures_match(&signature, expected_signature) {
             debug!(?signature, expected=?expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }
@@ -708,7 +708,7 @@ impl SignatureContext<'_> {
         let signature = sig_v2::calculate_signature(&secret_key, string_to_sign);
 
         let expected_signature = info.signature;
-        if signature != expected_signature {
+        if !signatures_match(&signature, expected_signature) {
             debug!(?signature, expected=?expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }
@@ -745,7 +745,7 @@ impl SignatureContext<'_> {
         let signature = sig_v2::calculate_signature(&secret_key, &string_to_sign);
 
         let expected_signature = presigned_url.signature;
-        if signature != expected_signature {
+        if !signatures_match(&signature, expected_signature) {
             debug!(?signature, expected=?expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }
@@ -1789,10 +1789,17 @@ file content\r\n\
     }
 
     #[test]
-    fn sig_v4_signatures_match_reports_match_and_mismatch() {
-        assert!(sig_v4_signatures_match("abcd", "abcd"));
-        assert!(!sig_v4_signatures_match("abcd", "abce"));
-        assert!(!sig_v4_signatures_match("abcd", "abc"));
+    fn signatures_match_reports_match_and_mismatch() {
+        assert!(signatures_match("abcd", "abcd"));
+        assert!(!signatures_match("xbcd", "abcd"));
+        assert!(!signatures_match("abcx", "abcd"));
+        assert!(!signatures_match("abcd", "abc"));
+    }
+
+    #[test]
+    fn sig_v2_verifiers_do_not_use_ordinary_signature_comparison() {
+        let source = include_str!("signature.rs");
+        assert!(!source.contains("signature != expected_signature"));
     }
 
     #[tokio::test]

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -1799,7 +1799,7 @@ file content\r\n\
     #[test]
     fn sig_v2_verifiers_do_not_use_ordinary_signature_comparison() {
         let source = include_str!("signature.rs");
-        assert!(!source.contains("signature != expected_signature"));
+        assert!(!source.contains(concat!("signature !", "= expected_signature")));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Compare SigV2 and AWS chunked-stream signatures in constant time.

## Changes

- Generalize the existing subtle-based SigV4 helper and use it for SigV2 header, POST, and presigned authentication.
- Use a subtle-based byte-slice helper for chunk and trailer signatures.
- Preserve all existing success and error behavior.

## Verification

- Tests cover equal values, first-byte mismatch, last-byte mismatch, and length mismatch.
- Source guards prevent reintroduction of the previous direct comparisons.
- `cargo fmt --all --check`
- `git diff --check`
