### PR TITLE
perf(s3s): avoid path decode allocation in prepare

### DIFF
--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -332,9 +332,7 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
             req.headers.insert(hyper::header::HOST, val);
         }
 
-        let decoded_uri_path = urlencoding::decode(req.uri.path())
-            .map_err(|_| S3ErrorCode::InvalidURI)?
-            .into_owned();
+        let decoded_uri_path = urlencoding::decode(req.uri.path()).map_err(|_| S3ErrorCode::InvalidURI)?;
 
         host_header = extract_host(req)?;
         let vh;
@@ -357,7 +355,7 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
                     vh_region = vh.region().map(str::to_owned);
                     break 'parse crate::path::parse_virtual_hosted_style_with_validation_and_normalization(
                         vh_bucket,
-                        &decoded_uri_path,
+                        decoded_uri_path.as_ref(),
                         validation,
                         ccx.config.snapshot().normalize_forward_slash_path,
                     );
@@ -367,7 +365,7 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
                 vh_bucket = None;
                 vh_region = None;
                 crate::path::parse_path_style_with_validation_and_normalization(
-                    &decoded_uri_path,
+                    decoded_uri_path.as_ref(),
                     validation,
                     ccx.config.snapshot().normalize_forward_slash_path,
                 )


### PR DESCRIPTION
## Summary

- Keep the decoded URI path as `Cow<str>` in `prepare` instead of unconditionally materializing a `String`.
- Let normal unescaped path-style and virtual-hosted-style requests stay borrowed while preserving the existing owned fallback for percent-decoded paths.

## Motivation

The GET output-path attribution microbench shows `prepare` as a small but fixed per-request component. The common request path is already valid UTF-8 without percent escapes, so `urlencoding::decode` can return a borrowed value. Calling `into_owned()` forced a per-request allocation before path parsing and signature preparation.

## Benchmark notes

On this machine, a single merged-main baseline run measured `prepare_path_style_get` at about `275ns/op`. With this change, one run measured about `263ns/op`, but a second run showed broad system noise across unrelated cases. I am treating this PR as a direct allocation reduction rather than claiming a stable end-to-end throughput gain from the microbench alone.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p s3s --features minio --tests -- -D warnings`
- `cargo test -p s3s --features minio`
- `cargo test -p s3s --features minio --release get_object_output_path_microbench -- --ignored --nocapture`

## Risk

Low. The decoded path is still produced by `urlencoding::decode`; invalid URI handling, path validation, and signature inputs are unchanged. Percent-encoded paths still allocate through `Cow::Owned`, while the common unescaped path remains borrowed.
