### PR TITLE
fix(s3s/host): require a label boundary in the MultiDomain overlap check

### DIFF
--- a/crates/s3s/src/host.rs
+++ b/crates/s3s/src/host.rs
@@ -321,37 +321,25 @@ mod tests {
         let md = result.unwrap();
         assert_eq!(md.base_domains, domains);
 
-        // a real subdomain is ambiguous and stays rejected
-        let domains = ["example.com", "s3.example.com"];
-        let result = MultiDomain::new(&domains);
-        let err = result.unwrap_err();
-        assert!(matches!(err, DomainError::OverlappingSubdomains));
-
-        let domains = ["s3.example.com", "example.com"];
-        let result = MultiDomain::new(&domains);
-        let err = result.unwrap_err();
-        assert!(matches!(err, DomainError::OverlappingSubdomains));
+        // a real subdomain is ambiguous and stays rejected, in either order
+        for domains in [
+            ["example.com", "s3.example.com"],
+            ["s3.example.com", "example.com"],
+            ["example.com:8080", "s3.example.com:8080"],
+        ] {
+            let err = MultiDomain::new(&domains).unwrap_err();
+            assert_eq!(err, DomainError::OverlappingSubdomains, "{domains:?}");
+        }
 
         // a shared suffix without a label boundary is not an overlap
-        let domains = ["example.com", "s3-example.com"];
-        let result = MultiDomain::new(&domains);
-        let md = result.unwrap();
-        assert_eq!(md.base_domains, domains);
-
-        let domains = ["rustfs.example.com", "s3-rustfs.example.com"];
-        let result = MultiDomain::new(&domains);
-        let md = result.unwrap();
-        assert_eq!(md.base_domains, domains);
-
-        let domains = ["example.com:8080", "s3-example.com:8080"];
-        let result = MultiDomain::new(&domains);
-        let md = result.unwrap();
-        assert_eq!(md.base_domains, domains);
-
-        let domains = ["example.com:8080", "s3.example.com:8080"];
-        let result = MultiDomain::new(&domains);
-        let err = result.unwrap_err();
-        assert!(matches!(err, DomainError::OverlappingSubdomains));
+        for domains in [
+            ["example.com", "s3-example.com"],
+            ["rustfs.example.com", "s3-rustfs.example.com"],
+            ["example.com:8080", "s3-example.com:8080"],
+        ] {
+            let md = MultiDomain::new(&domains).unwrap();
+            assert_eq!(md.base_domains, domains, "{domains:?}");
+        }
 
         let domains: [&str; 0] = [];
         let result = MultiDomain::new(&domains);

--- a/crates/s3s/src/host.rs
+++ b/crates/s3s/src/host.rs
@@ -146,6 +146,20 @@ fn is_valid_domain(mut s: &str) -> bool {
     true
 }
 
+/// Checks whether two base domains would compete for the same host header.
+///
+/// Two domains overlap when they are equal, or when one is a DNS subdomain of the other.
+/// The suffix must end on a label boundary, matching [`parse_host_header`]: `s3.example.com`
+/// is a subdomain of `example.com`, while `s3-example.com` is an unrelated domain.
+fn is_overlapping(a: &str, b: &str) -> bool {
+    a == b || is_subdomain_of(a, b) || is_subdomain_of(b, a)
+}
+
+/// Checks whether `host` is a strict DNS subdomain of `base_domain`.
+fn is_subdomain_of(host: &str, base_domain: &str) -> bool {
+    host.strip_suffix(base_domain).is_some_and(|rest| rest.ends_with('.'))
+}
+
 fn parse_host_header<'a>(base_domain: &'a str, host: &'a str) -> Option<VirtualHost<'a>> {
     if host == base_domain {
         return Some(VirtualHost::new(base_domain));
@@ -224,7 +238,7 @@ impl MultiDomain {
             }
 
             for other in &v {
-                if domain.ends_with(other) || other.ends_with(domain) {
+                if is_overlapping(domain, other) {
                     return Err(DomainError::OverlappingSubdomains);
                 }
             }
@@ -307,10 +321,59 @@ mod tests {
         let md = result.unwrap();
         assert_eq!(md.base_domains, domains);
 
+        // a real subdomain is ambiguous and stays rejected
+        let domains = ["example.com", "s3.example.com"];
+        let result = MultiDomain::new(&domains);
+        let err = result.unwrap_err();
+        assert!(matches!(err, DomainError::OverlappingSubdomains));
+
+        let domains = ["s3.example.com", "example.com"];
+        let result = MultiDomain::new(&domains);
+        let err = result.unwrap_err();
+        assert!(matches!(err, DomainError::OverlappingSubdomains));
+
+        // a shared suffix without a label boundary is not an overlap
+        let domains = ["example.com", "s3-example.com"];
+        let result = MultiDomain::new(&domains);
+        let md = result.unwrap();
+        assert_eq!(md.base_domains, domains);
+
+        let domains = ["rustfs.example.com", "s3-rustfs.example.com"];
+        let result = MultiDomain::new(&domains);
+        let md = result.unwrap();
+        assert_eq!(md.base_domains, domains);
+
+        let domains = ["example.com:8080", "s3-example.com:8080"];
+        let result = MultiDomain::new(&domains);
+        let md = result.unwrap();
+        assert_eq!(md.base_domains, domains);
+
+        let domains = ["example.com:8080", "s3.example.com:8080"];
+        let result = MultiDomain::new(&domains);
+        let err = result.unwrap_err();
+        assert!(matches!(err, DomainError::OverlappingSubdomains));
+
         let domains: [&str; 0] = [];
         let result = MultiDomain::new(&domains);
         let err = result.unwrap_err();
         assert!(matches!(err, DomainError::ZeroDomains));
+    }
+
+    #[test]
+    fn multi_domain_parse_shared_suffix() {
+        let domains = ["rustfs.example.com", "s3-rustfs.example.com"];
+        let md = MultiDomain::new(domains.iter().copied()).unwrap();
+
+        for domain in domains {
+            let vh = md.parse_host_header(domain).unwrap();
+            assert_eq!(vh.domain(), domain);
+            assert_eq!(vh.bucket(), None);
+
+            let host = format!("bucket.{domain}");
+            let vh = md.parse_host_header(&host).unwrap();
+            assert_eq!(vh.domain(), domain);
+            assert_eq!(vh.bucket(), Some("bucket"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #648

### Problem

`MultiDomain::new` compares base domains with plain `str::ends_with`, so the suffix test is not anchored to a label boundary — [host.rs#L226-L230](https://github.com/s3s-project/s3s/blob/1c248a36c3a226ef5bffd400f612d8958d197cb1/crates/s3s/src/host.rs#L226-L230):

```rust
if domain.ends_with(other) || other.ends_with(domain) {
    return Err(DomainError::OverlappingSubdomains);
}
```

`"s3-example.com".ends_with("example.com")` is `true` at the character level, so two unrelated domains are rejected as overlapping subdomains. Any shared textual suffix does it; the separator just has to be something other than `.`.

The request router in the same file already gets this right — `parse_host_header` strips the base domain and then requires a `.` before it ([host.rs#L154](https://github.com/s3s-project/s3s/blob/1c248a36c3a226ef5bffd400f612d8958d197cb1/crates/s3s/src/host.rs#L154)). So the constructor refuses configurations that the router would have handled correctly and independently.

Found while packaging RustFS, which passes its S3 API domain and its console domain to `MultiDomain::new`; the pair `rustfs.example.com` + `s3-rustfs.example.com` makes the server exit at startup.

### Fix

Give the constructor the same notion of "subdomain" the router uses:

```rust
fn is_overlapping(a: &str, b: &str) -> bool {
    a == b || is_subdomain_of(a, b) || is_subdomain_of(b, a)
}

fn is_subdomain_of(host: &str, base_domain: &str) -> bool {
    host.strip_suffix(base_domain).is_some_and(|rest| rest.ends_with('.'))
}
```

Equal domains and real subdomains keep erroring exactly as before — `example.com` + `s3.example.com` is genuinely ambiguous (`b.s3.example.com` could be bucket `b.s3` or bucket `b`) and rejecting it at construction is correct. Only pairs sharing a textual suffix across a non-`.` boundary start working.

Ports need no special handling: they are part of the compared string, so `example.com:8080` + `s3.example.com:8080` still overlaps while `example.com:8080` + `s3-example.com:8080` no longer does. Both are covered by tests.

`parse_host_header` is left untouched — it was already correct, and keeping the diff to the constructor means no change in routing behaviour.

### Testing

`cargo test -p s3s` on Rust 1.96.1 (the workspace MSRV):

- **Before:** the two new tests fail with `called Result::unwrap() on an Err value: OverlappingSubdomains` — `multi_domain_new` on the `s3-example.com` pair, `multi_domain_parse_shared_suffix` on construction.
- **After:** 742 lib tests + 35 doctests pass, `cargo clippy -p s3s --all-targets -- -D warnings` and `cargo fmt --check -p s3s` are clean.

New coverage in `multi_domain_new`:

- `["example.com", "s3.example.com"]` and the reverse order — still `OverlappingSubdomains`, so the ambiguity guard is pinned in both directions.
- `["example.com", "s3-example.com"]` and `["rustfs.example.com", "s3-rustfs.example.com"]` — now accepted.
- the same two shapes with `:8080` ports.

New `multi_domain_parse_shared_suffix` asserts the end-to-end behaviour the old check made unreachable: with both `rustfs.example.com` and `s3-rustfs.example.com` configured, each resolves to itself with no bucket, and `bucket.<domain>` resolves to bucket `bucket` under the right base domain.
