### PR TITLE
fix(s3s/host): restrict and configure the CNAME-style fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,6 +2492,7 @@ dependencies = [
  "openssl",
  "pin-project-lite",
  "quick-xml",
+ "regex",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ base64-simd = "0.8.0"
 hex-simd = "0.8.0"
 itoa = "1.0.18"
 nom = "8.0.0"
+regex = "1.13.1"
 
 # Date & time
 chrono = { version = "0.4.45", default-features = false }

--- a/crates/s3s/Cargo.toml
+++ b/crates/s3s/Cargo.toml
@@ -51,6 +51,7 @@ nom.workspace = true
 numeric_cast.workspace = true
 pin-project-lite.workspace = true
 quick-xml.workspace = true
+regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_urlencoded.workspace = true

--- a/crates/s3s/src/host.rs
+++ b/crates/s3s/src/host.rs
@@ -5,13 +5,56 @@
 //! `Host` header into a [`VirtualHost`] value that carries the base domain,
 //! the bucket name (when the request uses virtual-hosted-style addressing),
 //! and an optional region.
+//!
+//! # Built-in implementations
+//!
+//! - [`SingleDomain`] keeps the traditional behaviour: any unrecognized
+//!   valid host becomes the bucket name (CNAME-style). The fallback can be
+//!   disabled with [`SingleDomain::with_cname_fallback`].
+//! - [`MultiDomain`] additionally restricts the fallback to hosts that pass
+//!   bucket-name validation and allows narrowing it with
+//!   [`MultiDomain::with_path_style_hosts`].
+//!
+//! # CNAME-style fallback ([`MultiDomain`] only)
+//!
+//! A host that matches no configured base domain can still be handled in two
+//! ways, mirroring AWS S3:
+//!
+//! - If the host could itself be a bucket name (e.g. `my-bucket.com`,
+//!   `localhost`), the whole host becomes the bucket name. This supports
+//!   [CNAME-style virtual hosting](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#VirtualHostingCustomURLs),
+//!   which is a legitimate AWS usage pattern. Each such request is recorded
+//!   at `debug!` level for diagnostics.
+//! - Otherwise (e.g. `localhost:8014` — a host with a port can never be a
+//!   CNAME'd bucket), the host is returned without a bucket and the request
+//!   is parsed as path-style instead of failing with `InvalidBucketName`.
+//!
+//! Hosts that are not valid domain names at all still yield
+//! `InvalidRequest`.
+//!
+//! Hosts that should always be parsed as path-style (e.g. `localhost` when
+//! the service is reached directly, outside any reverse proxy) can be
+//! selected with [`MultiDomain::with_path_style_hosts`], which takes a
+//! [`regex::RegexSet`] matched against the full `Host` header
+//! (port included). Note: once a [`MultiDomain`] is configured, path-style
+//! fallback happens only for hosts that match the rule above or fail the
+//! bucket-name check; see
+//! [s3s-project/s3s#643](https://github.com/s3s-project/s3s/issues/643).
+#![deny(missing_docs)]
 
 use crate::error::S3Result;
+use crate::path::check_bucket_name;
 
+use regex::RegexSet;
 use std::borrow::Cow;
 
 use stdx::default::default;
+use tracing::debug;
 
+/// The parsed result of an HTTP `Host` header.
+///
+/// Carries the base domain, the bucket name (when the request uses
+/// virtual-hosted-style addressing), and an optional region.
 #[derive(Debug, Clone)]
 pub struct VirtualHost<'a> {
     domain: Cow<'a, str>,
@@ -20,6 +63,11 @@ pub struct VirtualHost<'a> {
 }
 
 impl<'a> VirtualHost<'a> {
+    /// Creates a new [`VirtualHost`] for the given domain.
+    ///
+    /// The bucket and region are left unset; use
+    /// [`VirtualHost::with_bucket`] and [`VirtualHost::with_region`] to set
+    /// them.
     pub fn new(domain: impl Into<Cow<'a, str>>) -> Self {
         Self {
             domain: domain.into(),
@@ -70,12 +118,17 @@ impl<'a> VirtualHost<'a> {
         self
     }
 
+    /// Returns the base domain of the virtual host.
     #[inline]
     #[must_use]
     pub fn domain(&self) -> &str {
         self.domain.as_ref()
     }
 
+    /// Returns the bucket name, if the request used virtual-hosted-style
+    /// addressing.
+    ///
+    /// When unset, the caller parses the request as path-style.
     #[inline]
     #[must_use]
     pub fn bucket(&self) -> Option<&str> {
@@ -95,22 +148,35 @@ impl<'a> VirtualHost<'a> {
     }
 }
 
+/// A parser that turns the HTTP `Host` header into a [`VirtualHost`].
+///
+/// See the [module-level docs](self) for the behaviour of the built-in
+/// implementations.
 pub trait S3Host: Send + Sync + 'static {
     /// Parses the `Host` header of the HTTP request.
     ///
     /// # Errors
     /// Returns an error if the `Host` is invalid for this service.
+    ///
+    /// The returned [`VirtualHost`] may leave the bucket unset; the caller
+    /// then parses the request as path-style. Built-in implementations leave
+    /// the bucket unset for hosts that cannot be CNAME-style buckets — see
+    /// the [module-level docs](self) for the exact fallback behaviour.
     fn parse_host_header<'a>(&'a self, host: &'a str) -> S3Result<VirtualHost<'a>>;
 }
 
+/// Errors returned when constructing the built-in [`S3Host`] implementations.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum DomainError {
+    /// The domain string is not a valid domain.
     #[error("The domain is invalid")]
     InvalidDomain,
 
+    /// Two configured domains overlap (one is a subdomain of the other).
     #[error("Some subdomains overlap with each other")]
     OverlappingSubdomains,
 
+    /// No base domain was provided.
     #[error("No base domains are specified")]
     ZeroDomains,
 }
@@ -172,9 +238,50 @@ fn parse_host_header<'a>(base_domain: &'a str, host: &'a str) -> Option<VirtualH
     None
 }
 
+/// CNAME-style fallback for a host that matches no configured base domain.
+///
+/// Returns `None` when the host is not a valid domain at all (the caller
+/// then reports `InvalidRequest`). Otherwise:
+///
+/// - If the host matches `path_style_hosts`, it is returned without a bucket
+///   so the request is parsed as path-style.
+/// - Otherwise, the lowercased host becomes the bucket name if it passes
+///   bucket-name validation (CNAME-style addressing). This is a legitimate
+///   AWS usage pattern and is recorded at `debug!` level.
+/// - Otherwise (e.g. a host carrying a port such as `localhost:8014`), the
+///   host is returned without a bucket so the request is parsed as
+///   path-style.
+///
+/// See the [module-level docs](self) and
+/// [s3s-project/s3s#643](https://github.com/s3s-project/s3s/issues/643).
+fn parse_cname_fallback<'a>(host: &'a str, path_style_hosts: &RegexSet) -> Option<VirtualHost<'a>> {
+    if !is_valid_domain(host) {
+        return None;
+    }
+
+    if path_style_hosts.is_match(host) {
+        return Some(VirtualHost::new(host));
+    }
+
+    let bucket = host.to_ascii_lowercase();
+    if check_bucket_name(&bucket) {
+        debug!(?host, "host matches no configured base domain; treating it as a CNAME-style bucket");
+        return Some(VirtualHost::new(host).with_bucket(bucket));
+    }
+
+    Some(VirtualHost::new(host))
+}
+
+/// A host parser with a single base domain.
+///
+/// Unrecognized hosts are handled by the CNAME-style fallback described in
+/// the [module-level docs](self): any valid host becomes the bucket name.
+/// The fallback can be disabled with [`SingleDomain::with_cname_fallback`],
+/// in which case unrecognized hosts are always parsed as path-style.
 #[derive(Debug)]
 pub struct SingleDomain {
     base_domain: String,
+    cname_fallback: bool,
 }
 
 impl SingleDomain {
@@ -189,7 +296,22 @@ impl SingleDomain {
 
         Ok(Self {
             base_domain: base_domain.into(),
+            cname_fallback: true,
         })
+    }
+
+    /// Controls the CNAME-style fallback for hosts outside the base domain.
+    ///
+    /// When disabled, a host that matches neither the base domain nor a
+    /// subdomain is parsed as path-style instead of being treated as a
+    /// bucket name. See
+    /// [s3s-project/s3s#643](https://github.com/s3s-project/s3s/issues/643).
+    ///
+    /// Default: enabled
+    #[must_use]
+    pub fn with_cname_fallback(mut self, enabled: bool) -> Self {
+        self.cname_fallback = enabled;
+        self
     }
 }
 
@@ -202,17 +324,26 @@ impl S3Host for SingleDomain {
         }
 
         if is_valid_domain(host) {
-            let bucket = host.to_ascii_lowercase();
-            return Ok(VirtualHost::new(host).with_bucket(bucket));
+            if self.cname_fallback {
+                let bucket = host.to_ascii_lowercase();
+                return Ok(VirtualHost::new(host).with_bucket(bucket));
+            }
+            return Ok(VirtualHost::new(host));
         }
 
         Err(s3_error!(InvalidRequest, "Invalid host header"))
     }
 }
 
+/// A host parser with multiple base domains.
+///
+/// Hosts outside the configured domains are handled by the CNAME-style
+/// fallback described in the [module-level docs](self). Hosts matching
+/// [`MultiDomain::with_path_style_hosts`] are always parsed as path-style.
 #[derive(Debug)]
 pub struct MultiDomain {
     base_domains: Vec<String>,
+    path_style_hosts: RegexSet,
 }
 
 impl MultiDomain {
@@ -250,7 +381,25 @@ impl MultiDomain {
             return Err(DomainError::ZeroDomains);
         }
 
-        Ok(Self { base_domains: v })
+        Ok(Self {
+            base_domains: v,
+            path_style_hosts: RegexSet::empty(),
+        })
+    }
+
+    /// Sets the hosts that are always parsed as path-style.
+    ///
+    /// Hosts that match the [`regex::RegexSet`] are returned
+    /// without a bucket instead of being treated as CNAME-style bucket names.
+    /// The patterns are matched against the full `Host` header, port
+    /// included. See
+    /// [s3s-project/s3s#643](https://github.com/s3s-project/s3s/issues/643).
+    ///
+    /// Default: no hosts
+    #[must_use]
+    pub fn with_path_style_hosts(mut self, path_style_hosts: RegexSet) -> Self {
+        self.path_style_hosts = path_style_hosts;
+        self
     }
 }
 
@@ -262,9 +411,8 @@ impl S3Host for MultiDomain {
             }
         }
 
-        if is_valid_domain(host) {
-            let bucket = host.to_ascii_lowercase();
-            return Ok(VirtualHost::new(host).with_bucket(bucket));
+        if let Some(vh) = parse_cname_fallback(host, &self.path_style_hosts) {
+            return Ok(vh);
         }
 
         Err(s3_error!(InvalidRequest, "Invalid host header"))
@@ -397,6 +545,92 @@ mod tests {
         let vh = result.unwrap();
         assert_eq!(vh.domain(), "example.com");
         assert_eq!(vh.bucket(), Some("example.com.org"));
+    }
+
+    #[test]
+    fn single_domain_parse_cname_fallback() {
+        let sd = SingleDomain::new("s3.example.com").unwrap();
+
+        // SingleDomain keeps the traditional behaviour: any unrecognized
+        // valid host becomes the bucket name, even with a port.
+        let vh = sd.parse_host_header("localhost").unwrap();
+        assert_eq!(vh.domain(), "localhost");
+        assert_eq!(vh.bucket(), Some("localhost"));
+
+        let vh = sd.parse_host_header("localhost:8014").unwrap();
+        assert_eq!(vh.domain(), "localhost:8014");
+        assert_eq!(vh.bucket(), Some("localhost:8014"));
+
+        // Invalid domain names still error.
+        let err = sd.parse_host_header("example.com.").unwrap_err();
+        assert_eq!(err.code(), &S3ErrorCode::InvalidRequest);
+    }
+
+    #[test]
+    fn single_domain_disable_cname_fallback() {
+        let sd = SingleDomain::new("s3.example.com").unwrap().with_cname_fallback(false);
+
+        // With the fallback disabled, unrecognized valid hosts are parsed
+        // as path-style, even when they are valid bucket names.
+        let vh = sd.parse_host_header("localhost").unwrap();
+        assert_eq!(vh.domain(), "localhost");
+        assert_eq!(vh.bucket(), None);
+
+        let vh = sd.parse_host_header("localhost:8014").unwrap();
+        assert_eq!(vh.domain(), "localhost:8014");
+        assert_eq!(vh.bucket(), None);
+
+        let vh = sd.parse_host_header("cdn.example.org").unwrap();
+        assert_eq!(vh.domain(), "cdn.example.org");
+        assert_eq!(vh.bucket(), None);
+
+        // Invalid domain names still error.
+        let err = sd.parse_host_header("example.com.").unwrap_err();
+        assert_eq!(err.code(), &S3ErrorCode::InvalidRequest);
+    }
+
+    #[test]
+    fn multi_domain_parse_cname_fallback() {
+        let domains = ["s3.example.com", "s3.example.org"];
+        let md = MultiDomain::new(domains.iter().copied()).unwrap();
+
+        // MultiDomain keeps the CNAME-style fallback.
+        let vh = md.parse_host_header("localhost").unwrap();
+        assert_eq!(vh.domain(), "localhost");
+        assert_eq!(vh.bucket(), Some("localhost"));
+
+        let vh = md.parse_host_header("localhost:8014").unwrap();
+        assert_eq!(vh.domain(), "localhost:8014");
+        assert_eq!(vh.bucket(), None);
+
+        let err = md.parse_host_header("example.com.").unwrap_err();
+        assert_eq!(err.code(), &S3ErrorCode::InvalidRequest);
+    }
+
+    #[test]
+    fn multi_domain_path_style_hosts() {
+        let domains = ["s3.example.com", "s3.example.org"];
+        let path_style_hosts = RegexSet::new([r"^localhost$", r"^localhost:\d+$"]).unwrap();
+        let md = MultiDomain::new(domains.iter().copied())
+            .unwrap()
+            .with_path_style_hosts(path_style_hosts);
+
+        // Hosts matching the set are parsed as path-style...
+        let vh = md.parse_host_header("localhost").unwrap();
+        assert_eq!(vh.domain(), "localhost");
+        assert_eq!(vh.bucket(), None);
+
+        let vh = md.parse_host_header("localhost:8014").unwrap();
+        assert_eq!(vh.domain(), "localhost:8014");
+        assert_eq!(vh.bucket(), None);
+
+        // ...while other hosts keep the CNAME-style fallback.
+        let vh = md.parse_host_header("cdn.example.org").unwrap();
+        assert_eq!(vh.domain(), "cdn.example.org");
+        assert_eq!(vh.bucket(), Some("cdn.example.org"));
+
+        let err = md.parse_host_header("example.com.").unwrap_err();
+        assert_eq!(err.code(), &S3ErrorCode::InvalidRequest);
     }
 
     #[test]

--- a/crates/s3s/src/host.rs
+++ b/crates/s3s/src/host.rs
@@ -159,9 +159,9 @@ pub trait S3Host: Send + Sync + 'static {
     /// Returns an error if the `Host` is invalid for this service.
     ///
     /// The returned [`VirtualHost`] may leave the bucket unset; the caller
-    /// then parses the request as path-style. Built-in implementations leave
-    /// the bucket unset for hosts that cannot be CNAME-style buckets — see
-    /// the [module-level docs](self) for the exact fallback behaviour.
+    /// then parses the request as path-style. Whether a host is left without
+    /// a bucket depends on the implementation — see the
+    /// [module-level docs](self) for the exact fallback behaviour.
     fn parse_host_header<'a>(&'a self, host: &'a str) -> S3Result<VirtualHost<'a>>;
 }
 

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -473,6 +473,160 @@ async fn vh_region_fallback_for_anonymous_request() {
     );
 }
 
+/// With an `S3Host` configured, an unrecognized host carrying a port
+/// (e.g. `localhost:8014`) can never be a CNAME bucket and must fall back
+/// to path-style parsing; a portless host that is a valid bucket name keeps
+/// the CNAME fallback. See
+/// [s3s-project/s3s#643](https://github.com/s3s-project/s3s/issues/643).
+#[tokio::test]
+async fn host_fallback_path_style_and_cname() {
+    use crate::config::{S3ConfigProvider, StaticConfigProvider};
+    use crate::host::MultiDomain;
+    use crate::http::{Body, Request};
+    use crate::path::S3Path;
+    use std::sync::Arc;
+
+    struct NoOpS3;
+    #[async_trait::async_trait]
+    impl crate::s3_trait::S3 for NoOpS3 {}
+
+    let s3: Arc<dyn crate::s3_trait::S3> = Arc::new(NoOpS3);
+    let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+    let host = MultiDomain::new(["s3.example.com"]).unwrap();
+    let ccx = CallContext {
+        s3: &s3,
+        config: &config,
+        host: Some(&host),
+        auth: None,
+        access: None,
+        route: None,
+        validation: None,
+    };
+
+    // `localhost:8014` can never be a CNAME bucket -> path-style: `GET /`
+    // parses as the root path (ListBuckets), not as a bucket named
+    // "localhost:8014".
+    let mut req = Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .uri("http://localhost:8014/")
+            .header(crate::header::HOST, "localhost:8014")
+            .body(Body::empty())
+            .unwrap(),
+    );
+    let _ = super::prepare(&mut req, &ccx).await;
+    assert!(
+        matches!(req.s3ext.s3_path, Some(S3Path::Root)),
+        "host with port must fall back to path-style"
+    );
+
+    // `localhost` is a valid bucket name -> CNAME fallback keeps the bucket.
+    let mut req = Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .uri("http://localhost/")
+            .header(crate::header::HOST, "localhost")
+            .body(Body::empty())
+            .unwrap(),
+    );
+    let _ = super::prepare(&mut req, &ccx).await;
+    assert!(
+        matches!(req.s3ext.s3_path, Some(S3Path::Bucket { ref bucket }) if bucket.as_ref() == "localhost"),
+        "portless valid-bucket host must keep the CNAME fallback"
+    );
+}
+
+/// With a path-style host rule configured, an unrecognized host matching it
+/// is parsed as path-style even when it is a valid bucket name. See
+/// [s3s-project/s3s#643](https://github.com/s3s-project/s3s/issues/643).
+#[tokio::test]
+async fn host_path_style_rule_is_path_style() {
+    use crate::config::{S3ConfigProvider, StaticConfigProvider};
+    use crate::host::MultiDomain;
+    use crate::http::{Body, Request};
+    use crate::path::S3Path;
+    use regex::RegexSet;
+    use std::sync::Arc;
+
+    struct NoOpS3;
+    #[async_trait::async_trait]
+    impl crate::s3_trait::S3 for NoOpS3 {}
+
+    let s3: Arc<dyn crate::s3_trait::S3> = Arc::new(NoOpS3);
+    let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+    let host = MultiDomain::new(["s3.example.com"])
+        .unwrap()
+        .with_path_style_hosts(RegexSet::new([r"^localhost$"]).unwrap());
+    let ccx = CallContext {
+        s3: &s3,
+        config: &config,
+        host: Some(&host),
+        auth: None,
+        access: None,
+        route: None,
+        validation: None,
+    };
+
+    // `localhost` would be a valid CNAME bucket, but the path-style rule
+    // matches, so `GET /` parses as the root path (ListBuckets).
+    let mut req = Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .uri("http://localhost/")
+            .header(crate::header::HOST, "localhost")
+            .body(Body::empty())
+            .unwrap(),
+    );
+    let _ = super::prepare(&mut req, &ccx).await;
+    assert!(
+        matches!(req.s3ext.s3_path, Some(S3Path::Root)),
+        "path-style host rule must parse matching hosts as path-style"
+    );
+}
+
+/// With the CNAME-style fallback disabled on `SingleDomain`, an
+/// unrecognized portless host is parsed as path-style. See
+/// [s3s-project/s3s#643](https://github.com/s3s-project/s3s/issues/643).
+#[tokio::test]
+async fn single_domain_fallback_disabled_is_path_style() {
+    use crate::config::{S3ConfigProvider, StaticConfigProvider};
+    use crate::host::SingleDomain;
+    use crate::http::{Body, Request};
+    use crate::path::S3Path;
+    use std::sync::Arc;
+
+    struct NoOpS3;
+    #[async_trait::async_trait]
+    impl crate::s3_trait::S3 for NoOpS3 {}
+
+    let s3: Arc<dyn crate::s3_trait::S3> = Arc::new(NoOpS3);
+    let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+    let host = SingleDomain::new("s3.example.com").unwrap().with_cname_fallback(false);
+    let ccx = CallContext {
+        s3: &s3,
+        config: &config,
+        host: Some(&host),
+        auth: None,
+        access: None,
+        route: None,
+        validation: None,
+    };
+
+    let mut req = Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .uri("http://localhost/")
+            .header(crate::header::HOST, "localhost")
+            .body(Body::empty())
+            .unwrap(),
+    );
+    let _ = super::prepare(&mut req, &ccx).await;
+    assert!(
+        matches!(req.s3ext.s3_path, Some(S3Path::Root)),
+        "disabled CNAME fallback must parse unrecognized hosts as path-style"
+    );
+}
+
 #[test]
 fn error_custom_headers() {
     fn redirect307(location: &str) -> S3Error {


### PR DESCRIPTION
## Summary

- `MultiDomain` keeps the CNAME-style fallback, but it now fires only when the host passes bucket-name validation. Hosts that should always be parsed as path-style (e.g. `localhost` when reached directly) can be selected with `MultiDomain::with_path_style_hosts(RegexSet)`.
- `SingleDomain` gains `with_cname_fallback(bool)`: the fallback stays enabled by default (behaviour unchanged), and can be disabled so that unrecognized hosts are always parsed as path-style.
- The fallback is recorded at `debug!` level — CNAME-style virtual hosting is a legitimate AWS usage pattern and must not spam warnings.
- The whole `s3s::host` module is now documented under `#![deny(missing_docs)]`.

## Motivation

Configuring any `S3Host` used to disable path-style addressing for every host outside the configured domains ([#643](https://github.com/s3s-project/s3s/issues/643)). The host became the bucket name whenever it passed a loose domain check:

- `localhost:8014` (host with a port) failed with a misleading 400 `InvalidBucketName`.
- `localhost` (portless, e.g. behind a reverse proxy) silently changed request semantics: `GET /` became ListObjects on a bucket named `localhost`.

The portless case cannot be resolved by heuristic — `Host: localhost` is indistinguishable from a legitimately CNAME'd bucket named `localhost` — so it must be resolved by configuration. This PR adds that configuration: `MultiDomain` fires the fallback only for hosts that pass bucket-name validation (fixing `localhost:8014`) and lets users select path-style hosts with `with_path_style_hosts(RegexSet)`; `SingleDomain` gets a simple `with_cname_fallback(false)` switch for the same purpose.

## Compatibility

- `MultiDomain` no longer fails on hosts that cannot be buckets (e.g. `localhost:8014`); they are parsed as path-style instead of returning 400.
- New public API: `MultiDomain::with_path_style_hosts(RegexSet)`, `SingleDomain::with_cname_fallback(bool)`.
- Default behaviour of both implementations is unchanged.
- New dependency: `regex` (promoted to the workspace dependency table).

## Testing

- `just ci-rust` — fmt check, workspace-wide clippy (`-D warnings`), workspace-wide tests, codegen, clean-tree assertion
- `just dev` — fetch, fmt, codegen, lint, test
- `cargo doc -p s3s --all-features --no-deps` — no warnings from `host.rs`

New tests pin the strict and fallback behaviour at both the parser level (`single_domain_parse_cname_fallback`, `single_domain_disable_cname_fallback`, `multi_domain_parse_cname_fallback`, `multi_domain_path_style_hosts`) and the routing level (`host_fallback_path_style_and_cname`, `host_path_style_rule_is_path_style`, `single_domain_fallback_disabled_is_path_style`).

Addresses [#643](https://github.com/s3s-project/s3s/issues/643)
