### PR TITLE
ci(audit): drop stale ignores and document lru advisory

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,9 +3,10 @@
 
 [advisories]
 # lru v0.16.x: panic-safety use-after-free in `LruCache::pop()`.
-# Transitive via aws-sdk-s3, which pins lru ^0.16.x even at the latest release.
+# Transitive via aws-sdk-s3, which pins lru ^0.16.x as of 2026-08.
 # Requires a key whose `Drop` panics during `pop()`; no patched version is
-# reachable upstream yet.
+# reachable upstream yet. Revisit: remove this ignore once aws-sdk-s3 allows
+# lru >= 0.18.2.
 ignore = [
     "RUSTSEC-2026-0253",
 ]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,11 +2,10 @@
 # See: https://github.com/RustSec/rustsec/blob/main/cargo-audit/audit.toml.example
 
 [advisories]
-# rsa v0.9.10: Marvin Attack timing sidechannel in RSA PKCS#1 decryption.
-# Transitive dependency via reqsign-core → opendal → s3s-fs (dev-dependency).
-# Only used for S3 signature verification, not decryption. Low risk. No fix available.
+# lru v0.16.x: panic-safety use-after-free in `LruCache::pop()`.
+# Transitive via aws-sdk-s3, which pins lru ^0.16.x even at the latest release.
+# Requires a key whose `Drop` panics during `pop()`; no patched version is
+# reachable upstream yet.
 ignore = [
-    "RUSTSEC-2023-0071",
-    # proc-macro-error2: unmaintained, transitive via jiff → defmt → defmt-macros
-    "RUSTSEC-2026-0173",
+    "RUSTSEC-2026-0253",
 ]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+      - '.cargo/**' # audit.toml / deny.toml: config changes must run the audit job
   merge_group:
     types: [checks_requested]
   schedule:


### PR DESCRIPTION
## Summary

Clean up the cargo-audit configuration and unblock the Audit CI job, which currently fails on the merge queue with `error: 1 denied warning found` (RUSTSEC-2026-0253).

## Changes

- Drop two stale ignores whose crates are no longer in the dependency graph (verified absent from `Cargo.lock`):
  - `RUSTSEC-2023-0071` (rsa) — the reqsign-core → opendal → s3s-fs path no longer exists;
  - `RUSTSEC-2026-0173` (proc-macro-error2) — no longer pulled in via jiff → defmt → defmt-macros.
- Add `RUSTSEC-2026-0253` (lru) to the ignore list with rationale:
  - Transitive via `aws-sdk-s3`, which pins `lru ^0.16.x` even at the latest release (1.141.0);
  - Panic-safety use-after-free in `LruCache::pop()`, requiring a key whose `Drop` panics during `pop()`;
  - No patched version is reachable upstream yet.

## Verification

- `cargo audit` exits 0 (0 vulnerabilities, 0 warnings).
- `cargo audit -D warnings` passes — the exact command used by the Audit CI job.