### PR TITLE
fix(s3s/auth): enforce constant-time signature comparison via typed Signature

### DIFF
--- a/crates/s3s/src/auth/mod.rs
+++ b/crates/s3s/src/auth/mod.rs
@@ -73,6 +73,8 @@
 mod secret_key;
 pub use self::secret_key::{Credentials, SecretKey};
 
+pub(crate) mod signature;
+
 mod simple_auth;
 pub use self::simple_auth::SimpleAuth;
 

--- a/crates/s3s/src/auth/signature.rs
+++ b/crates/s3s/src/auth/signature.rs
@@ -9,7 +9,7 @@
 //!   (the length difference is algorithm-public, not secret).
 //! - `PartialEq` / `Eq` / `Hash` are deliberately NOT implemented: an ordinary
 //!   `==` comparison is a compile error; comparison must go through
-//!   [`ConstantTimeEq`] to avoid timing side channels.
+//!   [`Signature::compare`] or [`ConstantTimeEq`] to avoid timing side channels.
 //! - [`Signature::as_str`] is for string-to-sign chaining and logging, NOT for
 //!   comparison.
 //! - Do NOT add unchecked constructors (e.g. `From<&str>`); doing so would
@@ -71,6 +71,18 @@ impl Signature {
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    /// Compares two signatures in constant time.
+    ///
+    /// Returns `true` if `left` and `right` hold the same canonical value.
+    /// Cross-form comparisons (`SigV4` vs `SigV2`) are always `false`.
+    ///
+    /// This is the canonical way to compare signatures; see the module-level
+    /// invariants for why `==` / `!=` must not be used.
+    #[must_use]
+    pub fn compare(left: &Self, right: &Self) -> bool {
+        bool::from(left.ct_eq(right))
     }
 }
 
@@ -169,6 +181,18 @@ mod tests {
         let hex_sig = Signature::from_hex(HEX_64).unwrap();
         let b64_sig = Signature::from_base64(B64_20).unwrap();
         assert!(!bool::from(hex_sig.ct_eq(&b64_sig)));
+    }
+
+    #[test]
+    fn compare_reports_match_and_mismatch() {
+        let a = Signature::from_hex(HEX_64).unwrap();
+        let same = Signature::from_hex(HEX_64).unwrap();
+        let different = Signature::from_hex(&format!("0{}", &HEX_64[1..])).unwrap();
+        let b64 = Signature::from_base64(B64_20).unwrap();
+
+        assert!(Signature::compare(&a, &same));
+        assert!(!Signature::compare(&a, &different));
+        assert!(!Signature::compare(&a, &b64));
     }
 
     #[test]

--- a/crates/s3s/src/auth/signature.rs
+++ b/crates/s3s/src/auth/signature.rs
@@ -1,0 +1,172 @@
+//! Request signatures used for AWS Signature verification.
+//!
+//! # Invariants
+//!
+//! - Values are validated at construction and always hold a canonical encoded
+//!   form (`SigV4`: 64 lowercase hex chars; `SigV2`: 28-char standard Base64 with
+//!   padding), so [`ConstantTimeEq`] always compares equal-length inputs.
+//! - `PartialEq` / `Eq` / `Hash` are deliberately NOT implemented: an ordinary
+//!   `==` comparison is a compile error; comparison must go through
+//!   [`ConstantTimeEq`] to avoid timing side channels.
+//! - [`Signature::as_str`] is for string-to-sign chaining and logging, NOT for
+//!   comparison.
+//! - Do NOT add unchecked constructors (e.g. `From<&str>`); doing so would
+//!   break both invariants above.
+
+use crate::utils::crypto::is_sha256_checksum;
+use subtle::ConstantTimeEq;
+
+/// An AWS request signature in its canonical encoded form.
+///
+/// Not a secret: the value is transmitted in cleartext with the request itself.
+/// `Debug` therefore prints the value (unlike [`SecretKey`](crate::auth::SecretKey)).
+#[derive(Debug)]
+pub struct Signature(Box<str>);
+
+impl Signature {
+    /// Parses a `SigV4` signature (64 lowercase hexadecimal characters).
+    ///
+    /// Returns `None` if `value` is not a canonical `SigV4` signature.
+    #[must_use]
+    pub fn from_hex(value: &str) -> Option<Self> {
+        is_sha256_checksum(value).then(|| Self(value.into()))
+    }
+
+    /// Parses a `SigV2` signature (standard Base64 with padding; HMAC-SHA1, 20 bytes).
+    ///
+    /// Returns `None` if `value` is not a canonical `SigV2` signature.
+    #[must_use]
+    pub fn from_base64(value: &str) -> Option<Self> {
+        // A full decode is required: `decoded_length` alone does not validate
+        // the Base64 alphabet. The canonical re-encode check rejects
+        // non-canonical variants such as non-zero padding bits. When the
+        // decoded length equals the buffer length, the buffer holds exactly
+        // the decoded bytes, so re-encoding the buffer is equivalent.
+        let mut buf = [0_u8; 20];
+        let decoded_len = base64_simd::STANDARD
+            .decode(value.as_bytes(), base64_simd::Out::from_slice(&mut buf))
+            .ok()?
+            .len();
+        (decoded_len == buf.len() && base64_simd::STANDARD.encode_to_string(buf) == value).then(|| Self(value.into()))
+    }
+
+    /// Wraps a signature produced by `sig_v4::calculate_signature` /
+    /// `sig_v2::calculate_signature`, whose output is canonical by construction.
+    ///
+    /// Called only inside the two `calculate_signature` functions.
+    /// Do not use for data received from the wire; use [`Self::from_hex`] /
+    /// [`Self::from_base64`] instead.
+    #[must_use]
+    pub(crate) fn from_computed(value: String) -> Self {
+        debug_assert!(
+            Self::from_hex(&value).is_some() || Self::from_base64(&value).is_some(),
+            "internal error: computed signature is not canonical"
+        );
+        Self(value.into_boxed_str())
+    }
+
+    /// Returns the canonical encoded form.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl ConstantTimeEq for Signature {
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        self.0.as_bytes().ct_eq(other.0.as_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HEX_64: &str = "aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404";
+    const B64_20: &str = "1No4mq5ETf02z8aet9voy6gui6E=";
+    const B64_20_PLUS: &str = "++++AAAAAAAAAAAAAAAAAAAAAAA=";
+
+    #[test]
+    fn from_hex_accepts_canonical() {
+        let sig = Signature::from_hex(HEX_64).expect("canonical hex should parse");
+        assert_eq!(sig.as_str(), HEX_64);
+    }
+
+    #[test]
+    fn from_hex_rejects_uppercase() {
+        assert!(Signature::from_hex(&HEX_64.to_uppercase()).is_none());
+    }
+
+    #[test]
+    fn from_hex_rejects_wrong_length() {
+        assert!(Signature::from_hex(&HEX_64[..63]).is_none());
+    }
+
+    #[test]
+    fn from_hex_rejects_non_hex_chars() {
+        assert!(Signature::from_hex(&format!("z{}", &HEX_64[1..])).is_none());
+    }
+
+    #[test]
+    fn from_base64_accepts_canonical() {
+        let sig = Signature::from_base64(B64_20).expect("canonical base64 should parse");
+        assert_eq!(sig.as_str(), B64_20);
+    }
+
+    #[test]
+    fn from_base64_accepts_plus_and_slash() {
+        let sig = Signature::from_base64(B64_20_PLUS).expect("base64 with '+' should parse");
+        assert_eq!(sig.as_str(), B64_20_PLUS);
+    }
+
+    #[test]
+    fn from_base64_rejects_non_base64_alphabet() {
+        // `decoded_length` alone accepts this (structure is valid); the full
+        // decode must reject it.
+        assert!(Signature::from_base64("!!!!!!!!!!!!!!!!!!!!!!!=").is_none());
+    }
+
+    #[test]
+    fn from_base64_rejects_missing_padding() {
+        assert!(Signature::from_base64(&B64_20[..27]).is_none());
+    }
+
+    #[test]
+    fn from_base64_rejects_non_20_byte_payload() {
+        // 24 chars decode to 18 bytes, not 20.
+        assert!(Signature::from_base64("AAAAAAAAAAAAAAAAAAAAAAAA").is_none());
+    }
+
+    #[test]
+    fn from_computed_round_trip() {
+        let sig = Signature::from_computed(HEX_64.to_owned());
+        assert_eq!(sig.as_str(), HEX_64);
+    }
+
+    #[test]
+    fn ct_eq_matches_equal_values() {
+        let a = Signature::from_hex(HEX_64).unwrap();
+        let b = Signature::from_hex(HEX_64).unwrap();
+        assert!(bool::from(a.ct_eq(&b)));
+    }
+
+    #[test]
+    fn ct_eq_reports_mismatch() {
+        let a = Signature::from_hex(HEX_64).unwrap();
+        let b = Signature::from_hex(&format!("0{}", &HEX_64[1..])).unwrap();
+        assert!(!bool::from(a.ct_eq(&b)));
+    }
+
+    #[test]
+    fn ct_eq_cross_encoding_is_always_unequal() {
+        let hex_sig = Signature::from_hex(HEX_64).unwrap();
+        let b64_sig = Signature::from_base64(B64_20).unwrap();
+        assert!(!bool::from(hex_sig.ct_eq(&b64_sig)));
+    }
+
+    #[test]
+    fn debug_prints_plaintext_value() {
+        let sig = Signature::from_hex(HEX_64).unwrap();
+        assert!(format!("{sig:?}").contains(HEX_64));
+    }
+}

--- a/crates/s3s/src/auth/signature.rs
+++ b/crates/s3s/src/auth/signature.rs
@@ -4,7 +4,9 @@
 //!
 //! - Values are validated at construction and always hold a canonical encoded
 //!   form (`SigV4`: 64 lowercase hex chars; `SigV2`: 28-char standard Base64 with
-//!   padding), so [`ConstantTimeEq`] always compares equal-length inputs.
+//!   padding). Comparisons within the same form are always equal-length and
+//!   constant-time over the content; cross-form comparison is always unequal
+//!   (the length difference is algorithm-public, not secret).
 //! - `PartialEq` / `Eq` / `Hash` are deliberately NOT implemented: an ordinary
 //!   `==` comparison is a compile error; comparison must go through
 //!   [`ConstantTimeEq`] to avoid timing side channels.
@@ -37,6 +39,12 @@ impl Signature {
     /// Returns `None` if `value` is not a canonical `SigV2` signature.
     #[must_use]
     pub fn from_base64(value: &str) -> Option<Self> {
+        // SigV2 signatures are always 28 chars (20-byte HMAC-SHA1 with padding);
+        // reject other lengths before decoding.
+        if value.len() != 28 {
+            return None;
+        }
+
         // A full decode is required: `decoded_length` alone does not validate
         // the Base64 alphabet. The canonical re-encode check rejects
         // non-canonical variants such as non-zero padding bits. When the
@@ -135,6 +143,8 @@ mod tests {
     fn from_base64_rejects_non_20_byte_payload() {
         // 24 chars decode to 18 bytes, not 20.
         assert!(Signature::from_base64("AAAAAAAAAAAAAAAAAAAAAAAA").is_none());
+        // 32 chars would decode to 24 bytes, not 20.
+        assert!(Signature::from_base64("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").is_none());
     }
 
     #[test]

--- a/crates/s3s/src/auth/signature.rs
+++ b/crates/s3s/src/auth/signature.rs
@@ -40,22 +40,16 @@ impl Signature {
     #[must_use]
     pub fn from_base64(value: &str) -> Option<Self> {
         // SigV2 signatures are always 28 chars (20-byte HMAC-SHA1 with padding);
-        // reject other lengths before decoding.
+        // reject other lengths before any validation work.
         if value.len() != 28 {
             return None;
         }
 
-        // A full decode is required: `decoded_length` alone does not validate
-        // the Base64 alphabet. The canonical re-encode check rejects
-        // non-canonical variants such as non-zero padding bits. When the
-        // decoded length equals the buffer length, the buffer holds exactly
-        // the decoded bytes, so re-encoding the buffer is equivalent.
-        let mut buf = [0_u8; 20];
-        let decoded_len = base64_simd::STANDARD
-            .decode(value.as_bytes(), base64_simd::Out::from_slice(&mut buf))
-            .ok()?
-            .len();
-        (decoded_len == buf.len() && base64_simd::STANDARD.encode_to_string(buf) == value).then(|| Self(value.into()))
+        // `check` validates the alphabet, the padding structure, and the
+        // canonical padding bits (`STANDARD` is not forgiving). The
+        // decoded-length check pins the payload to exactly 20 bytes.
+        base64_simd::STANDARD.check(value.as_bytes()).ok()?;
+        (base64_simd::STANDARD.decoded_length(value.as_bytes()).ok()? == 20).then(|| Self(value.into()))
     }
 
     /// Wraps a signature produced by `sig_v4::calculate_signature` /
@@ -145,6 +139,9 @@ mod tests {
         assert!(Signature::from_base64("AAAAAAAAAAAAAAAAAAAAAAAA").is_none());
         // 32 chars would decode to 24 bytes, not 20.
         assert!(Signature::from_base64("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").is_none());
+        // 28 chars with double padding decode to 19 bytes, not 20:
+        // `check` alone would accept this, the decoded-length check rejects it.
+        assert!(Signature::from_base64("AAAAAAAAAAAAAAAAAAAAAAAAAA==").is_none());
     }
 
     #[test]

--- a/crates/s3s/src/http/aws_chunked_stream.rs
+++ b/crates/s3s/src/http/aws_chunked_stream.rs
@@ -1,6 +1,7 @@
 //! aws-chunked stream
 
 use crate::auth::SecretKey;
+use crate::auth::signature::Signature;
 use crate::error::StdError;
 use crate::protocol::TrailingHeaders;
 use crate::sig_v4;
@@ -20,6 +21,7 @@ use futures::pin_mut;
 use futures::stream::{Stream, StreamExt};
 use hyper::body::{Buf, Bytes};
 use memchr::memchr;
+use subtle::ConstantTimeEq;
 
 /// Maximum size for chunk metadata
 /// Prevents `DoS` via oversized chunk size declarations
@@ -68,7 +70,7 @@ struct SignatureCtx {
     secret_key: SecretKey,
 
     /// previous chunk's signature
-    prev_signature: Box<str>,
+    prev_signature: Signature,
 }
 
 /// [`AwsChunkedStream`]
@@ -138,13 +140,15 @@ fn parse_chunk_meta(mut input: &[u8]) -> nom::IResult<&[u8], ChunkMeta<'_>> {
 }
 
 /// check signature
-fn check_signature(ctx: &SignatureCtx, expected_signature: &[u8], chunk_data: &[Bytes]) -> Option<Box<str>> {
+fn check_signature(ctx: &SignatureCtx, expected_signature: &[u8], chunk_data: &[Bytes]) -> Option<Signature> {
+    let expected_signature = Signature::from_hex(std::str::from_utf8(expected_signature).ok()?)?;
+
     let string_to_sign =
-        sig_v4::create_chunk_string_to_sign(&ctx.amz_date, &ctx.region, &ctx.service, &ctx.prev_signature, chunk_data);
+        sig_v4::create_chunk_string_to_sign(&ctx.amz_date, &ctx.region, &ctx.service, ctx.prev_signature.as_str(), chunk_data);
 
     let chunk_signature = sig_v4::calculate_signature(&string_to_sign, &ctx.secret_key, &ctx.amz_date, &ctx.region, &ctx.service);
 
-    (chunk_signature.as_bytes() == expected_signature).then(|| chunk_signature.into())
+    bool::from(chunk_signature.ct_eq(&expected_signature)).then_some(chunk_signature)
 }
 
 impl AwsChunkedStream {
@@ -152,7 +156,7 @@ impl AwsChunkedStream {
     #[allow(clippy::too_many_arguments)]
     pub fn new<S>(
         body: S,
-        seed_signature: Box<str>,
+        seed_signature: Signature,
         amz_date: AmzDate,
         region: Box<str>,
         service: Box<str>,
@@ -321,11 +325,20 @@ impl AwsChunkedStream {
 
         // Verify the trailer signature if present, or require it when unsigned=false
         if let Some(provided) = provided_signature.as_ref() {
-            let string_to_sign =
-                create_trailer_string_to_sign(&ctx.amz_date, &ctx.region, &ctx.service, &ctx.prev_signature, &canonical_trailers);
+            let Some(provided) = std::str::from_utf8(provided).ok().and_then(Signature::from_hex) else {
+                return Some(Err(AwsChunkedStreamError::SignatureMismatch));
+            };
+
+            let string_to_sign = create_trailer_string_to_sign(
+                &ctx.amz_date,
+                &ctx.region,
+                &ctx.service,
+                ctx.prev_signature.as_str(),
+                &canonical_trailers,
+            );
             let trailer_signature =
                 sig_v4::calculate_signature(&string_to_sign, &ctx.secret_key, &ctx.amz_date, &ctx.region, &ctx.service);
-            if trailer_signature.as_bytes() != provided.as_slice() {
+            if !bool::from(trailer_signature.ct_eq(&provided)) {
                 return Some(Err(AwsChunkedStreamError::SignatureMismatch));
             }
         } else if !unsigned {
@@ -634,7 +647,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            seed_signature.into(),
+            Signature::from_hex(seed_signature).unwrap(),
             date,
             region.into(),
             service.into(),
@@ -688,7 +701,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            seed_signature.into(),
+            Signature::from_hex(seed_signature).unwrap(),
             date,
             region.into(),
             service.into(),
@@ -745,14 +758,14 @@ mod tests {
         let canonical = b"x-amz-meta-foo:bar\n".to_vec();
         let string_to_sign = create_trailer_string_to_sign(&date, region, service, seed_signature, &canonical);
         let sig = sig_v4::calculate_signature(&string_to_sign, &SecretKey::from(secret_access_key), &date, region, service);
-        let trailers_block = Bytes::from(format!("x-amz-meta-foo: bar\r\nx-amz-trailer-signature:{sig}"));
+        let trailers_block = Bytes::from(format!("x-amz-meta-foo: bar\r\nx-amz-trailer-signature:{}", sig.as_str()));
 
         let chunk_results: Vec<Result<Bytes, _>> = vec![Ok(chunk1), Ok(chunk2), Ok(chunk3), Ok(trailers_block)];
 
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            seed_signature.into(),
+            Signature::from_hex(seed_signature).unwrap(),
             date,
             region.into(),
             service.into(),
@@ -794,7 +807,7 @@ mod tests {
 
         let chunk_results: Vec<Result<Bytes, _>> = vec![Ok(chunk1), Ok(chunk2), Ok(trailers_block)];
 
-        let seed_signature = "deadbeef"; // not used for unsigned per-chunk, but used to build ctx
+        let seed_signature = "0000000000000000000000000000000000000000000000000000000000000000"; // not used for unsigned per-chunk, but used to build ctx
         let timestamp = "20130524T000000Z";
         let region = "us-east-1";
         let service = "s3";
@@ -804,7 +817,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            seed_signature.into(),
+            Signature::from_hex(seed_signature).unwrap(),
             date,
             region.into(),
             service.into(),
@@ -832,14 +845,14 @@ mod tests {
         let chunk_meta = b"ZZZZ\r\n"; // Invalid hex
         let chunk_results: Vec<Result<Bytes, _>> = vec![Ok(Bytes::from_static(chunk_meta))];
 
-        let seed_signature = "test";
+        let seed_signature = "0000000000000000000000000000000000000000000000000000000000000000";
         let timestamp = "20130524T000000Z";
         let date = AmzDate::parse(timestamp).unwrap();
 
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            seed_signature.into(),
+            Signature::from_hex(seed_signature).unwrap(),
             date,
             "us-east-1".into(),
             "s3".into(),
@@ -858,14 +871,14 @@ mod tests {
         let chunk_meta = b"10"; // Missing \r\n
         let chunk_results: Vec<Result<Bytes, _>> = vec![Ok(Bytes::from_static(chunk_meta))];
 
-        let seed_signature = "test";
+        let seed_signature = "0000000000000000000000000000000000000000000000000000000000000000";
         let timestamp = "20130524T000000Z";
         let date = AmzDate::parse(timestamp).unwrap();
 
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            seed_signature.into(),
+            Signature::from_hex(seed_signature).unwrap(),
             date,
             "us-east-1".into(),
             "s3".into(),
@@ -887,14 +900,14 @@ mod tests {
         let chunk1 = join(&[chunk_meta, chunk_data, b"\r\n"]);
         let chunk_results: Vec<Result<Bytes, _>> = vec![Ok(chunk1)];
 
-        let seed_signature = "test";
+        let seed_signature = "0000000000000000000000000000000000000000000000000000000000000000";
         let timestamp = "20130524T000000Z";
         let date = AmzDate::parse(timestamp).unwrap();
 
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            seed_signature.into(),
+            Signature::from_hex(seed_signature).unwrap(),
             date,
             "us-east-1".into(),
             "s3".into(),
@@ -916,14 +929,14 @@ mod tests {
 
         let chunk_results: Vec<Result<Bytes, _>> = vec![Ok(chunk1)];
 
-        let seed_signature = "test";
+        let seed_signature = "0000000000000000000000000000000000000000000000000000000000000000";
         let timestamp = "20130524T000000Z";
         let date = AmzDate::parse(timestamp).unwrap();
 
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            seed_signature.into(),
+            Signature::from_hex(seed_signature).unwrap(),
             date,
             "us-east-1".into(),
             "s3".into(),
@@ -944,14 +957,14 @@ mod tests {
         let err: Result<Bytes, StdError> = Err(Box::new(io::Error::other("network error")));
         let chunk_results: Vec<Result<Bytes, _>> = vec![err];
 
-        let seed_signature = "test";
+        let seed_signature = "0000000000000000000000000000000000000000000000000000000000000000";
         let timestamp = "20130524T000000Z";
         let date = AmzDate::parse(timestamp).unwrap();
 
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            seed_signature.into(),
+            Signature::from_hex(seed_signature).unwrap(),
             date,
             "us-east-1".into(),
             "s3".into(),
@@ -972,14 +985,14 @@ mod tests {
         let chunk1 = join(&[chunk_meta, chunk_data, b"\r\n"]);
         let chunk_results: Vec<Result<Bytes, _>> = vec![Ok(chunk1)];
 
-        let seed_signature = "test";
+        let seed_signature = "0000000000000000000000000000000000000000000000000000000000000000";
         let timestamp = "20130524T000000Z";
         let date = AmzDate::parse(timestamp).unwrap();
 
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            seed_signature.into(),
+            Signature::from_hex(seed_signature).unwrap(),
             date,
             "us-east-1".into(),
             "s3".into(),
@@ -1005,14 +1018,14 @@ mod tests {
 
         let chunk_results: Vec<Result<Bytes, _>> = vec![Ok(chunk1), Ok(chunk2)];
 
-        let seed_signature = "test";
+        let seed_signature = "0000000000000000000000000000000000000000000000000000000000000000";
         let timestamp = "20130524T000000Z";
         let date = AmzDate::parse(timestamp).unwrap();
 
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            seed_signature.into(),
+            Signature::from_hex(seed_signature).unwrap(),
             date,
             "us-east-1".into(),
             "s3".into(),
@@ -1042,14 +1055,14 @@ mod tests {
 
         let chunk_results: Vec<Result<Bytes, _>> = vec![Ok(chunk1), Ok(chunk2)];
 
-        let seed_signature = "test";
+        let seed_signature = "0000000000000000000000000000000000000000000000000000000000000000";
         let timestamp = "20130524T000000Z";
         let date = AmzDate::parse(timestamp).unwrap();
 
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            seed_signature.into(),
+            Signature::from_hex(seed_signature).unwrap(),
             date,
             "us-east-1".into(),
             "s3".into(),
@@ -1098,7 +1111,7 @@ mod tests {
 
         let chunk_results: Vec<Result<Bytes, _>> = vec![Ok(chunk1), Ok(chunk2), Ok(Bytes::from(trailers))];
 
-        let seed_signature = "deadbeef";
+        let seed_signature = "0000000000000000000000000000000000000000000000000000000000000000";
         let timestamp = "20130524T000000Z";
         let region = "us-east-1";
         let service = "s3";
@@ -1108,7 +1121,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            seed_signature.into(),
+            Signature::from_hex(seed_signature).unwrap(),
             date,
             region.into(),
             service.into(),
@@ -1140,7 +1153,7 @@ mod tests {
 
         let chunk_results: Vec<Result<Bytes, _>> = vec![Ok(Bytes::from(meta_part1)), Ok(Bytes::from(meta_part2))];
 
-        let seed_signature = "deadbeef";
+        let seed_signature = "0000000000000000000000000000000000000000000000000000000000000000";
         let timestamp = "20130524T000000Z";
         let region = "us-east-1";
         let service = "s3";
@@ -1150,7 +1163,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            seed_signature.into(),
+            Signature::from_hex(seed_signature).unwrap(),
             date,
             region.into(),
             service.into(),
@@ -1199,7 +1212,7 @@ mod tests {
 
         let chunk_results: Vec<Result<Bytes, _>> = vec![Ok(chunk1), Ok(chunk2), Ok(Bytes::from(large_trailers))];
 
-        let seed_signature = "deadbeef";
+        let seed_signature = "0000000000000000000000000000000000000000000000000000000000000000";
         let timestamp = "20130524T000000Z";
         let region = "us-east-1";
         let service = "s3";
@@ -1209,7 +1222,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            seed_signature.into(),
+            Signature::from_hex(seed_signature).unwrap(),
             date,
             region.into(),
             service.into(),
@@ -1284,7 +1297,7 @@ mod tests {
 
         let chunk_results: Vec<Result<Bytes, _>> = vec![Ok(chunk1), Ok(chunk2), Ok(Bytes::from(many_trailers))];
 
-        let seed_signature = "deadbeef";
+        let seed_signature = "0000000000000000000000000000000000000000000000000000000000000000";
         let timestamp = "20130524T000000Z";
         let region = "us-east-1";
         let service = "s3";
@@ -1294,7 +1307,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            seed_signature.into(),
+            Signature::from_hex(seed_signature).unwrap(),
             date,
             region.into(),
             service.into(),

--- a/crates/s3s/src/http/aws_chunked_stream.rs
+++ b/crates/s3s/src/http/aws_chunked_stream.rs
@@ -21,7 +21,6 @@ use futures::pin_mut;
 use futures::stream::{Stream, StreamExt};
 use hyper::body::{Buf, Bytes};
 use memchr::memchr;
-use subtle::ConstantTimeEq;
 
 /// Maximum size for chunk metadata
 /// Prevents `DoS` via oversized chunk size declarations
@@ -148,7 +147,7 @@ fn check_signature(ctx: &SignatureCtx, expected_signature: &[u8], chunk_data: &[
 
     let chunk_signature = sig_v4::calculate_signature(&string_to_sign, &ctx.secret_key, &ctx.amz_date, &ctx.region, &ctx.service);
 
-    bool::from(chunk_signature.ct_eq(&expected_signature)).then_some(chunk_signature)
+    Signature::compare(&chunk_signature, &expected_signature).then_some(chunk_signature)
 }
 
 impl AwsChunkedStream {
@@ -338,7 +337,7 @@ impl AwsChunkedStream {
             );
             let trailer_signature =
                 sig_v4::calculate_signature(&string_to_sign, &ctx.secret_key, &ctx.amz_date, &ctx.region, &ctx.service);
-            if !bool::from(trailer_signature.ct_eq(&provided)) {
+            if !Signature::compare(&trailer_signature, &provided) {
                 return Some(Err(AwsChunkedStreamError::SignatureMismatch));
             }
         } else if !unsigned {

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -1,5 +1,6 @@
 use crate::auth::S3Auth;
 use crate::auth::SecretKey;
+use crate::auth::signature::Signature;
 use crate::config::{S3Config, S3ConfigProvider};
 use crate::error::*;
 use crate::http;
@@ -107,16 +108,12 @@ fn has_unencoded_reserved_path_char(path: &str) -> bool {
 }
 
 struct SignatureVerificationContext<'a> {
-    expected_signature: &'a str,
+    expected_signature: Signature,
     raw_uri_path: &'a str,
     secret_key: &'a SecretKey,
     amz_date: &'a AmzDate,
     region: &'a str,
     service: &'a str,
-}
-
-fn sig_v4_signatures_match(actual_signature: &str, expected_signature: &str) -> bool {
-    actual_signature.as_bytes().ct_eq(expected_signature.as_bytes()).into()
 }
 
 fn validate_sig_v4_clock_skew(amz_date: &AmzDate, now: time::OffsetDateTime, config: &S3Config) -> S3Result<()> {
@@ -136,11 +133,11 @@ impl SignatureVerificationContext<'_> {
         &self,
         canonical_request: &str,
         raw_canonical_request: impl FnOnce() -> String,
-    ) -> S3Result<String> {
+    ) -> S3Result<Signature> {
         let string_to_sign = sig_v4::create_string_to_sign(canonical_request, self.amz_date, self.region, self.service);
         let signature = sig_v4::calculate_signature(&string_to_sign, self.secret_key, self.amz_date, self.region, self.service);
 
-        if sig_v4_signatures_match(&signature, self.expected_signature) {
+        if bool::from(signature.ct_eq(&self.expected_signature)) {
             return Ok(signature);
         }
 
@@ -154,7 +151,7 @@ impl SignatureVerificationContext<'_> {
         let raw_signature =
             sig_v4::calculate_signature(&string_to_sign, self.secret_key, self.amz_date, self.region, self.service);
 
-        if !sig_v4_signatures_match(&raw_signature, self.expected_signature) {
+        if !bool::from(raw_signature.ct_eq(&self.expected_signature)) {
             debug!(?signature, ?raw_signature, expected=?self.expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }
@@ -316,8 +313,8 @@ impl SignatureContext<'_> {
         let string_to_sign = info.policy;
         let signature = sig_v4::calculate_signature(string_to_sign, &secret_key, &amz_date, region, service);
 
-        let expected_signature = info.x_amz_signature;
-        if !sig_v4_signatures_match(&signature, expected_signature) {
+        let expected_signature = Signature::from_hex(info.x_amz_signature).ok_or_else(|| s3_error!(SignatureDoesNotMatch))?;
+        if !bool::from(signature.ct_eq(&expected_signature)) {
             debug!(?signature, expected=?expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }
@@ -406,7 +403,7 @@ impl SignatureContext<'_> {
             ));
         }
 
-        let expected_signature = presigned_url.signature;
+        let expected_signature = Signature::from_hex(presigned_url.signature).ok_or_else(|| s3_error!(SignatureDoesNotMatch))?;
         let headers = self.hs.find_multiple_with_on_missing(&presigned_url.signed_headers, |name| {
             // HTTP/2 replaces `host` header with `:authority`
             // but `:authority` is not in the request headers
@@ -507,7 +504,7 @@ impl SignatureContext<'_> {
 
         let is_stream = amz_content_sha256.is_some_and(|v| v.is_streaming());
 
-        let expected_signature = authorization.signature;
+        let expected_signature = Signature::from_hex(authorization.signature).ok_or_else(|| s3_error!(SignatureDoesNotMatch))?;
         let method = &self.req_method;
         let query_strings: &[(String, String)] = self.qs.as_ref().map_or(&[], AsRef::as_ref);
 
@@ -592,7 +589,7 @@ impl SignatureContext<'_> {
             let unsigned = matches!(amz_content_sha256, Some(AmzContentSha256::StreamingUnsignedPayloadTrailer));
             let stream = AwsChunkedStream::new(
                 mem::take(self.req_body),
-                signature.into(),
+                signature,
                 amz_date,
                 region.into(),
                 service.into(),
@@ -683,8 +680,8 @@ impl SignatureContext<'_> {
 
         debug!(?string_to_sign, "sig_v2 header_auth");
 
-        let expected_signature = auth_v2.signature;
-        if signature != expected_signature {
+        let expected_signature = Signature::from_base64(auth_v2.signature).ok_or_else(|| s3_error!(SignatureDoesNotMatch))?;
+        if !bool::from(signature.ct_eq(&expected_signature)) {
             debug!(?signature, expected=?expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }
@@ -713,8 +710,8 @@ impl SignatureContext<'_> {
         let string_to_sign = info.policy;
         let signature = sig_v2::calculate_signature(&secret_key, string_to_sign);
 
-        let expected_signature = info.signature;
-        if signature != expected_signature {
+        let expected_signature = Signature::from_base64(info.signature).ok_or_else(|| s3_error!(SignatureDoesNotMatch))?;
+        if !bool::from(signature.ct_eq(&expected_signature)) {
             debug!(?signature, expected=?expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }
@@ -750,8 +747,9 @@ impl SignatureContext<'_> {
         );
         let signature = sig_v2::calculate_signature(&secret_key, &string_to_sign);
 
-        let expected_signature = presigned_url.signature;
-        if signature != expected_signature {
+        let expected_signature =
+            Signature::from_base64(presigned_url.signature.as_ref()).ok_or_else(|| s3_error!(SignatureDoesNotMatch))?;
+        if !bool::from(signature.ct_eq(&expected_signature)) {
             debug!(?signature, expected=?expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }
@@ -849,7 +847,7 @@ mod tests {
             sig_v4::Payload::Unsigned,
         );
         let verifier = SignatureVerificationContext {
-            expected_signature: "0000000000000000000000000000000000000000000000000000000000000000",
+            expected_signature: Signature::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
             raw_uri_path: "/test-bucket/path",
             secret_key: &secret_key,
             amz_date: &amz_date,
@@ -869,7 +867,7 @@ mod tests {
             sig_v4::Payload::Unsigned,
         );
         let verifier = SignatureVerificationContext {
-            expected_signature: "0000000000000000000000000000000000000000000000000000000000000000",
+            expected_signature: Signature::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
             raw_uri_path: "/test-bucket/path=",
             secret_key: &secret_key,
             amz_date: &amz_date,
@@ -1256,7 +1254,7 @@ file content\r\n\
             let string_to_sign = sig_v4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
             let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
             let mut signed_query_strings = query_strings_for_signing.clone();
-            signed_query_strings.push(("X-Amz-Signature".to_owned(), signature));
+            signed_query_strings.push(("X-Amz-Signature".to_owned(), signature.as_str().to_owned()));
             let qs = OrderedQs::from_vec_unchecked(signed_query_strings);
             let headers = OrderedHeaders::from_slice_unchecked(&[("host", "s3.amazonaws.com")]);
 
@@ -1318,7 +1316,7 @@ file content\r\n\
         let string_to_sign = sig_v4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
         let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
         let mut signed_query_strings = query_strings_for_signing;
-        signed_query_strings.push(("X-Amz-Signature".to_owned(), signature));
+        signed_query_strings.push(("X-Amz-Signature".to_owned(), signature.as_str().to_owned()));
         let qs = OrderedQs::from_vec_unchecked(signed_query_strings);
 
         let mut body = Body::empty();
@@ -1385,7 +1383,7 @@ file content\r\n\
         let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
 
         let mut signed_query_strings = query_strings_for_signing;
-        signed_query_strings.push(("X-Amz-Signature".to_owned(), signature));
+        signed_query_strings.push(("X-Amz-Signature".to_owned(), signature.as_str().to_owned()));
         let qs = OrderedQs::from_vec_unchecked(signed_query_strings);
 
         let headers = OrderedHeaders::from_slice_unchecked(&[
@@ -1464,7 +1462,7 @@ file content\r\n\
         let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
 
         let mut signed_query_strings = query_strings_for_signing;
-        signed_query_strings.push(("X-Amz-Signature".to_owned(), signature));
+        signed_query_strings.push(("X-Amz-Signature".to_owned(), signature.as_str().to_owned()));
         let qs = OrderedQs::from_vec_unchecked(signed_query_strings);
 
         let headers = OrderedHeaders::from_slice_unchecked(&[
@@ -1548,7 +1546,8 @@ file content\r\n\
             let string_to_sign = sig_v4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
             let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
             let authorization = format!(
-                "AWS4-HMAC-SHA256 Credential={access_key}/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={signature}"
+                "AWS4-HMAC-SHA256 Credential={access_key}/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={}",
+                signature.as_str(),
             );
             let headers = OrderedHeaders::from_slice_unchecked(&[
                 ("authorization", authorization.as_str()),
@@ -1625,7 +1624,8 @@ file content\r\n\
         let string_to_sign = sig_v4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
         let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
         let authorization = format!(
-            "AWS4-HMAC-SHA256 Credential={access_key}/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={signature}"
+            "AWS4-HMAC-SHA256 Credential={access_key}/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={}",
+            signature.as_str(),
         );
 
         let headers = OrderedHeaders::from_slice_unchecked(&[
@@ -1703,7 +1703,8 @@ file content\r\n\
         let string_to_sign = sig_v4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
         let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
         let authorization = format!(
-            "AWS4-HMAC-SHA256 Credential={access_key}/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={signature}"
+            "AWS4-HMAC-SHA256 Credential={access_key}/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={}",
+            signature.as_str(),
         );
         let headers = OrderedHeaders::from_slice_unchecked(&[
             ("authorization", authorization.as_str()),
@@ -1739,6 +1740,7 @@ file content\r\n\
         assert_eq!(cred.access_key, access_key);
     }
 
+    #[allow(clippy::too_many_lines)]
     #[tokio::test]
     async fn v4_header_auth_raw_uri_path_signature_seeds_streaming_body() {
         use crate::auth::SecretKey;
@@ -1789,21 +1791,29 @@ file content\r\n\
         let seed_string_to_sign = sig_v4::create_string_to_sign(&raw_canonical_request, &amz_date, "us-east-1", "s3");
         let seed_signature = sig_v4::calculate_signature(&seed_string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
 
-        let chunk_string_to_sign =
-            sig_v4::create_chunk_string_to_sign(&amz_date, "us-east-1", "s3", &seed_signature, std::slice::from_ref(&chunk_data));
+        let chunk_string_to_sign = sig_v4::create_chunk_string_to_sign(
+            &amz_date,
+            "us-east-1",
+            "s3",
+            seed_signature.as_str(),
+            std::slice::from_ref(&chunk_data),
+        );
         let chunk_signature = sig_v4::calculate_signature(&chunk_string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
-        let final_string_to_sign = sig_v4::create_chunk_string_to_sign(&amz_date, "us-east-1", "s3", &chunk_signature, &[]);
+        let final_string_to_sign =
+            sig_v4::create_chunk_string_to_sign(&amz_date, "us-east-1", "s3", chunk_signature.as_str(), &[]);
         let final_signature = sig_v4::calculate_signature(&final_string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
 
         let mut streaming_body = Vec::new();
-        streaming_body.extend_from_slice(format!("{:x};chunk-signature={chunk_signature}\r\n", chunk_data.len()).as_bytes());
+        streaming_body
+            .extend_from_slice(format!("{:x};chunk-signature={}\r\n", chunk_data.len(), chunk_signature.as_str()).as_bytes());
         streaming_body.extend_from_slice(&chunk_data);
         streaming_body.extend_from_slice(b"\r\n");
-        streaming_body.extend_from_slice(format!("0;chunk-signature={final_signature}\r\n\r\n").as_bytes());
+        streaming_body.extend_from_slice(format!("0;chunk-signature={}\r\n\r\n", final_signature.as_str()).as_bytes());
         let content_length = u64::try_from(streaming_body.len()).unwrap();
 
         let authorization = format!(
-            "AWS4-HMAC-SHA256 Credential={access_key}/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length, Signature={seed_signature}"
+            "AWS4-HMAC-SHA256 Credential={access_key}/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length, Signature={}",
+            seed_signature.as_str()
         );
         let headers = OrderedHeaders::from_slice_unchecked(&[
             ("authorization", authorization.as_str()),
@@ -1883,7 +1893,7 @@ file content\r\n\
 
         let auth_v2 = AuthorizationV2 {
             access_key,
-            signature: &signature,
+            signature: signature.as_str(),
         };
 
         let mut cx = SignatureContext {
@@ -1912,13 +1922,6 @@ file content\r\n\
             .expect("valid SigV2 auth should succeed");
         assert_eq!(cred.region, None, "SigV2 carries no region");
         assert_eq!(cred.service.as_deref(), Some("s3"), "SigV2 service is always 's3'");
-    }
-
-    #[test]
-    fn sig_v4_signatures_match_reports_match_and_mismatch() {
-        assert!(sig_v4_signatures_match("abcd", "abcd"));
-        assert!(!sig_v4_signatures_match("abcd", "abce"));
-        assert!(!sig_v4_signatures_match("abcd", "abc"));
     }
 
     #[tokio::test]
@@ -1956,8 +1959,9 @@ file content\r\n\
         let string_to_sign = sig_v4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
         let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
         let authorization = format!(
-            "AWS4-HMAC-SHA256 Credential={access_key}/{}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={signature}",
-            amz_date.fmt_date()
+            "AWS4-HMAC-SHA256 Credential={access_key}/{}/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={}",
+            amz_date.fmt_date(),
+            signature.as_str(),
         );
 
         let headers = OrderedHeaders::from_slice_unchecked(&[
@@ -2051,7 +2055,7 @@ file content\r\n\
             boundary = boundary,
             date = amz_date.fmt_date(),
             policy_b64 = policy_b64,
-            signature = signature,
+            signature = signature.as_str(),
         );
 
         let mime: Mime = format!("multipart/form-data; boundary={boundary}").parse().unwrap();

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -26,7 +26,6 @@ use std::sync::Arc;
 use hyper::Method;
 use hyper::Uri;
 use mime::Mime;
-use subtle::ConstantTimeEq;
 use tracing::debug;
 
 /// Maximum allowed size for STS request body (8KB should be enough for operations like `AssumeRole`)
@@ -137,7 +136,7 @@ impl SignatureVerificationContext<'_> {
         let string_to_sign = sig_v4::create_string_to_sign(canonical_request, self.amz_date, self.region, self.service);
         let signature = sig_v4::calculate_signature(&string_to_sign, self.secret_key, self.amz_date, self.region, self.service);
 
-        if bool::from(signature.ct_eq(&self.expected_signature)) {
+        if Signature::compare(&signature, &self.expected_signature) {
             return Ok(signature);
         }
 
@@ -151,7 +150,7 @@ impl SignatureVerificationContext<'_> {
         let raw_signature =
             sig_v4::calculate_signature(&string_to_sign, self.secret_key, self.amz_date, self.region, self.service);
 
-        if !bool::from(raw_signature.ct_eq(&self.expected_signature)) {
+        if !Signature::compare(&raw_signature, &self.expected_signature) {
             debug!(?signature, ?raw_signature, expected=?self.expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }
@@ -314,7 +313,7 @@ impl SignatureContext<'_> {
         let signature = sig_v4::calculate_signature(string_to_sign, &secret_key, &amz_date, region, service);
 
         let expected_signature = Signature::from_hex(info.x_amz_signature).ok_or_else(|| s3_error!(SignatureDoesNotMatch))?;
-        if !bool::from(signature.ct_eq(&expected_signature)) {
+        if !Signature::compare(&signature, &expected_signature) {
             debug!(?signature, expected=?expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }
@@ -681,7 +680,7 @@ impl SignatureContext<'_> {
         debug!(?string_to_sign, "sig_v2 header_auth");
 
         let expected_signature = Signature::from_base64(auth_v2.signature).ok_or_else(|| s3_error!(SignatureDoesNotMatch))?;
-        if !bool::from(signature.ct_eq(&expected_signature)) {
+        if !Signature::compare(&signature, &expected_signature) {
             debug!(?signature, expected=?expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }
@@ -711,7 +710,7 @@ impl SignatureContext<'_> {
         let signature = sig_v2::calculate_signature(&secret_key, string_to_sign);
 
         let expected_signature = Signature::from_base64(info.signature).ok_or_else(|| s3_error!(SignatureDoesNotMatch))?;
-        if !bool::from(signature.ct_eq(&expected_signature)) {
+        if !Signature::compare(&signature, &expected_signature) {
             debug!(?signature, expected=?expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }
@@ -749,7 +748,7 @@ impl SignatureContext<'_> {
 
         let expected_signature =
             Signature::from_base64(presigned_url.signature.as_ref()).ok_or_else(|| s3_error!(SignatureDoesNotMatch))?;
-        if !bool::from(signature.ct_eq(&expected_signature)) {
+        if !Signature::compare(&signature, &expected_signature) {
             debug!(?signature, expected=?expected_signature, "signature mismatch");
             return Err(s3_error!(SignatureDoesNotMatch));
         }

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -518,7 +518,7 @@ async fn post_multipart_bucket_routes_to_post_object() {
         ),
         amz_date = amz_date_str,
         b = boundary,
-        signature = signature,
+        signature = signature.as_str(),
         bucket = bucket,
         policy_b64 = policy_b64,
         algorithm = algorithm,
@@ -766,7 +766,7 @@ mod post_policy_test_helpers {
 
         let body = build_multipart_fields(
             &[
-                ("x-amz-signature", &signature),
+                ("x-amz-signature", signature.as_str()),
                 ("bucket", bucket),
                 ("policy", &policy_b64),
                 ("x-amz-algorithm", algorithm),

--- a/crates/s3s/src/sig_v2/methods.rs
+++ b/crates/s3s/src/sig_v2/methods.rs
@@ -1,4 +1,5 @@
 use crate::auth::SecretKey;
+use crate::auth::signature::Signature;
 use crate::http::OrderedHeaders;
 use crate::http::OrderedQs;
 use crate::utils::crypto::hmac_sha1;
@@ -11,8 +12,8 @@ fn base64(data: impl AsRef<[u8]>) -> String {
     base64_simd::STANDARD.encode_to_string(data)
 }
 
-pub fn calculate_signature(secret_key: &SecretKey, string_to_sign: &str) -> String {
-    base64(hmac_sha1(secret_key.expose(), string_to_sign))
+pub fn calculate_signature(secret_key: &SecretKey, string_to_sign: &str) -> Signature {
+    Signature::from_computed(base64(hmac_sha1(secret_key.expose(), string_to_sign)))
 }
 
 const INCLUDED_QUERY: &[&str] = &[
@@ -211,7 +212,7 @@ mod tests {
                 )
             );
 
-            assert_eq!(signature, "qgk2+6Sv9/oM7G3qLEjTH1a1l1g=");
+            assert_eq!(signature.as_str(), "qgk2+6Sv9/oM7G3qLEjTH1a1l1g=");
         }
 
         {
@@ -239,7 +240,7 @@ mod tests {
                 )
             );
 
-            assert_eq!(signature, "iqRzw+ileNPu1fhspnRs8nOjjIA=");
+            assert_eq!(signature.as_str(), "iqRzw+ileNPu1fhspnRs8nOjjIA=");
         }
 
         {
@@ -264,7 +265,7 @@ mod tests {
                 )
             );
 
-            assert_eq!(signature, "m0WP8eCtspQl5Ahe6L1SozdX9YA=");
+            assert_eq!(signature.as_str(), "m0WP8eCtspQl5Ahe6L1SozdX9YA=");
         }
 
         {
@@ -289,7 +290,7 @@ mod tests {
                 )
             );
 
-            assert_eq!(signature, "82ZHiFIjc+WbcwFKGUVEQspPn+0=");
+            assert_eq!(signature.as_str(), "82ZHiFIjc+WbcwFKGUVEQspPn+0=");
         }
 
         {
@@ -319,8 +320,8 @@ mod tests {
             );
 
             // FIXME: The example is wrong?
-            // assert_eq!(signature, "XbyTlbQdu9Xw5o8P4iMwPktxQd8=");
-            assert_eq!(signature, "Ri1hpB1zpS9pGqR7y8kuNFCl4sE=");
+            // assert_eq!(signature.as_str(), "XbyTlbQdu9Xw5o8P4iMwPktxQd8=");
+            assert_eq!(signature.as_str(), "Ri1hpB1zpS9pGqR7y8kuNFCl4sE=");
         }
 
         {
@@ -361,8 +362,8 @@ mod tests {
                 )
             );
 
-            // assert_eq!(signature, "dKZcB+bz2EPXgSdXZp9ozGeOM4I="); // The example is wrong?
-            assert_eq!(signature, "jtBQa0Aq+DkULFI8qrpwIjGEx0E=");
+            // assert_eq!(signature.as_str(), "dKZcB+bz2EPXgSdXZp9ozGeOM4I="); // The example is wrong?
+            assert_eq!(signature.as_str(), "jtBQa0Aq+DkULFI8qrpwIjGEx0E=");
         }
 
         {
@@ -387,7 +388,7 @@ mod tests {
                 )
             );
 
-            assert_eq!(signature, "qGdzdERIC03wnaRNKh6OqZehG9s=");
+            assert_eq!(signature.as_str(), "qGdzdERIC03wnaRNKh6OqZehG9s=");
         }
 
         {
@@ -412,7 +413,7 @@ mod tests {
                 )
             );
 
-            assert_eq!(signature, "DNEZGsoieTZ92F3bUfSPQcbGmlM=");
+            assert_eq!(signature.as_str(), "DNEZGsoieTZ92F3bUfSPQcbGmlM=");
         }
 
         {
@@ -446,7 +447,7 @@ mod tests {
                 )
             );
 
-            assert_eq!(signature, presigned_url.signature);
+            assert_eq!(signature.as_str(), presigned_url.signature.as_ref());
         }
     }
 
@@ -488,7 +489,7 @@ mod tests {
 
         // Sanity-check: a non-empty signature is produced for this input
         let sig = calculate_signature(&secret_key, &string_to_sign);
-        assert_ne!(sig.len(), 0);
+        assert_ne!(sig.as_str().len(), 0);
     }
 
     /// Regression test for <https://github.com/s3s-project/s3s/issues/137>
@@ -514,7 +515,7 @@ mod tests {
 
         // Sanity-check: a non-empty signature is produced for this input
         let sig = calculate_signature(&secret_key, &string_to_sign);
-        assert_ne!(sig.len(), 0);
+        assert_ne!(sig.as_str().len(), 0);
     }
 
     /// Regression test for <https://github.com/s3s-project/s3s/issues/137>
@@ -546,6 +547,6 @@ mod tests {
 
         // Sanity-check: a non-empty signature is produced for this input
         let sig = calculate_signature(&secret_key, &string_to_sign);
-        assert_ne!(sig.len(), 0);
+        assert_ne!(sig.as_str().len(), 0);
     }
 }

--- a/crates/s3s/src/sig_v4/methods.rs
+++ b/crates/s3s/src/sig_v4/methods.rs
@@ -3,6 +3,7 @@
 use super::AmzDate;
 
 use crate::auth::SecretKey;
+use crate::auth::signature::Signature;
 use crate::http::OrderedHeaders;
 use crate::utils::crypto::{hex, hex_sha256, hex_sha256_chunk, hmac_sha256};
 use crate::utils::stable_sort_by_first;
@@ -394,7 +395,7 @@ pub fn calculate_signature(
     amz_date: &AmzDate,
     region: &str,
     service: &str,
-) -> String {
+) -> Signature {
     let mut secret = {
         let secret_key = secret_key.expose();
         let mut buf = <SmallVec<[u8; 128]>>::with_capacity(secret_key.len().saturating_add(4));
@@ -420,7 +421,7 @@ pub fn calculate_signature(
     let signing_key = hmac_sha256(date_region_service_key, "aws4_request");
 
     // Signature
-    hex(hmac_sha256(signing_key, string_to_sign))
+    Signature::from_computed(hex(hmac_sha256(signing_key, string_to_sign)))
 }
 
 fn create_presigned_canonical_request_with_uri_mode(
@@ -622,7 +623,7 @@ mod tests {
         );
 
         let signature = calculate_signature(&string_to_sign, &secret_access_key, &date, region, service);
-        assert_eq!(signature, "f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41");
+        assert_eq!(signature.as_str(), "f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41");
     }
 
     #[test]
@@ -679,7 +680,7 @@ mod tests {
         );
 
         let signature = calculate_signature(&string_to_sign, &secret_access_key, &date, region, service);
-        assert_eq!(signature, "98ad721746da40c64f1a55b78f14c238d841ea1380cd77a1b5971af0ece108bd");
+        assert_eq!(signature.as_str(), "98ad721746da40c64f1a55b78f14c238d841ea1380cd77a1b5971af0ece108bd");
     }
 
     #[test]
@@ -739,7 +740,7 @@ mod tests {
         );
 
         let signature = calculate_signature(&string_to_sign, &secret_access_key, &date, region, service);
-        assert_eq!(signature, "4f232c4386841ef735655705268965c44a0e4690baa4adea153f7db9fa80a0a9",);
+        assert_eq!(signature.as_str(), "4f232c4386841ef735655705268965c44a0e4690baa4adea153f7db9fa80a0a9",);
     }
 
     #[test]
@@ -767,10 +768,13 @@ mod tests {
         );
 
         let chunk1_signature = calculate_signature(&chunk1_string_to_sign, &secret_access_key, &date, region, service);
-        assert_eq!(chunk1_signature, "ad80c730a21e5b8d04586a2213dd63b9a0e99e0e2307b0ade35a65485a288648");
+        assert_eq!(
+            chunk1_signature.as_str(),
+            "ad80c730a21e5b8d04586a2213dd63b9a0e99e0e2307b0ade35a65485a288648"
+        );
 
         let chunk2_string_to_sign =
-            create_chunk_string_to_sign(&date, region, service, &chunk1_signature, &[Bytes::from(vec![b'a'; 1024])]);
+            create_chunk_string_to_sign(&date, region, service, chunk1_signature.as_str(), &[Bytes::from(vec![b'a'; 1024])]);
         assert_eq!(
             chunk2_string_to_sign,
             concat!(
@@ -784,9 +788,12 @@ mod tests {
         );
 
         let chunk2_signature = calculate_signature(&chunk2_string_to_sign, &secret_access_key, &date, region, service);
-        assert_eq!(chunk2_signature, "0055627c9e194cb4542bae2aa5492e3c1575bbb81b612b7d234b86a503ef5497");
+        assert_eq!(
+            chunk2_signature.as_str(),
+            "0055627c9e194cb4542bae2aa5492e3c1575bbb81b612b7d234b86a503ef5497"
+        );
 
-        let chunk3_string_to_sign = create_chunk_string_to_sign(&date, region, service, &chunk2_signature, &[]);
+        let chunk3_string_to_sign = create_chunk_string_to_sign(&date, region, service, chunk2_signature.as_str(), &[]);
         assert_eq!(
             chunk3_string_to_sign,
             concat!(
@@ -800,7 +807,10 @@ mod tests {
         );
 
         let chunk3_signature = calculate_signature(&chunk3_string_to_sign, &secret_access_key, &date, region, service);
-        assert_eq!(chunk3_signature, "b6c6ea8a5354eaf15b3cb7646744f4275b71ea724fed81ceb9323e279d449df9");
+        assert_eq!(
+            chunk3_signature.as_str(),
+            "b6c6ea8a5354eaf15b3cb7646744f4275b71ea724fed81ceb9323e279d449df9"
+        );
     }
 
     #[test]
@@ -861,7 +871,7 @@ mod tests {
         );
 
         let signature = calculate_signature(&string_to_sign, &secret_access_key, &date, region, service);
-        assert_eq!(signature, "106e2a8a18243abcf37539882f36619c00e2dfc72633413f02d3b74544bfeb8e");
+        assert_eq!(signature.as_str(), "106e2a8a18243abcf37539882f36619c00e2dfc72633413f02d3b74544bfeb8e");
     }
 
     #[test]
@@ -941,11 +951,14 @@ mod tests {
         );
 
         let chunk1_signature = calculate_signature(&chunk1_string_to_sign, &secret_access_key, &date, region, service);
-        assert_eq!(chunk1_signature, "b474d8862b1487a5145d686f57f013e54db672cee1c953b3010fb58501ef5aa2");
+        assert_eq!(
+            chunk1_signature.as_str(),
+            "b474d8862b1487a5145d686f57f013e54db672cee1c953b3010fb58501ef5aa2"
+        );
 
         // Chunk 2: 1024 bytes of 'a'
         let chunk2_string_to_sign =
-            create_chunk_string_to_sign(&date, region, service, &chunk1_signature, &[Bytes::from(vec![b'a'; 1024])]);
+            create_chunk_string_to_sign(&date, region, service, chunk1_signature.as_str(), &[Bytes::from(vec![b'a'; 1024])]);
         assert_eq!(
             chunk2_string_to_sign,
             concat!(
@@ -959,10 +972,13 @@ mod tests {
         );
 
         let chunk2_signature = calculate_signature(&chunk2_string_to_sign, &secret_access_key, &date, region, service);
-        assert_eq!(chunk2_signature, "1c1344b170168f8e65b41376b44b20fe354e373826ccbbe2c1d40a8cae51e5c7");
+        assert_eq!(
+            chunk2_signature.as_str(),
+            "1c1344b170168f8e65b41376b44b20fe354e373826ccbbe2c1d40a8cae51e5c7"
+        );
 
         // Chunk 3: 0 bytes
-        let chunk3_string_to_sign = create_chunk_string_to_sign(&date, region, service, &chunk2_signature, &[]);
+        let chunk3_string_to_sign = create_chunk_string_to_sign(&date, region, service, chunk2_signature.as_str(), &[]);
         assert_eq!(
             chunk3_string_to_sign,
             concat!(
@@ -976,7 +992,10 @@ mod tests {
         );
 
         let chunk3_signature = calculate_signature(&chunk3_string_to_sign, &secret_access_key, &date, region, service);
-        assert_eq!(chunk3_signature, "2ca2aba2005185cf7159c6277faf83795951dd77a3a99e6e65d5c9f85863f992");
+        assert_eq!(
+            chunk3_signature.as_str(),
+            "2ca2aba2005185cf7159c6277faf83795951dd77a3a99e6e65d5c9f85863f992"
+        );
     }
 
     #[test]
@@ -1005,7 +1024,10 @@ mod tests {
         );
 
         let trailer_signature = calculate_signature(&trailer_string_to_sign, &secret_access_key, &date, region, service);
-        assert_eq!(trailer_signature, "d81f82fc3505edab99d459891051a732e8730629a2e4a59689829ca17fe2e435");
+        assert_eq!(
+            trailer_signature.as_str(),
+            "d81f82fc3505edab99d459891051a732e8730629a2e4a59689829ca17fe2e435"
+        );
     }
 
     #[test]
@@ -1057,7 +1079,7 @@ mod tests {
         );
 
         let signature = calculate_signature(&string_to_sign, &secret_access_key, &date, region, service);
-        assert_eq!(signature, "fea454ca298b7da1c68078a5d1bdbfbbe0d65c699e0f91ac7a200a0136783543");
+        assert_eq!(signature.as_str(), "fea454ca298b7da1c68078a5d1bdbfbbe0d65c699e0f91ac7a200a0136783543");
     }
 
     #[test]
@@ -1110,7 +1132,7 @@ mod tests {
         );
 
         let signature = calculate_signature(&string_to_sign, &secret_access_key, &date, region, service);
-        assert_eq!(signature, "34b48302e7b5fa45bde8084f4b7868a86f0a534bc59db6670ed5711ef69dc6f7");
+        assert_eq!(signature.as_str(), "34b48302e7b5fa45bde8084f4b7868a86f0a534bc59db6670ed5711ef69dc6f7");
     }
 
     #[test]
@@ -1185,8 +1207,8 @@ mod tests {
             info.credential.aws_region,
             info.credential.aws_service,
         );
-        assert_eq!(signature, "aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404");
-        assert_eq!(signature, info.signature);
+        assert_eq!(signature.as_str(), "aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404");
+        assert_eq!(signature.as_str(), info.signature);
     }
 
     #[test]
@@ -1235,7 +1257,7 @@ mod tests {
             let string_to_sign = create_string_to_sign(&canonical_request, &date, region, service);
 
             let signature = calculate_signature(&string_to_sign, &secret_access_key, &date, region, service);
-            assert_eq!(signature, "96ad058ca27352e0fc2bd4efd8973792077570667bdaf749655f42e204bc649c");
+            assert_eq!(signature.as_str(), "96ad058ca27352e0fc2bd4efd8973792077570667bdaf749655f42e204bc649c");
         }
     }
 
@@ -1310,7 +1332,7 @@ mod tests {
             let string_to_sign = create_string_to_sign(&canonical_request, &date, region, service);
 
             let signature = calculate_signature(&string_to_sign, &secret_access_key, &date, region, service);
-            assert_eq!(signature, "7ed3ea6c69ed841068bbdd3cc1eb92a9ae5a4b1b0635267066bd676f6edc0189");
+            assert_eq!(signature.as_str(), "7ed3ea6c69ed841068bbdd3cc1eb92a9ae5a4b1b0635267066bd676f6edc0189");
         }
     }
 
@@ -1377,7 +1399,7 @@ mod tests {
         let signature = calculate_signature(&string_to_sign, &secret_access_key, &amz_date, "us-east-1", "s3");
 
         // Signature value derived from the above test inputs (not from official AWS test vectors)
-        assert_eq!(signature, "f4db56459304dafaa603a99a23c6bea8821890259a65c18ff503a4a72a80efd9");
+        assert_eq!(signature.as_str(), "f4db56459304dafaa603a99a23c6bea8821890259a65c18ff503a4a72a80efd9");
     }
 
     #[test]
@@ -1423,7 +1445,7 @@ mod tests {
         let signature = calculate_signature(&string_to_sign, &secret_access_key, &amz_date, "us-east-1", "s3");
 
         // Signature value derived from the test inputs above; not from official AWS test vectors.
-        assert_eq!(signature, "fd31b71961609f4b313497cb07ab0aedd268863bd547cc198db23cf04b8f663d");
+        assert_eq!(signature.as_str(), "fd31b71961609f4b313497cb07ab0aedd268863bd547cc198db23cf04b8f663d");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Make constant-time signature comparison a compile-time guarantee: the signature value is wrapped in a typed `Signature` whose only comparison path is `subtle::ConstantTimeEq` — writing `==` / `!=` on a signature value fails to compile.

This builds on the direction set by #646, which identified the timing side channels in SigV2 and aws-chunked signature verification and moved SigV4 onto `subtle::ct_eq`. Where #646 prevented regression with source-text tripwire tests — bypassable by variable renames, `.eq()`, or cross-module comparisons — this PR makes the guarantee structural: the type system itself forbids ordinary comparison.

## Changes

- Add a `Signature` type (`auth/signature.rs`) that validates the canonical encoding at construction:
  - `SigV4` form: 64 lowercase hex chars (`from_hex`);
  - `SigV2` form: 28-char standard Base64, fully decoded into 20 bytes and re-encoded for canonical-form validation (`from_base64`; rejects invalid alphabets and non-canonical padding bits);
  - `PartialEq` / `Eq` / `Hash` / `Display` / `FromStr` are deliberately not implemented; `Debug` is derived (signatures are not secret — they travel in cleartext with the request);
  - `from_computed` (pub(crate)) is called only inside the two `calculate_signature` functions, with a `debug_assert` self-check that the computed output is canonical.
- `sig_v4::calculate_signature` / `sig_v2::calculate_signature` now return `Signature`, collapsing the trust boundary from 8 comparison sites into the 2 calculators.
- Fix timing side channels (the core of this PR):
  - SigV2 header / POST / presigned: plain `!=` replaced with constant-time comparison;
  - aws-chunked per-chunk and trailer signatures: plain byte `==` / `!=` replaced with constant-time comparison;
  - SigV4 sites are unified onto the same typed mechanism (already `ct_eq`-based before).
- Type the verification chain: `verify_with_raw_path_fallback -> S3Result<Signature>`, `AwsChunkedStream::new(seed: Signature)`, `SignatureCtx.prev_signature: Signature` — production code can no longer feed a non-canonical signature into the stream.
- Remove the `sig_v4_signatures_match` helper.
- Behavior and error codes are unchanged: malformed input maps to the same errors as before (400 / `403 SignatureDoesNotMatch` / `AwsChunkedStreamError::SignatureMismatch`).

## Verification

- 14 new unit tests in `auth::signature`: canonical acceptance; rejection of uppercase / wrong length / non-hex chars; a Base64 alphabet-trap regression (`decoded_length` passes but the full decode fails); non-20-byte rejection; `from_computed` round-trip; `ct_eq` match / mismatch / cross-encoding always-unequal; plaintext `Debug` output.
- `just dev` passes (fetch, fmt, codegen, lint, test).
- `just ci-rust` passes (fmt check, clippy `-D warnings`, workspace tests, codegen, `assert_unchanged` — working tree left clean).

Thanks to #646 for pinpointing the side channels and proving out the constant-time direction; this PR carries that approach further by making the guarantee compile-time instead of test-enforced.