### PR TITLE
fix(s3s): propagate source() from stream error wrappers

### DIFF
--- a/crates/s3s/src/http/aws_chunked_stream.rs
+++ b/crates/s3s/src/http/aws_chunked_stream.rs
@@ -76,7 +76,7 @@ struct SignatureCtx {
 pub enum AwsChunkedStreamError {
     /// Underlying error
     #[error("AwsChunkedStreamError: Underlying: {}",.0)]
-    Underlying(StdError),
+    Underlying(#[source] StdError),
     /// Signature mismatch
     #[error("AwsChunkedStreamError: SignatureMismatch")]
     SignatureMismatch,
@@ -941,7 +941,8 @@ mod tests {
     async fn test_underlying_error() {
         // Test Underlying error propagation
         use std::io;
-        let err: Result<Bytes, StdError> = Err(Box::new(io::Error::other("network error")));
+        let cause = io::Error::new(io::ErrorKind::ConnectionReset, "network error");
+        let err: Result<Bytes, StdError> = Err(Box::new(cause));
         let chunk_results: Vec<Result<Bytes, _>> = vec![err];
 
         let seed_signature = "test";
@@ -962,6 +963,16 @@ mod tests {
 
         let result = chunked_stream.next().await.unwrap();
         assert!(matches!(result, Err(AwsChunkedStreamError::Underlying(_))));
+
+        let err = result.unwrap_err();
+        assert_eq!(err.to_string(), "AwsChunkedStreamError: Underlying: network error");
+
+        // The cause chain must stay intact so that callers can classify the failure,
+        // for example to tell a client disconnect apart from a server-side fault.
+        let err: &dyn std::error::Error = &err;
+        let source = err.source().expect("the underlying error should be exposed as the source");
+        let kind = source.downcast_ref::<io::Error>().map(io::Error::kind);
+        assert_eq!(kind, Some(io::ErrorKind::ConnectionReset));
     }
 
     #[tokio::test]

--- a/crates/s3s/src/http/multipart.rs
+++ b/crates/s3s/src/http/multipart.rs
@@ -109,7 +109,7 @@ impl Multipart {
 #[derive(Debug, thiserror::Error)]
 pub enum MultipartError {
     #[error("MultipartError: Underlying: {0}")]
-    Underlying(StdError),
+    Underlying(#[source] StdError),
     #[error("MultipartError: InvalidFormat")]
     InvalidFormat,
     #[error("MultipartError: FieldTooLarge: field size {0} bytes exceeds limit of {1} bytes")]
@@ -338,7 +338,7 @@ pub enum FileStreamError {
     Incomplete,
     /// IO error
     #[error("FileStreamError: Underlying: {0}")]
-    Underlying(StdError),
+    Underlying(#[source] StdError),
     /// Boundary buffer too large
     #[error("FileStreamError: BoundaryBufferTooLarge: size {0} exceeds limit {1}")]
     BoundaryBufferTooLarge(usize, usize),
@@ -583,6 +583,7 @@ fn parse_content_disposition(input: &[u8]) -> nom::IResult<&[u8], ContentDisposi
 mod tests {
     use super::*;
 
+    use std::io;
     use std::slice;
 
     async fn aggregate_file_stream(mut file_stream: FileStream) -> Result<Bytes, FileStreamError> {
@@ -995,5 +996,31 @@ mod tests {
         }
 
         assert!(errored, "Should have received BoundaryBufferTooLarge error");
+    }
+
+    #[test]
+    fn multipart_underlying_error_exposes_source() {
+        let cause = io::Error::new(io::ErrorKind::ConnectionReset, "boom");
+        let err = MultipartError::Underlying(Box::new(cause));
+
+        assert_eq!(err.to_string(), "MultipartError: Underlying: boom");
+
+        let err: &dyn std::error::Error = &err;
+        let source = err.source().expect("the underlying error should be exposed as the source");
+        let kind = source.downcast_ref::<io::Error>().map(io::Error::kind);
+        assert_eq!(kind, Some(io::ErrorKind::ConnectionReset));
+    }
+
+    #[test]
+    fn file_stream_underlying_error_exposes_source() {
+        let cause = io::Error::new(io::ErrorKind::ConnectionReset, "boom");
+        let err = FileStreamError::Underlying(Box::new(cause));
+
+        assert_eq!(err.to_string(), "FileStreamError: Underlying: boom");
+
+        let err: &dyn std::error::Error = &err;
+        let source = err.source().expect("the underlying error should be exposed as the source");
+        let kind = source.downcast_ref::<io::Error>().map(io::Error::kind);
+        assert_eq!(kind, Some(io::ErrorKind::ConnectionReset));
     }
 }

--- a/crates/s3s/src/sig_v4/upload_stream.rs
+++ b/crates/s3s/src/sig_v4/upload_stream.rs
@@ -43,7 +43,7 @@ enum State {
 pub enum UploadStreamError {
     /// Underlying stream error.
     #[error("UploadStreamError: Underlying: {0}")]
-    Underlying(StdError),
+    Underlying(#[source] StdError),
     /// Payload SHA-256 mismatch.
     #[error("UploadStreamError: Sha256Mismatch")]
     Sha256Mismatch,
@@ -308,12 +308,21 @@ mod tests {
     #[tokio::test]
     async fn propagate_underlying_error() {
         let checksum = Sha256Sum::from_bytes(Sha256::checksum(b""));
-        let err: Result<Bytes, StdError> = Err(Box::new(io::Error::other("boom")));
+        let cause = io::Error::new(io::ErrorKind::ConnectionReset, "boom");
+        let err: Result<Bytes, StdError> = Err(Box::new(cause));
         let stream = futures::stream::iter(vec![err]);
 
         let mut upload = UploadStream::new(stream, 0, checksum);
 
         let err = upload.next().await.unwrap().unwrap_err();
         assert!(matches!(err, UploadStreamError::Underlying(_)));
+        assert_eq!(err.to_string(), "UploadStreamError: Underlying: boom");
+
+        // The cause chain must stay intact so that callers can classify the failure,
+        // for example to tell a client disconnect apart from a server-side fault.
+        let err: &dyn std::error::Error = &err;
+        let source = err.source().expect("the underlying error should be exposed as the source");
+        let kind = source.downcast_ref::<io::Error>().map(io::Error::kind);
+        assert_eq!(kind, Some(io::ErrorKind::ConnectionReset));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #652.

The `Underlying` variants of four stream error types wrap an inner error but declare no `#[source]`, so `thiserror` generates no `source()` and the cause chain is severed.

This matters most for `UploadStreamError` and `AwsChunkedStreamError`, which surface through the request body stream, where a caller needs to tell a client disconnect apart from a server fault. The `io::ErrorKind` further down the chain is the only authoritative signal, and nothing else reaches it: `sig_v4` is private, so the type cannot be named or `downcast_ref`'d, and `hyper::Error` renders a fixed description that does not distinguish a reset from a timeout.

`MultipartError` and `FileStreamError` never reach an external caller, but the defect and the fix are identical, so they are included too.

## What changed

`#[source]` on four `Underlying` variants, in `sig_v4/upload_stream.rs`, `http/aws_chunked_stream.rs`, and `http/multipart.rs` (two). The rest is tests.

Messages are unchanged: `#[source]` controls only the generated `source()`, while `{0}` produces the text. No public API or semver impact, since both modules are private and `cargo semver-checks` passes 196/196.

## Tests

Each variant recovers its `io::ErrorKind` through `Error::source()` and pins the `Display` output. The two stream types drive a real stream rather than constructing the variant by hand. As a negative control, reverting all four attributes fails exactly those four tests and no others.

`cargo fmt`, `clippy -D warnings`, and the full workspace suite pass.

One note: `#[error("{0}")]` with `#[source]` repeats the cause text in the chain. That is deliberate, matching ten existing variants that pair `#[from]` with `{0}`. Happy to drop `{0}` if you prefer.
