### PR TITLE
test(s3s/ops): split GET output path attribution

### DIFF
--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -85,14 +85,6 @@ fn get_object_microbench_prepared_request() -> crate::http::Request {
     req
 }
 
-fn get_object_microbench_input() -> crate::dto::GetObjectInput {
-    crate::dto::GetObjectInput {
-        bucket: "bench-bucket".to_owned(),
-        key: "bench-key".to_owned(),
-        ..Default::default()
-    }
-}
-
 fn get_object_microbench_hundredths(numerator: u128, denominator: u128) -> String {
     let scaled = numerator.saturating_mul(100) / denominator;
     format!("{}.{:02}", scaled / 100, scaled % 100)
@@ -277,9 +269,9 @@ async fn run_get_object_operation_attribution_microbench_cases(
     .await;
     run_get_object_async_microbench_case("s3_trait_get_object_direct", iterations, || async {
         let req = crate::S3Request {
-            input: get_object_microbench_input(),
+            input: crate::dto::GetObjectInput::default(),
             method: hyper::Method::GET,
-            uri: "http://localhost/bench-bucket/bench-key".parse().unwrap(),
+            uri: hyper::Uri::from_static("http://localhost/bench-bucket/bench-key"),
             headers: hyper::HeaderMap::default(),
             extensions: ::http::Extensions::default(),
             credentials: None,
@@ -302,7 +294,7 @@ async fn run_get_object_operation_attribution_microbench_cases(
         value
     })
     .await;
-    run_get_object_async_microbench_case("ops_call_prepared_service_core", iterations, || async {
+    run_get_object_async_microbench_case("ops_call_path_style_get", iterations, || async {
         let mut req = crate::http::Request::from(get_object_microbench_http_request());
         let resp = super::call(&mut req, ccx).await.unwrap();
         let value = resp.headers.len();

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -79,6 +79,20 @@ fn get_object_microbench_http_request() -> crate::HttpRequest {
         .unwrap()
 }
 
+fn get_object_microbench_prepared_request() -> crate::http::Request {
+    let mut req = crate::http::Request::from(get_object_microbench_http_request());
+    req.s3ext.s3_path = Some(crate::path::S3Path::object("bench-bucket", "bench-key"));
+    req
+}
+
+fn get_object_microbench_input() -> crate::dto::GetObjectInput {
+    crate::dto::GetObjectInput {
+        bucket: "bench-bucket".to_owned(),
+        key: "bench-key".to_owned(),
+        ..Default::default()
+    }
+}
+
 fn get_object_microbench_hundredths(numerator: u128, denominator: u128) -> String {
     let scaled = numerator.saturating_mul(100) / denominator;
     format!("{}.{:02}", scaled / 100, scaled % 100)
@@ -213,6 +227,91 @@ impl crate::s3_trait::S3 for GetObjectOutputPathMicrobenchS3 {
     }
 }
 
+fn get_object_microbench_call_context<'a>(
+    s3: &'a std::sync::Arc<dyn crate::s3_trait::S3>,
+    config: &'a std::sync::Arc<dyn crate::config::S3ConfigProvider>,
+) -> CallContext<'a> {
+    CallContext {
+        s3,
+        config,
+        host: None,
+        auth: None,
+        access: None,
+        route: None,
+        validation: None,
+    }
+}
+
+async fn run_get_object_operation_attribution_microbench_cases(
+    iterations: u64,
+    s3: &std::sync::Arc<dyn crate::s3_trait::S3>,
+    ccx: &CallContext<'_>,
+) {
+    use std::hint::black_box;
+
+    run_get_object_async_microbench_case("request_from_http", iterations, || async {
+        let req = crate::http::Request::from(get_object_microbench_http_request());
+        let value = req.uri.path().len();
+        black_box(req);
+        value
+    })
+    .await;
+    run_get_object_async_microbench_case("prepare_path_style_get", iterations, || async {
+        let mut req = crate::http::Request::from(get_object_microbench_http_request());
+        let prep = super::prepare(&mut req, ccx).await.unwrap();
+        let value = match prep {
+            Prepare::S3(op) => op.name().len(),
+            Prepare::CustomRoute => 0,
+        };
+        black_box(req);
+        value
+    })
+    .await;
+    run_get_object_async_microbench_case("get_object_deserialize_http", iterations, || async {
+        let mut req = get_object_microbench_prepared_request();
+        let input = generated::GetObject::deserialize_http(&mut req).unwrap();
+        let value = input.bucket.len() + input.key.len();
+        black_box((req, input));
+        value
+    })
+    .await;
+    run_get_object_async_microbench_case("s3_trait_get_object_direct", iterations, || async {
+        let req = crate::S3Request {
+            input: get_object_microbench_input(),
+            method: hyper::Method::GET,
+            uri: "http://localhost/bench-bucket/bench-key".parse().unwrap(),
+            headers: hyper::HeaderMap::default(),
+            extensions: ::http::Extensions::default(),
+            credentials: None,
+            region: None,
+            service: None,
+            trailing_headers: None,
+        };
+        let resp = s3.get_object(req).await.unwrap();
+        let value = usize::try_from(resp.output.content_length.unwrap_or_default()).unwrap_or_default();
+        black_box(resp);
+        value
+    })
+    .await;
+    run_get_object_async_microbench_case("generated_get_object_operation_call", iterations, || async {
+        let mut req = crate::http::Request::from(get_object_microbench_http_request());
+        req.s3ext.s3_path = Some(crate::path::S3Path::object("bench-bucket", "bench-key"));
+        let resp = generated::GetObject.call(ccx, &mut req).await.unwrap();
+        let value = resp.headers.len();
+        black_box(resp);
+        value
+    })
+    .await;
+    run_get_object_async_microbench_case("ops_call_prepared_service_core", iterations, || async {
+        let mut req = crate::http::Request::from(get_object_microbench_http_request());
+        let resp = super::call(&mut req, ccx).await.unwrap();
+        let value = resp.headers.len();
+        black_box(resp);
+        value
+    })
+    .await;
+}
+
 #[tokio::test(flavor = "current_thread")]
 #[ignore = "focused microbenchmark for GET output path attribution"]
 async fn get_object_output_path_microbench() {
@@ -253,24 +352,8 @@ async fn get_object_output_path_microbench() {
     let s3: std::sync::Arc<dyn crate::s3_trait::S3> = std::sync::Arc::new(GetObjectOutputPathMicrobenchS3);
     let config: std::sync::Arc<dyn crate::config::S3ConfigProvider> =
         std::sync::Arc::new(crate::config::StaticConfigProvider::default());
-    let ccx = CallContext {
-        s3: &s3,
-        config: &config,
-        host: None,
-        auth: None,
-        access: None,
-        route: None,
-        validation: None,
-    };
-    run_get_object_async_microbench_case("generated_get_object_operation_call", iterations, || async {
-        let mut req = crate::http::Request::from(get_object_microbench_http_request());
-        req.s3ext.s3_path = Some(crate::path::S3Path::object("bench-bucket", "bench-key"));
-        let resp = generated::GetObject.call(&ccx, &mut req).await.unwrap();
-        let value = resp.headers.len();
-        black_box(resp);
-        value
-    })
-    .await;
+    let ccx = get_object_microbench_call_context(&s3, &config);
+    run_get_object_operation_attribution_microbench_cases(iterations, &s3, &ccx).await;
 
     let service = crate::service::S3ServiceBuilder::new(GetObjectOutputPathMicrobenchS3).build();
     run_get_object_async_microbench_case("s3service_call_path_style_get", iterations, || {


### PR DESCRIPTION
## Summary

This extends the ignored GET output-path diagnostic microbench with finer attribution cases after #663 landed upstream.

The new cases split the current service-level GET path into request conversion, path-style prepare, generated `GetObject::deserialize_http`, direct `S3::get_object`, generated operation call, and the `ops::call` service core. This keeps the benchmark focused on per-request fixed overhead without changing production behavior.

## Motivation

The previous merged microbench showed the full `S3Service::call` GET path is materially larger than response serialization alone. These additional cases make that gap easier to attribute before proposing any real optimization, so later changes can target a measured service center instead of guessing from one aggregate number.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy -p s3s --features minio --tests`
- `cargo test -p s3s --features minio --release get_object_output_path_microbench -- --ignored --nocapture`

Observed diagnostic output on this branch:

```text
s3s_get_output_path_bench case=http_get_request_builder iterations=100000 total_ns=8563583 ns_per_op=85.63 avg_value=23.00
s3s_get_output_path_bench case=body_once_poll_frame iterations=100000 total_ns=722542 ns_per_op=7.22 avg_value=1024.00
s3s_get_output_path_bench case=body_streaming_blob_poll_frame iterations=100000 total_ns=2560125 ns_per_op=25.60 avg_value=1024.00
s3s_get_output_path_bench case=serialize_common_and_poll_body iterations=100000 total_ns=41431625 ns_per_op=414.31 avg_value=1030.00
s3s_get_output_path_bench case=request_from_http iterations=100000 total_ns=10169084 ns_per_op=101.69 avg_value=23.00
s3s_get_output_path_bench case=prepare_path_style_get iterations=100000 total_ns=28552875 ns_per_op=285.52 avg_value=9.00
s3s_get_output_path_bench case=get_object_deserialize_http iterations=100000 total_ns=20876625 ns_per_op=208.76 avg_value=21.00
s3s_get_output_path_bench case=s3_trait_get_object_direct iterations=100000 total_ns=24520791 ns_per_op=245.20 avg_value=1024.00
s3s_get_output_path_bench case=generated_get_object_operation_call iterations=100000 total_ns=83987083 ns_per_op=839.87 avg_value=6.00
s3s_get_output_path_bench case=ops_call_path_style_get iterations=100000 total_ns=104369084 ns_per_op=1043.69 avg_value=6.00
s3s_get_output_path_bench case=s3service_call_path_style_get iterations=100000 total_ns=117882875 ns_per_op=1178.82 avg_value=6.00
s3s_get_output_path_bench case=s3service_call_and_poll_body iterations=100000 total_ns=117166125 ns_per_op=1171.66 avg_value=1030.00
```

## Notes

This is still an ignored microbench only. It intentionally does not claim an end-to-end performance improvement.
