### PR TITLE
feat(s3s/sigv4): make presigned expires max configurable

### DIFF
--- a/crates/s3s/src/config.rs
+++ b/crates/s3s/src/config.rs
@@ -43,6 +43,9 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use serde::{Deserialize, Serialize};
 
+// AWS-compatible default: https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html#PresignedUrl-Expiration
+pub(crate) const DEFAULT_PRESIGNED_URL_MAX_EXPIRES_SECS: u32 = 7 * 24 * 60 * 60;
+
 /// S3 Service Configuration Provider trait.
 ///
 /// This trait provides a `snapshot` method that returns an `Arc<S3Config>`.
@@ -134,6 +137,13 @@ pub struct S3Config {
     /// Default: 900 (15 minutes)
     pub presigned_url_max_skew_time_secs: u32,
 
+    /// Maximum allowed `X-Amz-Expires` value for `SigV4` presigned URLs in seconds.
+    ///
+    /// Default: 604800 (7 days, matching AWS S3 behavior)
+    ///
+    /// Values larger than 604800 intentionally diverge from AWS S3 compatibility.
+    pub presigned_url_max_expires_secs: u32,
+
     /// Whether to normalize forward slashes in object keys.
     ///
     /// If enabled, multiple consecutive slashes will be treated as a single slash:
@@ -165,6 +175,7 @@ impl Default for S3Config {
             form_max_fields_size: 20 * 1024 * 1024,            // 20 MB
             form_max_parts: 1000,
             presigned_url_max_skew_time_secs: 900, // 15 minutes
+            presigned_url_max_expires_secs: DEFAULT_PRESIGNED_URL_MAX_EXPIRES_SECS,
             normalize_forward_slash_path: false,
         }
     }
@@ -283,6 +294,7 @@ mod tests {
         assert_eq!(config.form_max_fields_size, 20 * 1024 * 1024);
         assert_eq!(config.form_max_parts, 1000);
         assert_eq!(config.presigned_url_max_skew_time_secs, 900);
+        assert_eq!(config.presigned_url_max_expires_secs, DEFAULT_PRESIGNED_URL_MAX_EXPIRES_SECS);
     }
 
     #[test]
@@ -371,6 +383,7 @@ mod tests {
             form_max_fields_size: 5 * 1024 * 1024,
             form_max_parts: 500,
             presigned_url_max_skew_time_secs: 600,
+            presigned_url_max_expires_secs: 86_400,
             normalize_forward_slash_path: false,
         };
 
@@ -390,6 +403,7 @@ mod tests {
         // Other fields should have defaults
         assert_eq!(config.post_object_max_file_size, 5 * 1024 * 1024 * 1024);
         assert_eq!(config.form_max_field_size, 1024 * 1024);
+        assert_eq!(config.presigned_url_max_expires_secs, DEFAULT_PRESIGNED_URL_MAX_EXPIRES_SECS);
     }
 
     #[test]

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -336,8 +336,9 @@ impl SignatureContext<'_> {
 
     pub async fn v4_check_presigned_url(&mut self) -> S3Result<CredentialsExt> {
         let qs = self.qs.unwrap(); // assume: qs has "X-Amz-Signature"
+        let config = self.config.snapshot();
 
-        let presigned_url = PresignedUrlV4::parse(qs).map_err(|err| {
+        let presigned_url = PresignedUrlV4::parse(qs, config.presigned_url_max_expires_secs).map_err(|err| {
             s3_error!(
                 err,
                 AuthorizationQueryParametersError,
@@ -380,7 +381,6 @@ impl SignatureContext<'_> {
             // This is to account for clock skew between the client and server.
             // See also https://github.com/minio/minio/blob/b5177993b371817699d3fa25685f54f88d8bfcce/cmd/signature-v4.go#L238-L242
 
-            let config = self.config.snapshot();
             let max_skew_time = time::Duration::seconds(i64::from(config.presigned_url_max_skew_time_secs));
             if duration.is_negative() && duration.abs() > max_skew_time {
                 return Err(s3_error!(RequestTimeTooSkewed, "request date is later than server time too much"));
@@ -935,6 +935,57 @@ mod tests {
         assert_eq!(err.code(), &S3ErrorCode::AuthorizationQueryParametersError);
         assert_eq!(err.message(), Some("The authorization query parameters that you provided are not valid."));
         assert!(err.source().is_some(), "parse error must remain available as the source");
+    }
+
+    #[tokio::test]
+    async fn v4_presigned_url_accepts_expires_beyond_aws_default_when_configured() {
+        use crate::config::{S3Config, S3ConfigProvider, StaticConfigProvider};
+
+        let amz_date = AmzDate::parse(&fmt_current_amz_date(time::OffsetDateTime::now_utc()))
+            .expect("current time should produce a valid x-amz-date");
+        let mut query_strings = presigned_query_fields(&amz_date, "s3");
+        query_strings[3] = ("X-Amz-Expires".to_owned(), "604801".to_owned());
+        query_strings.push((
+            "X-Amz-Signature".to_owned(),
+            "aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404".to_owned(),
+        ));
+        let qs = OrderedQs::from_vec_unchecked(query_strings);
+
+        let s3_config = S3Config {
+            presigned_url_max_skew_time_secs: u32::MAX,
+            presigned_url_max_expires_secs: 700_000,
+            ..Default::default()
+        };
+        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::new(Arc::new(s3_config)));
+        let method = Method::GET;
+        let uri = Uri::from_static("https://s3.amazonaws.com/test.txt");
+        let mut body = Body::empty();
+        let mut cx = SignatureContext {
+            auth: None,
+            config: &config,
+            req_version: ::http::Version::HTTP_11,
+            req_method: &method,
+            req_uri: &uri,
+            req_body: &mut body,
+            qs: Some(&qs),
+            hs: OrderedHeaders::from_slice_unchecked(&[("host", "s3.amazonaws.com")]),
+            decoded_uri_path: "/test.txt",
+            raw_uri_path: "/test.txt",
+            vh_bucket: None,
+            content_length: None,
+            mime: None,
+            decoded_content_length: None,
+            transformed_body: None,
+            multipart: None,
+            trailing_headers: None,
+        };
+
+        let err = cx
+            .v4_check()
+            .await
+            .expect("X-Amz-Signature must select presigned auth")
+            .expect_err("missing auth provider should fail after presigned parsing succeeds");
+        assert_eq!(err.code(), &S3ErrorCode::NotImplemented);
     }
 
     #[tokio::test]

--- a/crates/s3s/src/sig_v4/methods.rs
+++ b/crates/s3s/src/sig_v4/methods.rs
@@ -1145,7 +1145,7 @@ mod tests {
 
         let qs = OrderedQs::from_vec_unchecked(query_strings.iter().map(|&(n, v)| (n.to_owned(), v.to_owned())).collect());
 
-        let info = PresignedUrlV4::parse(&qs).unwrap();
+        let info = PresignedUrlV4::parse(&qs, crate::config::DEFAULT_PRESIGNED_URL_MAX_EXPIRES_SECS).unwrap();
 
         let canonical_request = create_presigned_canonical_request(&method, uri.path(), query_strings, &headers);
 

--- a/crates/s3s/src/sig_v4/presigned_url_v4.rs
+++ b/crates/s3s/src/sig_v4/presigned_url_v4.rs
@@ -8,9 +8,6 @@ use crate::utils::crypto::is_sha256_checksum;
 
 use smallvec::SmallVec;
 
-// AWS SigV4 spec maximum: https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html#PresignedUrl-Expiration
-const MAX_EXPIRES_SECONDS: u32 = 7 * 24 * 60 * 60;
-
 /// Presigned url information
 #[derive(Debug)]
 pub struct PresignedUrlV4<'a> {
@@ -67,11 +64,18 @@ impl<'a> PresignedQs<'a> {
 }
 
 impl<'a> PresignedUrlV4<'a> {
-    /// Parses `PresignedUrl` from query
+    /// Parses `PresignedUrl` from query with a caller-supplied `X-Amz-Expires` upper bound.
+    ///
+    /// `max_expires_secs` is the maximum allowed `X-Amz-Expires` value in seconds.
+    /// Values larger than this upper bound are rejected during parsing.
     ///
     /// # Errors
     /// Returns `ParsePresignedUrlError` if it failed to parse
-    pub fn parse(qs: &'a OrderedQs) -> Result<Self, ParsePresignedUrlError> {
+    pub fn parse(qs: &'a OrderedQs, max_expires_secs: u32) -> Result<Self, ParsePresignedUrlError> {
+        Self::parse_impl(qs, max_expires_secs)
+    }
+
+    fn parse_impl(qs: &'a OrderedQs, max_expires_secs: u32) -> Result<Self, ParsePresignedUrlError> {
         let err = || ParsePresignedUrlError { _priv: () };
 
         let info = PresignedQs::from_ordered_qs(qs).ok_or_else(err)?;
@@ -82,7 +86,7 @@ impl<'a> PresignedUrlV4<'a> {
 
         let amz_date = AmzDate::parse(info.date).map_err(|_e| err())?;
 
-        let expires = parse_expires(info.expires).ok_or_else(err)?;
+        let expires = parse_expires(info.expires, max_expires_secs).ok_or_else(err)?;
 
         if !info.signed_headers.is_ascii() {
             return Err(err());
@@ -105,10 +109,10 @@ impl<'a> PresignedUrlV4<'a> {
     }
 }
 
-fn parse_expires(s: &str) -> Option<time::Duration> {
+fn parse_expires(s: &str, max_expires_secs: u32) -> Option<time::Duration> {
     // u32 parse rejects negative values and non-integers implicitly
     let x = s.parse::<u32>().ok()?;
-    if x > MAX_EXPIRES_SECONDS {
+    if x > max_expires_secs {
         return None;
     }
     Some(time::Duration::new(i64::from(x), 0))
@@ -119,6 +123,10 @@ mod tests {
     use super::*;
 
     use crate::http::OrderedQs;
+
+    fn default_max_expires_secs() -> u32 {
+        crate::config::DEFAULT_PRESIGNED_URL_MAX_EXPIRES_SECS
+    }
 
     fn make_qs(pairs: &[(&str, &str)]) -> OrderedQs {
         OrderedQs::from_vec_unchecked(
@@ -144,7 +152,7 @@ mod tests {
     fn parse_extracts_presigned_url_fields() {
         let qs = make_qs(&valid_query_strings());
 
-        let info = PresignedUrlV4::parse(&qs).unwrap();
+        let info = PresignedUrlV4::parse(&qs, default_max_expires_secs()).unwrap();
 
         assert_eq!(info.algorithm, "AWS4-HMAC-SHA256");
         assert_eq!(info.credential.access_key_id, "AKIAIOSFODNN7EXAMPLE");
@@ -159,7 +167,7 @@ mod tests {
     #[test]
     fn parse_rejects_missing_query_fields() {
         let qs = make_qs(&valid_query_strings()[..5]);
-        assert!(PresignedUrlV4::parse(&qs).is_err());
+        assert!(PresignedUrlV4::parse(&qs, default_max_expires_secs()).is_err());
     }
 
     #[test]
@@ -167,7 +175,7 @@ mod tests {
         let mut pairs = valid_query_strings();
         pairs[4] = ("X-Amz-SignedHeaders", "höst");
         let qs = make_qs(&pairs);
-        assert!(PresignedUrlV4::parse(&qs).is_err());
+        assert!(PresignedUrlV4::parse(&qs, default_max_expires_secs()).is_err());
     }
 
     #[test]
@@ -175,7 +183,7 @@ mod tests {
         let mut pairs = valid_query_strings();
         pairs[1] = ("X-Amz-Credential", "bad-credential");
         let qs = make_qs(&pairs);
-        assert!(PresignedUrlV4::parse(&qs).is_err());
+        assert!(PresignedUrlV4::parse(&qs, default_max_expires_secs()).is_err());
     }
 
     #[test]
@@ -183,7 +191,7 @@ mod tests {
         let mut pairs = valid_query_strings();
         pairs[2] = ("X-Amz-Date", "not-a-date");
         let qs = make_qs(&pairs);
-        assert!(PresignedUrlV4::parse(&qs).is_err());
+        assert!(PresignedUrlV4::parse(&qs, default_max_expires_secs()).is_err());
     }
 
     #[test]
@@ -191,7 +199,7 @@ mod tests {
         let mut pairs = valid_query_strings();
         pairs[5] = ("X-Amz-Signature", "not-a-sha256");
         let qs = make_qs(&pairs);
-        assert!(PresignedUrlV4::parse(&qs).is_err());
+        assert!(PresignedUrlV4::parse(&qs, default_max_expires_secs()).is_err());
     }
 
     #[test]
@@ -200,7 +208,10 @@ mod tests {
             let mut pairs = valid_query_strings();
             pairs[3] = ("X-Amz-Expires", expires);
             let qs = make_qs(&pairs);
-            assert!(PresignedUrlV4::parse(&qs).is_err(), "X-Amz-Expires={expires} must be rejected");
+            assert!(
+                PresignedUrlV4::parse(&qs, default_max_expires_secs()).is_err(),
+                "X-Amz-Expires={expires} must be rejected"
+            );
         }
     }
 
@@ -210,9 +221,21 @@ mod tests {
             let mut pairs = valid_query_strings();
             pairs[3] = ("X-Amz-Expires", expires);
             let qs = make_qs(&pairs);
-            let parsed = PresignedUrlV4::parse(&qs).expect("boundary expiration should parse");
+            let parsed = PresignedUrlV4::parse(&qs, default_max_expires_secs()).expect("boundary expiration should parse");
             assert_eq!(parsed.expires.whole_seconds().to_string(), expires);
         }
+    }
+
+    #[test]
+    fn parse_respects_custom_max_expires() {
+        let mut pairs = valid_query_strings();
+        pairs[3] = ("X-Amz-Expires", "604801");
+        let qs = make_qs(&pairs);
+
+        let parsed = PresignedUrlV4::parse(&qs, 700_000).expect("custom max should allow larger expires");
+        assert_eq!(parsed.expires.whole_seconds(), 604_801);
+
+        assert!(PresignedUrlV4::parse(&qs, 3_600).is_err(), "custom max should reject larger expires");
     }
 
     #[test]
@@ -220,6 +243,6 @@ mod tests {
         let mut pairs = valid_query_strings().to_vec();
         pairs.push(("X-Amz-Expires", "1"));
         let qs = make_qs(&pairs);
-        assert!(PresignedUrlV4::parse(&qs).is_err());
+        assert!(PresignedUrlV4::parse(&qs, default_max_expires_secs()).is_err());
     }
 }


### PR DESCRIPTION
### Summary

Make the SigV4 presigned URL `X-Amz-Expires` limit configurable through `S3Config`, while keeping the default behavior aligned with AWS S3.

### Changes

- Add `S3Config.presigned_url_max_expires_secs` with a default value of `604800` seconds.
- Keep `PresignedUrlV4::parse(qs)` as the AWS-compatible default entry point, and add `PresignedUrlV4::parse_with_max_expires(qs, max_expires_secs)` for configurable behavior.
- Update `v4_check_presigned_url` to read the configured max expires value and pass it to the parser.
- Extend parser tests to cover default behavior, tighter limits, and explicitly relaxed limits.
- Add an operation-layer regression test showing that `X-Amz-Expires=604801` is accepted when the configured limit is larger than the AWS default.
- Keep the default configuration AWS-compatible, and avoid exposing the default value as a public constant.

### Rationale

This keeps the default behavior unchanged for AWS-compatible deployments, while allowing self-hosted or policy-specific deployments to tighten or relax the maximum presigned URL lifetime without forking the parser logic.

### Verification

- `just ci-rust`
- `just fmt`
- `just test`
- `cargo test -p s3s sig_v4::presigned_url_v4`
- `cargo test -p s3s v4_presigned_url_rejects_invalid_expires_as_authorization_query_error`
- `cargo test -p s3s v4_presigned_url_accepts_expires_beyond_aws_default_when_configured`
- `cargo test -p s3s config::tests`

### Related

- https://github.com/s3s-project/s3s/pull/645
