### PR TITLE
test(s3s): expand GET serialization attribution bench

### DIFF
--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -169,6 +169,7 @@ fn get_object_microbench_drain_body(mut body: crate::http::Body) -> usize {
 #[ignore = "focused microbenchmark for GET response serialization attribution"]
 fn get_object_response_serialization_microbench() {
     use crate::dto::ETag;
+    use crate::dto::TimestampFormat;
     use crate::http;
 
     const DEFAULT_ITERS: u64 = 200_000;
@@ -184,6 +185,15 @@ fn get_object_response_serialization_microbench() {
         http::set_stream_body(&mut res, get_object_microbench_body());
         Ok(res)
     });
+    run_get_object_microbench_case("generated_empty_output", iterations, || {
+        generated::GetObject::serialize_http(crate::dto::GetObjectOutput::default())
+    });
+    run_get_object_microbench_case("generated_body_only", iterations, || {
+        generated::GetObject::serialize_http(crate::dto::GetObjectOutput {
+            body: Some(get_object_microbench_body()),
+            ..Default::default()
+        })
+    });
     run_get_object_microbench_case("manual_common_headers", iterations, || {
         let mut res = http::Response::default();
         http::set_stream_body(&mut res, get_object_microbench_body());
@@ -193,6 +203,40 @@ fn get_object_response_serialization_microbench() {
             &mut res,
             hyper::header::ETAG,
             Some(ETag::Strong("0123456789abcdef0123456789abcdef".to_owned())),
+        )?;
+        Ok(res)
+    });
+    run_get_object_microbench_case("manual_common_headers_5", iterations, || {
+        let mut res = http::Response::default();
+        http::set_stream_body(&mut res, get_object_microbench_body());
+        http::add_opt_header(&mut res, crate::header::ACCEPT_RANGES, Some("bytes".to_owned()))?;
+        http::add_opt_header(&mut res, crate::header::CACHE_CONTROL, Some("no-cache".to_owned()))?;
+        http::add_opt_header(&mut res, hyper::header::CONTENT_LENGTH, Some(1024_i64))?;
+        http::add_opt_header(&mut res, hyper::header::CONTENT_TYPE, Some("application/octet-stream".to_owned()))?;
+        http::add_opt_header(
+            &mut res,
+            hyper::header::ETAG,
+            Some(ETag::Strong("0123456789abcdef0123456789abcdef".to_owned())),
+        )?;
+        Ok(res)
+    });
+    run_get_object_microbench_case("manual_common_headers_5_last_modified", iterations, || {
+        let mut res = http::Response::default();
+        http::set_stream_body(&mut res, get_object_microbench_body());
+        http::add_opt_header(&mut res, crate::header::ACCEPT_RANGES, Some("bytes".to_owned()))?;
+        http::add_opt_header(&mut res, crate::header::CACHE_CONTROL, Some("no-cache".to_owned()))?;
+        http::add_opt_header(&mut res, hyper::header::CONTENT_LENGTH, Some(1024_i64))?;
+        http::add_opt_header(&mut res, hyper::header::CONTENT_TYPE, Some("application/octet-stream".to_owned()))?;
+        http::add_opt_header(
+            &mut res,
+            hyper::header::ETAG,
+            Some(ETag::Strong("0123456789abcdef0123456789abcdef".to_owned())),
+        )?;
+        http::add_opt_header_timestamp(
+            &mut res,
+            hyper::header::LAST_MODIFIED,
+            Some(get_object_microbench_last_modified()),
+            TimestampFormat::HttpDate,
         )?;
         Ok(res)
     });


### PR DESCRIPTION
## Summary

- Expand the ignored GET response serialization microbench with generated empty/body-only cases.
- Add manual 5-header and 5-header-plus-Last-Modified attribution cases.

## Motivation

The current GET output path profile points at fixed response serialization/header construction cost after the request preparation allocation was removed. These additional focused cases make it easier to separate body wrapping, generated optional-header scanning, common header insertion, timestamp formatting, and user metadata serialization before changing production code.

## Local attribution snapshot

With `S3S_GET_SERIALIZE_BENCH_ITERS=1000000` on this machine:

- `generated_empty_output`: about `104ns/op`
- `generated_body_only`: about `111ns/op`
- `manual_common_headers_5`: about `166ns/op`
- `manual_common_headers_5_last_modified`: about `290ns/op`
- `get_object_common_no_timestamp`: about `265ns/op`
- `get_object_common_timestamp`: about `379ns/op`
- `get_object_common_metadata_2`: about `762ns/op`

The numbers suggest that generated optional-header scanning and timestamp/header formatting are better follow-up candidates than the body wrapper alone. This PR only improves attribution; it does not change runtime behavior.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p s3s --features minio --tests -- -D warnings`
- `cargo test -p s3s --features minio get_object_response_serialization_microbench -- --ignored --nocapture`
- `cargo test -p s3s --features minio --release get_object_response_serialization_microbench -- --ignored --nocapture`
- `S3S_GET_SERIALIZE_BENCH_ITERS=1000000 cargo test -p s3s --features minio --release get_object_response_serialization_microbench -- --ignored --nocapture`

## Risk

Low. This is test-only and extends an ignored focused microbench. It does not affect normal test execution or production code paths.
