### PR TITLE
test(s3s/ops): add GET output path attribution microbench

### DIFF
--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -62,6 +62,14 @@ fn get_object_microbench_common_output(metadata_len: usize, include_timestamps: 
     }
 }
 
+fn get_object_microbench_http_request() -> crate::HttpRequest {
+    hyper::Request::builder()
+        .method(hyper::Method::GET)
+        .uri("http://localhost/bench-bucket/bench-key")
+        .body(crate::http::Body::empty())
+        .unwrap()
+}
+
 fn get_object_microbench_hundredths(numerator: u128, denominator: u128) -> String {
     let scaled = numerator.saturating_mul(100) / denominator;
     format!("{}.{:02}", scaled / 100, scaled % 100)
@@ -92,6 +100,54 @@ where
         get_object_microbench_hundredths(elapsed.as_nanos(), u128::from(iterations)),
         get_object_microbench_hundredths(header_count, u128::from(iterations))
     );
+}
+
+async fn run_get_object_async_microbench_case<F, Fut>(name: &'static str, iterations: u64, mut f: F)
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = usize>,
+{
+    use std::hint::black_box;
+
+    for _ in 0..1_000 {
+        black_box(f().await);
+    }
+
+    let start = std::time::Instant::now();
+    let mut value_count = 0u128;
+    for _ in 0..iterations {
+        value_count = value_count.saturating_add(f().await as u128);
+    }
+    let elapsed = start.elapsed();
+    println!(
+        "s3s_get_output_path_bench case={name} iterations={iterations} total_ns={} ns_per_op={} avg_value={}",
+        elapsed.as_nanos(),
+        get_object_microbench_hundredths(elapsed.as_nanos(), u128::from(iterations)),
+        get_object_microbench_hundredths(value_count, u128::from(iterations))
+    );
+}
+
+fn get_object_microbench_drain_body(mut body: crate::http::Body) -> usize {
+    use std::pin::Pin;
+    use std::task::Context;
+    use std::task::Poll;
+
+    let waker = futures::task::noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let mut body = Pin::new(&mut body);
+    let mut bytes = 0usize;
+    loop {
+        match http_body::Body::poll_frame(body.as_mut(), &mut cx) {
+            Poll::Ready(Some(Ok(frame))) => {
+                if let Ok(data) = frame.into_data() {
+                    bytes = bytes.saturating_add(data.len());
+                }
+            }
+            Poll::Ready(Some(Err(err))) => panic!("body poll failed: {err}"),
+            Poll::Ready(None) => return bytes,
+            Poll::Pending => panic!("microbench body unexpectedly returned Pending"),
+        }
+    }
 }
 
 #[test]
@@ -134,6 +190,97 @@ fn get_object_response_serialization_microbench() {
     run_get_object_microbench_case("get_object_common_metadata_2", iterations, || {
         generated::GetObject::serialize_http(get_object_microbench_common_output(2, true))
     });
+}
+
+struct GetObjectOutputPathMicrobenchS3;
+
+#[async_trait::async_trait]
+impl crate::s3_trait::S3 for GetObjectOutputPathMicrobenchS3 {
+    async fn get_object(
+        &self,
+        _req: crate::S3Request<crate::dto::GetObjectInput>,
+    ) -> crate::error::S3Result<crate::S3Response<crate::dto::GetObjectOutput>> {
+        Ok(crate::S3Response::new(get_object_microbench_common_output(0, true)))
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "focused microbenchmark for GET output path attribution"]
+async fn get_object_output_path_microbench() {
+    use std::hint::black_box;
+
+    const DEFAULT_ITERS: u64 = 100_000;
+    let iterations = std::env::var("S3S_GET_OUTPUT_PATH_BENCH_ITERS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_ITERS);
+    assert!(iterations != 0, "S3S_GET_OUTPUT_PATH_BENCH_ITERS must be greater than 0");
+
+    run_get_object_async_microbench_case("http_get_request_builder", iterations, || async {
+        let req = get_object_microbench_http_request();
+        let value = req.uri().path().len();
+        black_box(req);
+        value
+    })
+    .await;
+    run_get_object_async_microbench_case("body_once_poll_frame", iterations, || async {
+        get_object_microbench_drain_body(crate::http::Body::from(bytes::Bytes::from_static(&[b'a'; 1024])))
+    })
+    .await;
+    run_get_object_async_microbench_case("body_streaming_blob_poll_frame", iterations, || async {
+        get_object_microbench_drain_body(crate::http::Body::from(get_object_microbench_body()))
+    })
+    .await;
+    run_get_object_async_microbench_case("serialize_common_and_poll_body", iterations, || async {
+        let resp = generated::GetObject::serialize_http(get_object_microbench_common_output(0, true)).unwrap();
+        let header_count = resp.headers.len();
+        let body_bytes = get_object_microbench_drain_body(resp.body);
+        header_count + body_bytes
+    })
+    .await;
+
+    let s3: std::sync::Arc<dyn crate::s3_trait::S3> = std::sync::Arc::new(GetObjectOutputPathMicrobenchS3);
+    let config: std::sync::Arc<dyn crate::config::S3ConfigProvider> =
+        std::sync::Arc::new(crate::config::StaticConfigProvider::default());
+    let ccx = CallContext {
+        s3: &s3,
+        config: &config,
+        host: None,
+        auth: None,
+        access: None,
+        route: None,
+        validation: None,
+    };
+    run_get_object_async_microbench_case("generated_get_object_operation_call", iterations, || async {
+        let mut req = crate::http::Request::from(get_object_microbench_http_request());
+        req.s3ext.s3_path = Some(crate::path::S3Path::object("bench-bucket", "bench-key"));
+        let resp = generated::GetObject.call(&ccx, &mut req).await.unwrap();
+        let value = resp.headers.len();
+        black_box(resp);
+        value
+    })
+    .await;
+
+    let service = crate::service::S3ServiceBuilder::new(GetObjectOutputPathMicrobenchS3).build();
+    run_get_object_async_microbench_case("s3service_call_path_style_get", iterations, || {
+        let service = service.clone();
+        async move {
+            let resp = service.call(get_object_microbench_http_request()).await.unwrap();
+            let value = resp.headers().len();
+            black_box(resp);
+            value
+        }
+    })
+    .await;
+    run_get_object_async_microbench_case("s3service_call_and_poll_body", iterations, || {
+        let service = service.clone();
+        async move {
+            let resp = service.call(get_object_microbench_http_request()).await.unwrap();
+            let (parts, body) = resp.into_parts();
+            parts.headers.len() + get_object_microbench_drain_body(body)
+        }
+    })
+    .await;
 }
 
 /// Verifies that when an anonymous (unauthenticated) request is processed, the `None`

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -116,7 +116,7 @@ where
     let start = std::time::Instant::now();
     let mut value_count = 0u128;
     for _ in 0..iterations {
-        value_count = value_count.saturating_add(f().await as u128);
+        value_count = value_count.saturating_add(black_box(f().await) as u128);
     }
     let elapsed = start.elapsed();
     println!(
@@ -224,18 +224,20 @@ async fn get_object_output_path_microbench() {
     })
     .await;
     run_get_object_async_microbench_case("body_once_poll_frame", iterations, || async {
-        get_object_microbench_drain_body(crate::http::Body::from(bytes::Bytes::from_static(&[b'a'; 1024])))
+        let body = black_box(crate::http::Body::from(bytes::Bytes::from_static(&[b'a'; 1024])));
+        black_box(get_object_microbench_drain_body(body))
     })
     .await;
     run_get_object_async_microbench_case("body_streaming_blob_poll_frame", iterations, || async {
-        get_object_microbench_drain_body(crate::http::Body::from(get_object_microbench_body()))
+        let body = black_box(crate::http::Body::from(get_object_microbench_body()));
+        black_box(get_object_microbench_drain_body(body))
     })
     .await;
     run_get_object_async_microbench_case("serialize_common_and_poll_body", iterations, || async {
-        let resp = generated::GetObject::serialize_http(get_object_microbench_common_output(0, true)).unwrap();
+        let resp = black_box(generated::GetObject::serialize_http(get_object_microbench_common_output(0, true)).unwrap());
         let header_count = resp.headers.len();
         let body_bytes = get_object_microbench_drain_body(resp.body);
-        header_count + body_bytes
+        black_box(header_count + body_bytes)
     })
     .await;
 


### PR DESCRIPTION
## Summary

This adds a second ignored GET microbenchmark that extends the merged `GetObject::serialize_http` attribution down the output path. The new benchmark measures request construction, body frame polling, `serialize_http + body poll`, generated `GetObject::call`, `S3Service::call`, and `S3Service::call + body poll`.

The intent is diagnostic only: keep the attribution in crate-private unit tests, avoid new public APIs or dependencies, and provide a repeatable way to decide whether output-path work is worth optimizing before changing production code.

## Verification

```bash
cargo fmt --all --check
git diff --check
cargo clippy -p s3s --features minio --tests
cargo test -p s3s --features minio --release get_object_output_path_microbench -- --ignored --nocapture
cargo test -p s3s --features minio --release get_object_response_serialization_microbench -- --ignored --nocapture
```

## Release microbench sample

`get_object_output_path_microbench`, 100,000 iterations:

| case | ns/op | avg value |
|---|---:|---:|
| `http_get_request_builder` | 161.09 | 23.00 |
| `body_once_poll_frame` | 11.15 | 1024.00 |
| `body_streaming_blob_poll_frame` | 35.38 | 1024.00 |
| `serialize_common_and_poll_body` | 505.31 | 1030.00 |
| `generated_get_object_operation_call` | 774.07 | 6.00 |
| `s3service_call_path_style_get` | 1111.62 | 6.00 |
| `s3service_call_and_poll_body` | 1136.36 | 1030.00 |

`get_object_response_serialization_microbench`, 200,000 iterations:

| case | ns/op | avg headers |
|---|---:|---:|
| `response_default` | 3.61 | 0.00 |
| `set_stream_body_only` | 19.39 | 0.00 |
| `manual_common_headers` | 158.11 | 3.00 |
| `get_object_common_no_timestamp` | 275.95 | 5.00 |
| `get_object_common_timestamp` | 393.62 | 6.00 |
| `get_object_common_metadata_2` | 772.73 | 8.00 |

## Notes

This does not benchmark hyper connection scheduling, HPACK, TLS, kernel `writev`, or real network I/O. It only narrows the crate-local output path before those layers.
