### PR TITLE
fix(s3s/ops): validate configured SigV4 region

### DIFF
--- a/crates/s3s/src/config.rs
+++ b/crates/s3s/src/config.rs
@@ -43,6 +43,8 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use serde::{Deserialize, Serialize};
 
+use crate::region::Region;
+
 /// S3 Service Configuration Provider trait.
 ///
 /// This trait provides a `snapshot` method that returns an `Arc<S3Config>`.
@@ -134,6 +136,15 @@ pub struct S3Config {
     /// Default: 900 (15 minutes)
     pub presigned_url_max_skew_time_secs: u32,
 
+    /// Region accepted in `SigV4` credential scopes.
+    ///
+    /// When set, requests signed for another region are rejected with
+    /// `AuthorizationHeaderMalformed`. When unset, any region is accepted.
+    ///
+    /// Default: None
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_region: Option<Region>,
+
     /// Whether to normalize forward slashes in object keys.
     ///
     /// If enabled, multiple consecutive slashes will be treated as a single slash:
@@ -165,6 +176,7 @@ impl Default for S3Config {
             form_max_fields_size: 20 * 1024 * 1024,            // 20 MB
             form_max_parts: 1000,
             presigned_url_max_skew_time_secs: 900, // 15 minutes
+            expected_region: None,
             normalize_forward_slash_path: false,
         }
     }
@@ -283,6 +295,7 @@ mod tests {
         assert_eq!(config.form_max_fields_size, 20 * 1024 * 1024);
         assert_eq!(config.form_max_parts, 1000);
         assert_eq!(config.presigned_url_max_skew_time_secs, 900);
+        assert_eq!(config.expected_region, None);
     }
 
     #[test]
@@ -371,6 +384,7 @@ mod tests {
             form_max_fields_size: 5 * 1024 * 1024,
             form_max_parts: 500,
             presigned_url_max_skew_time_secs: 600,
+            expected_region: Some("us-west-2".parse().expect("valid test region")),
             normalize_forward_slash_path: false,
         };
 
@@ -390,6 +404,12 @@ mod tests {
         // Other fields should have defaults
         assert_eq!(config.post_object_max_file_size, 5 * 1024 * 1024 * 1024);
         assert_eq!(config.form_max_field_size, 1024 * 1024);
+    }
+
+    #[test]
+    fn test_serde_omits_unset_expected_region() {
+        let json = serde_json::to_value(S3Config::default()).expect("serialize failed");
+        assert!(json.get("expected_region").is_none());
     }
 
     #[test]

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -311,15 +311,6 @@ impl SignatureContext<'_> {
         }
 
         let region = credential.aws_region;
-        let service = credential.aws_service;
-
-        if !matches!(service, "s3" | "sts") {
-            return Err(s3_error!(
-                NotImplemented,
-                "unknown service '{}' in credential scope; expected 's3' or 'sts'",
-                service,
-            ));
-        }
 
         {
             let config = self.config.snapshot();
@@ -329,6 +320,16 @@ impl SignatureContext<'_> {
 
         let access_key = credential.access_key_id.to_owned();
         let secret_key = auth.get_secret_key(&access_key).await?;
+
+        let service = credential.aws_service;
+
+        if !matches!(service, "s3" | "sts") {
+            return Err(s3_error!(
+                NotImplemented,
+                "unknown service '{}' in credential scope; expected 's3' or 'sts'",
+                service,
+            ));
+        }
 
         let string_to_sign = info.policy;
         let signature = sig_v4::calculate_signature(string_to_sign, &secret_key, &amz_date, region, service);
@@ -369,15 +370,6 @@ impl SignatureContext<'_> {
         }
 
         let region = presigned_url.credential.aws_region;
-        let service = presigned_url.credential.aws_service;
-
-        if !matches!(service, "s3" | "sts") {
-            return Err(s3_error!(
-                NotImplemented,
-                "unknown service '{}' in credential scope; expected 's3' or 'sts'",
-                service,
-            ));
-        }
 
         let amz_content_sha256 = extract_amz_content_sha256(&self.hs)?;
 
@@ -418,6 +410,16 @@ impl SignatureContext<'_> {
         let auth = require_auth(self.auth)?;
         let access_key = presigned_url.credential.access_key_id;
         let secret_key = auth.get_secret_key(access_key).await?;
+
+        let service = presigned_url.credential.aws_service;
+
+        if !matches!(service, "s3" | "sts") {
+            return Err(s3_error!(
+                NotImplemented,
+                "unknown service '{}' in credential scope; expected 's3' or 'sts'",
+                service,
+            ));
+        }
 
         let expected_signature = presigned_url.signature;
         let headers = self.hs.find_multiple_with_on_missing(&presigned_url.signed_headers, |name| {
@@ -1082,8 +1084,6 @@ file content\r\n\
 
     #[tokio::test]
     async fn v4_presigned_url_rejects_wrong_region() {
-        use crate::auth::SecretKey;
-        use crate::auth::SimpleAuth;
         use crate::config::{S3ConfigProvider, StaticConfigProvider};
         use std::sync::Arc;
 
@@ -1097,9 +1097,7 @@ file content\r\n\
         ))
         .unwrap();
 
-        let access_key = "AKIAIOSFODNN7EXAMPLE";
-        let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
-        let auth = SimpleAuth::from_single(access_key, secret_key);
+        let auth = crate::ops::tests::NeverGetSecretKeyAuth;
         let s3_config = S3Config {
             expected_region: Some("us-west-2".parse().expect("valid test region")),
             ..Default::default()
@@ -1475,14 +1473,11 @@ file content\r\n\
 
     #[tokio::test]
     async fn v4_header_auth_rejects_wrong_region() {
-        use crate::auth::SecretKey;
-        use crate::auth::SimpleAuth;
         use crate::config::{S3Config, S3ConfigProvider, StaticConfigProvider};
         use std::sync::Arc;
 
         let access_key = "AKIAIOSFODNN7EXAMPLE";
-        let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
-        let auth = SimpleAuth::from_single(access_key, secret_key);
+        let auth = crate::ops::tests::NeverGetSecretKeyAuth;
         let s3_config = S3Config {
             presigned_url_max_skew_time_secs: u32::MAX,
             expected_region: Some("us-west-2".parse().expect("valid test region")),

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -384,7 +384,6 @@ impl SignatureContext<'_> {
 
         {
             // check expiration
-            let config = self.config.snapshot();
             validate_sig_v4_region(region, &config)?;
 
             let now = time::OffsetDateTime::now_utc();

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -131,6 +131,19 @@ fn validate_sig_v4_clock_skew(amz_date: &AmzDate, now: time::OffsetDateTime, con
     Ok(())
 }
 
+fn validate_sig_v4_region(region: &str, config: &S3Config) -> S3Result<()> {
+    if let Some(expected_region) = &config.expected_region
+        && region != expected_region.as_str()
+    {
+        return Err(s3_error!(
+            AuthorizationHeaderMalformed,
+            "The authorization header is malformed; the region is wrong; expecting '{expected_region}'."
+        ));
+    }
+
+    Ok(())
+}
+
 impl SignatureVerificationContext<'_> {
     fn verify_with_raw_path_fallback(
         &self,
@@ -297,11 +310,6 @@ impl SignatureContext<'_> {
             return Err(s3_error!(SignatureDoesNotMatch, "credential scope date does not match x-amz-date"));
         }
 
-        validate_sig_v4_clock_skew(&amz_date, time::OffsetDateTime::now_utc(), &self.config.snapshot())?;
-
-        let access_key = credential.access_key_id.to_owned();
-        let secret_key = auth.get_secret_key(&access_key).await?;
-
         let region = credential.aws_region;
         let service = credential.aws_service;
 
@@ -312,6 +320,15 @@ impl SignatureContext<'_> {
                 service,
             ));
         }
+
+        {
+            let config = self.config.snapshot();
+            validate_sig_v4_region(region, &config)?;
+            validate_sig_v4_clock_skew(&amz_date, time::OffsetDateTime::now_utc(), &config)?;
+        }
+
+        let access_key = credential.access_key_id.to_owned();
+        let secret_key = auth.get_secret_key(&access_key).await?;
 
         let string_to_sign = info.policy;
         let signature = sig_v4::calculate_signature(string_to_sign, &secret_key, &amz_date, region, service);
@@ -351,6 +368,17 @@ impl SignatureContext<'_> {
             return Err(s3_error!(SignatureDoesNotMatch, "credential scope date does not match x-amz-date"));
         }
 
+        let region = presigned_url.credential.aws_region;
+        let service = presigned_url.credential.aws_service;
+
+        if !matches!(service, "s3" | "sts") {
+            return Err(s3_error!(
+                NotImplemented,
+                "unknown service '{}' in credential scope; expected 's3' or 'sts'",
+                service,
+            ));
+        }
+
         let amz_content_sha256 = extract_amz_content_sha256(&self.hs)?;
 
         // Presigned URLs do not support streaming (chunked) payload signing,
@@ -361,6 +389,9 @@ impl SignatureContext<'_> {
 
         {
             // check expiration
+            let config = self.config.snapshot();
+            validate_sig_v4_region(region, &config)?;
+
             let now = time::OffsetDateTime::now_utc();
 
             let date = presigned_url
@@ -374,7 +405,6 @@ impl SignatureContext<'_> {
             // This is to account for clock skew between the client and server.
             // See also https://github.com/minio/minio/blob/b5177993b371817699d3fa25685f54f88d8bfcce/cmd/signature-v4.go#L238-L242
 
-            let config = self.config.snapshot();
             let max_skew_time = time::Duration::seconds(i64::from(config.presigned_url_max_skew_time_secs));
             if duration.is_negative() && duration.abs() > max_skew_time {
                 return Err(s3_error!(RequestTimeTooSkewed, "request date is later than server time too much"));
@@ -388,17 +418,6 @@ impl SignatureContext<'_> {
         let auth = require_auth(self.auth)?;
         let access_key = presigned_url.credential.access_key_id;
         let secret_key = auth.get_secret_key(access_key).await?;
-
-        let region = presigned_url.credential.aws_region;
-        let service = presigned_url.credential.aws_service;
-
-        if !matches!(service, "s3" | "sts") {
-            return Err(s3_error!(
-                NotImplemented,
-                "unknown service '{}' in credential scope; expected 's3' or 'sts'",
-                service,
-            ));
-        }
 
         let expected_signature = presigned_url.signature;
         let headers = self.hs.find_multiple_with_on_missing(&presigned_url.signed_headers, |name| {
@@ -488,7 +507,11 @@ impl SignatureContext<'_> {
             return Err(s3_error!(SignatureDoesNotMatch, "credential scope date does not match x-amz-date"));
         }
 
-        validate_sig_v4_clock_skew(&amz_date, time::OffsetDateTime::now_utc(), &self.config.snapshot())?;
+        {
+            let config = self.config.snapshot();
+            validate_sig_v4_region(region, &config)?;
+            validate_sig_v4_clock_skew(&amz_date, time::OffsetDateTime::now_utc(), &config)?;
+        }
 
         let amz_content_sha256 = extract_amz_content_sha256(&self.hs)?;
 
@@ -812,6 +835,22 @@ mod tests {
     }
 
     #[test]
+    fn sig_v4_region_validation_is_optional_and_reports_mismatch() {
+        let mut config = S3Config::default();
+        validate_sig_v4_region("us-east-1", &config).expect("unset expected region should accept any region");
+
+        config.expected_region = Some("us-west-2".parse().expect("valid test region"));
+        validate_sig_v4_region("us-west-2", &config).expect("matching region should be accepted");
+
+        let err = validate_sig_v4_region("us-east-1", &config).expect_err("mismatched region should be rejected");
+        assert_eq!(err.code(), &S3ErrorCode::AuthorizationHeaderMalformed);
+        assert_eq!(
+            err.message(),
+            Some("The authorization header is malformed; the region is wrong; expecting 'us-west-2'.")
+        );
+    }
+
+    #[test]
     fn raw_path_fallback_rejects_missing_or_mismatched_signatures() {
         let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
         let amz_date = AmzDate::parse("20130524T000000Z").unwrap();
@@ -1042,6 +1081,62 @@ file content\r\n\
     }
 
     #[tokio::test]
+    async fn v4_presigned_url_rejects_wrong_region() {
+        use crate::auth::SecretKey;
+        use crate::auth::SimpleAuth;
+        use crate::config::{S3ConfigProvider, StaticConfigProvider};
+        use std::sync::Arc;
+
+        let qs = OrderedQs::parse(concat!(
+            "X-Amz-Algorithm=AWS4-HMAC-SHA256",
+            "&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request",
+            "&X-Amz-Date=20130524T000000Z",
+            "&X-Amz-Expires=999999999",
+            "&X-Amz-SignedHeaders=host",
+            "&X-Amz-Signature=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ))
+        .unwrap();
+
+        let access_key = "AKIAIOSFODNN7EXAMPLE";
+        let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
+        let auth = SimpleAuth::from_single(access_key, secret_key);
+        let s3_config = S3Config {
+            expected_region: Some("us-west-2".parse().expect("valid test region")),
+            ..Default::default()
+        };
+        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::new(Arc::new(s3_config)));
+
+        let method = Method::GET;
+        let uri = Uri::from_static("https://s3.amazonaws.com/test.txt");
+        let mut body = Body::empty();
+        let mut cx = SignatureContext {
+            auth: Some(&auth),
+            config: &config,
+            req_version: ::http::Version::HTTP_11,
+            req_method: &method,
+            req_uri: &uri,
+            req_body: &mut body,
+            qs: Some(&qs),
+            hs: OrderedHeaders::from_slice_unchecked(&[("host", "s3.amazonaws.com")]),
+            decoded_uri_path: "/test.txt",
+            raw_uri_path: "/test.txt",
+            vh_bucket: None,
+            content_length: None,
+            mime: None,
+            decoded_content_length: None,
+            transformed_body: None,
+            multipart: None,
+            trailing_headers: None,
+        };
+
+        let err = cx
+            .v4_check_presigned_url()
+            .await
+            .expect_err("presigned URL for another region should be rejected");
+        assert_eq!(err.code(), &S3ErrorCode::AuthorizationHeaderMalformed);
+    }
+
+    #[tokio::test]
     async fn v4_presigned_url_accepts_standard_and_raw_uri_path_signatures() {
         use crate::auth::SecretKey;
         use crate::auth::SimpleAuth;
@@ -1051,7 +1146,11 @@ file content\r\n\
         let access_key = "AKIAIOSFODNN7EXAMPLE";
         let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
         let auth = SimpleAuth::from_single(access_key, secret_key.clone());
-        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+        let s3_config = S3Config {
+            expected_region: Some("us-east-1".parse().expect("valid test region")),
+            ..Default::default()
+        };
+        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::new(Arc::new(s3_config)));
 
         let method = Method::GET;
         let uri = Uri::from_static("https://s3.amazonaws.com/test-bucket/path/sitemap.xmlage=");
@@ -1375,6 +1474,62 @@ file content\r\n\
     }
 
     #[tokio::test]
+    async fn v4_header_auth_rejects_wrong_region() {
+        use crate::auth::SecretKey;
+        use crate::auth::SimpleAuth;
+        use crate::config::{S3Config, S3ConfigProvider, StaticConfigProvider};
+        use std::sync::Arc;
+
+        let access_key = "AKIAIOSFODNN7EXAMPLE";
+        let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
+        let auth = SimpleAuth::from_single(access_key, secret_key);
+        let s3_config = S3Config {
+            presigned_url_max_skew_time_secs: u32::MAX,
+            expected_region: Some("us-west-2".parse().expect("valid test region")),
+            ..Default::default()
+        };
+        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::new(Arc::new(s3_config)));
+
+        let authorization = format!(
+            "AWS4-HMAC-SHA256 Credential={access_key}/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        let headers = OrderedHeaders::from_slice_unchecked(&[
+            ("authorization", authorization.as_str()),
+            ("host", "s3.amazonaws.com"),
+            ("x-amz-content-sha256", "UNSIGNED-PAYLOAD"),
+            ("x-amz-date", "20130524T000000Z"),
+        ]);
+        let method = Method::GET;
+        let uri = Uri::from_static("https://s3.amazonaws.com/test.txt");
+        let mut body = Body::empty();
+        let mut cx = SignatureContext {
+            auth: Some(&auth),
+            config: &config,
+            req_version: ::http::Version::HTTP_11,
+            req_method: &method,
+            req_uri: &uri,
+            req_body: &mut body,
+            qs: None,
+            hs: headers,
+            decoded_uri_path: "/test.txt",
+            raw_uri_path: "/test.txt",
+            vh_bucket: None,
+            content_length: Some(0),
+            mime: None,
+            decoded_content_length: None,
+            transformed_body: None,
+            multipart: None,
+            trailing_headers: None,
+        };
+
+        let err = cx
+            .v4_check_header_auth()
+            .await
+            .expect_err("header signature for another region should be rejected");
+        assert_eq!(err.code(), &S3ErrorCode::AuthorizationHeaderMalformed);
+    }
+
+    #[tokio::test]
     async fn v4_header_auth_accepts_standard_and_raw_uri_path_signatures() {
         use crate::auth::SecretKey;
         use crate::auth::SimpleAuth;
@@ -1386,6 +1541,7 @@ file content\r\n\
         let auth = SimpleAuth::from_single(access_key, secret_key.clone());
         let s3_config = S3Config {
             presigned_url_max_skew_time_secs: u32::MAX,
+            expected_region: Some("us-east-1".parse().expect("valid test region")),
             ..Default::default()
         };
         let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::new(Arc::new(s3_config)));

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+pub(super) struct NeverGetSecretKeyAuth;
+
+#[async_trait::async_trait]
+impl crate::auth::S3Auth for NeverGetSecretKeyAuth {
+    async fn get_secret_key(&self, _access_key: &str) -> crate::error::S3Result<crate::auth::SecretKey> {
+        panic!("secret key lookup must not occur for a wrong-region request")
+    }
+}
+
 // use crate::service::S3Service;
 
 // use stdx::mem::output_size;
@@ -555,7 +564,7 @@ mod post_policy_test_helpers {
     use std::fmt::Write;
 
     use crate::S3Request;
-    use crate::auth::{SecretKey, SimpleAuth};
+    use crate::auth::{S3Auth, SecretKey, SimpleAuth};
     use crate::config::{S3Config, S3ConfigProvider, StaticConfigProvider};
     use crate::http::{Body, Request};
     use crate::ops::CallContext;
@@ -601,7 +610,7 @@ mod post_policy_test_helpers {
     pub fn create_test_context<'a>(
         s3: &'a Arc<dyn crate::s3_trait::S3>,
         config: &'a Arc<dyn S3ConfigProvider>,
-        auth: &'a SimpleAuth,
+        auth: &'a dyn S3Auth,
     ) -> CallContext<'a> {
         CallContext {
             s3,
@@ -815,7 +824,7 @@ async fn post_object_rejects_wrong_region() {
         ..Default::default()
     };
     let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::new(Arc::new(s3_config)));
-    let auth = post_policy_test_helpers::create_test_auth();
+    let auth = NeverGetSecretKeyAuth;
     let ccx = post_policy_test_helpers::create_test_context(&s3, &config, &auth);
     let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
     let policy_json = &format!(

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -591,6 +591,7 @@ mod post_policy_test_helpers {
         let config = S3Config {
             presigned_url_max_skew_time_secs: u32::MAX,
             post_object_max_file_size,
+            expected_region: Some("us-east-1".parse().expect("valid test region")),
             ..Default::default()
         };
         Arc::new(StaticConfigProvider::new(Arc::new(config)))
@@ -799,6 +800,34 @@ mod post_policy_test_helpers {
                 .unwrap(),
         )
     }
+}
+
+#[tokio::test]
+async fn post_object_rejects_wrong_region() {
+    use crate::auth::SecretKey;
+    use crate::config::{S3Config, S3ConfigProvider, StaticConfigProvider};
+    use std::sync::Arc;
+
+    let s3: Arc<dyn crate::s3_trait::S3> = Arc::new(post_policy_test_helpers::TestS3NoOp);
+    let s3_config = S3Config {
+        presigned_url_max_skew_time_secs: u32::MAX,
+        expected_region: Some("us-west-2".parse().expect("valid test region")),
+        ..Default::default()
+    };
+    let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::new(Arc::new(s3_config)));
+    let auth = post_policy_test_helpers::create_test_auth();
+    let ccx = post_policy_test_helpers::create_test_context(&s3, &config, &auth);
+    let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
+    let policy_json = &format!(
+        r#"{{"expiration":"2030-01-01T00:00:00.000Z","conditions":[{}]}}"#,
+        post_policy_test_helpers::BASE_CONDITIONS,
+    );
+    let mut req = post_policy_test_helpers::build_post_object_request(policy_json, "test", &secret_key, false);
+
+    let Err(err) = super::prepare(&mut req, &ccx).await else {
+        panic!("POST policy signed for another region should be rejected");
+    };
+    assert_eq!(err.code(), &crate::error::S3ErrorCode::AuthorizationHeaderMalformed);
 }
 
 /// Test that policy max < config max results in using policy max for file size limit

--- a/crates/s3s/src/region.rs
+++ b/crates/s3s/src/region.rs
@@ -6,6 +6,8 @@
 use std::fmt;
 use std::str::FromStr;
 
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
 /// Error returned when a region string is invalid.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error("invalid region: {0:?}")]
@@ -96,6 +98,25 @@ impl FromStr for Region {
     }
 }
 
+impl Serialize for Region {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Region {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value.into_boxed_str()).map_err(serde::de::Error::custom)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -153,5 +174,14 @@ mod tests {
         let r: Region = "ap-south-1".parse().unwrap();
         let s = r.into_boxed_str();
         assert_eq!(&*s, "ap-south-1");
+    }
+
+    #[test]
+    fn serde_rejects_invalid_region() {
+        let region: Region = serde_json::from_str(r#""ap-south-1""#).expect("valid region should deserialize");
+        assert_eq!(region.as_str(), "ap-south-1");
+
+        let err = serde_json::from_str::<Region>(r#""AP-SOUTH-1""#).expect_err("invalid region should be rejected");
+        assert!(err.to_string().contains("invalid region"));
     }
 }


### PR DESCRIPTION
## Summary

- add an optional, validated `expected_region` to `S3Config`
- reject mismatched SigV4 credential scopes for header authentication, presigned URLs, and POST policies
- return the MinIO-compatible `AuthorizationHeaderMalformed` response before secret-key lookup
- preserve the existing permissive behavior when `expected_region` is unset

## Motivation

SigV4 verification used the region from the client credential scope to derive the signing key, but did not compare it with a server-configured region. A correctly signed request therefore succeeded even when it targeted a different region. This is needed to resolve [rustfs/rustfs#5323](https://github.com/rustfs/rustfs/issues/5323).

## Compatibility

The new setting defaults to `None`, so existing users continue accepting any credential-scope region. Unset values are omitted from serialized configuration. When enabled, region mismatches return HTTP 400 with `AuthorizationHeaderMalformed`, matching MinIO behavior. Existing service, expiration, and authentication error precedence is preserved for requests without a region mismatch.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features --all-targets --quiet`
- `cargo test -p s3s --all-features rejects_wrong_region`
- `cargo test -p s3s --all-features v4_presigned_url_rejects_unknown_service`
- `cargo test -p s3s --all-features service::tests::future_size`

## Adversarial review

- Correctness: all three SigV4 authentication forms reject mismatches and retain matching/unset behavior.
- Simplicity: one shared validator and one typed config field cover all production call sites; one test-only auth guard covers the three regressions.
- Security: validation is fail-closed when configured, and tests panic if a wrong-region request reaches secret-key lookup; no credentials are logged.
- Concurrency/durability: each request uses one immutable config snapshot, held only across synchronous validation.
- Compatibility: the default remains permissive, the mismatch response matches MinIO, and unrelated validation order remains unchanged.
- Performance: the success path adds only an optional string comparison; the service future-size regression test passes.
- Test coverage: dedicated mismatch tests cover header, query, and POST SigV4 paths, including the no-key-lookup invariant, with matching/default and serde coverage.
