### PR TITLE
docs(s3s): document public API and deny missing docs in core modules

### DIFF
--- a/crates/s3s/src/auth/mod.rs
+++ b/crates/s3s/src/auth/mod.rs
@@ -70,6 +70,8 @@
 //! - Rotate credentials regularly
 //! - Use [`SimpleAuth`] only for testing, not production
 
+#![deny(missing_docs)]
+
 mod secret_key;
 pub use self::secret_key::{Credentials, SecretKey};
 

--- a/crates/s3s/src/auth/secret_key.rs
+++ b/crates/s3s/src/auth/secret_key.rs
@@ -5,12 +5,21 @@ use serde::Serialize;
 use subtle::ConstantTimeEq;
 use zeroize::Zeroize;
 
+/// Authenticated S3 credentials.
+///
+/// Contains the access key ID and the corresponding [`SecretKey`].
 #[derive(Debug, Clone)]
 pub struct Credentials {
+    /// The access key ID.
     pub access_key: String,
+    /// The secret key associated with the access key.
     pub secret_key: SecretKey,
 }
 
+/// An S3 secret key.
+///
+/// The secret value is zeroized on drop, and its [`Debug`](std::fmt::Debug)
+/// implementation hides the actual value.
 #[derive(Clone)]
 pub struct SecretKey(Box<str>);
 
@@ -19,6 +28,9 @@ impl SecretKey {
         Self(s.into())
     }
 
+    /// Exposes the secret key value.
+    ///
+    /// This is the only way to read the secret. Use it with care.
     #[must_use]
     pub fn expose(&self) -> &str {
         &self.0

--- a/crates/s3s/src/auth/simple_auth.rs
+++ b/crates/s3s/src/auth/simple_auth.rs
@@ -19,6 +19,7 @@ impl SimpleAuth {
         Self { map: HashMap::new() }
     }
 
+    /// Constructs a new `SimpleAuth` with a single registered access key pair.
     #[must_use]
     pub fn from_single(access_key: impl Into<String>, secret_key: impl Into<SecretKey>) -> Self {
         let access_key = access_key.into();

--- a/crates/s3s/src/checksum.rs
+++ b/crates/s3s/src/checksum.rs
@@ -5,6 +5,8 @@
 //! a [`crate::dto::Checksum`] struct whose fields are populated with
 //! base64-encoded digests for every algorithm that was enabled.
 
+#![deny(missing_docs)]
+
 use crate::crypto::Checksum as _;
 use crate::crypto::Crc32;
 use crate::crypto::Crc32c;
@@ -20,21 +22,37 @@ use crate::dto::Checksum;
 
 use stdx::default::default;
 
+/// Computes one or more S3 checksums simultaneously in a single pass.
+///
+/// Enable one or more algorithms by setting the corresponding field to `Some(...)`,
+/// feed data with [`update`](Self::update), then finalize with [`finalize`](Self::finalize)
+/// to obtain a [`crate::dto::Checksum`] holding base64-encoded digests.
 #[derive(Default)]
 pub struct ChecksumHasher {
+    /// CRC-32 (ISO-HDLC) checksum, used for `x-amz-checksum-crc32`.
     pub crc32: Option<Crc32>,
+    /// CRC-32C (Castagnoli / iSCSI) checksum, used for `x-amz-checksum-crc32c`.
     pub crc32c: Option<Crc32c>,
+    /// SHA-1 digest, used for `x-amz-checksum-sha1`.
     pub sha1: Option<Sha1>,
+    /// SHA-256 digest, used for `x-amz-checksum-sha256`.
     pub sha256: Option<Sha256>,
+    /// SHA-512 digest, used for `x-amz-checksum-sha512`.
     pub sha512: Option<Sha512>,
+    /// CRC-64/NVMe checksum, used for `x-amz-checksum-crc64nvme`.
     pub crc64nvme: Option<Crc64Nvme>,
+    /// MD5 digest, used for `x-amz-checksum-md5`.
     pub md5: Option<Md5>,
+    /// XXHASH64 checksum, used for `x-amz-checksum-xxhash64`.
     pub xxhash64: Option<XxHash64>,
+    /// XXHASH3 checksum, used for `x-amz-checksum-xxhash3`.
     pub xxhash3: Option<XxHash3>,
+    /// XXHASH128 checksum, used for `x-amz-checksum-xxhash128`.
     pub xxhash128: Option<XxHash128>,
 }
 
 impl ChecksumHasher {
+    /// Feeds `data` into every enabled algorithm.
     pub fn update(&mut self, data: &[u8]) {
         if let Some(crc32) = &mut self.crc32 {
             crc32.update(data);
@@ -68,6 +86,9 @@ impl ChecksumHasher {
         }
     }
 
+    /// Finalizes every enabled algorithm and returns the resulting [`crate::dto::Checksum`].
+    ///
+    /// The returned fields hold base64-encoded digests.
     #[must_use]
     pub fn finalize(self) -> Checksum {
         let mut ans: Checksum = default();

--- a/crates/s3s/src/crypto.rs
+++ b/crates/s3s/src/crypto.rs
@@ -6,19 +6,32 @@
 //! cryptographic hash functions: [`Sha1`], [`Sha256`], [`Sha512`], and [`Md5`];
 //! xxHash algorithms: [`XxHash64`], [`XxHash3`], [`XxHash128`].
 
+#![deny(missing_docs)]
+
 use numeric_cast::TruncatingCast;
 
+/// A checksum or hash algorithm.
+///
+/// Implementors provide incremental hashing: create a new instance with
+/// [`new`](Self::new), feed data with [`update`](Self::update), and obtain the
+/// digest with [`finalize`](Self::finalize). [`checksum`](Self::checksum)
+/// computes the digest of a buffer in one shot.
 pub trait Checksum {
+    /// The digest output type.
     type Output: AsRef<[u8]>;
 
+    /// Creates a new hasher.
     #[must_use]
     fn new() -> Self;
 
+    /// Feeds `data` into the hasher.
     fn update(&mut self, data: &[u8]);
 
+    /// Finalizes the hasher and returns the digest.
     #[must_use]
     fn finalize(self) -> Self::Output;
 
+    /// Computes the digest of `data` in one shot.
     #[must_use]
     fn checksum(data: &[u8]) -> Self::Output
     where
@@ -30,6 +43,9 @@ pub trait Checksum {
     }
 }
 
+/// CRC-32 (ISO-HDLC) checksum, used for `x-amz-checksum-crc32`.
+///
+/// Produces a 4-byte big-endian digest.
 pub struct Crc32(crc_fast::Digest);
 
 impl Default for Crc32 {
@@ -39,6 +55,7 @@ impl Default for Crc32 {
 }
 
 impl Crc32 {
+    /// Computes the CRC-32 checksum of `data` and returns it as a `u32`.
     #[must_use]
     pub fn checksum_u32(data: &[u8]) -> u32 {
         let mut hasher = Self::new();
@@ -63,6 +80,9 @@ impl Checksum for Crc32 {
     }
 }
 
+/// CRC-32C (Castagnoli / iSCSI) checksum, used for `x-amz-checksum-crc32c`.
+///
+/// Produces a 4-byte big-endian digest.
 pub struct Crc32c(crc_fast::Digest);
 
 impl Default for Crc32c {
@@ -87,6 +107,9 @@ impl Checksum for Crc32c {
     }
 }
 
+/// CRC-64/NVMe checksum, used for `x-amz-checksum-crc64nvme`.
+///
+/// Produces an 8-byte big-endian digest.
 pub struct Crc64Nvme(crc_fast::Digest);
 
 impl Default for Crc64Nvme {
@@ -111,6 +134,9 @@ impl Checksum for Crc64Nvme {
     }
 }
 
+/// SHA-1 hash, used for `x-amz-checksum-sha1`.
+///
+/// Produces a 20-byte digest.
 #[derive(Default)]
 pub struct Sha1(sha1::Sha1);
 
@@ -132,6 +158,9 @@ impl Checksum for Sha1 {
     }
 }
 
+/// SHA-256 hash, used for `x-amz-checksum-sha256`.
+///
+/// Produces a 32-byte digest.
 #[derive(Default)]
 pub struct Sha256(sha2::Sha256);
 
@@ -153,6 +182,9 @@ impl Checksum for Sha256 {
     }
 }
 
+/// MD5 hash, used for `x-amz-checksum-md5`.
+///
+/// Produces a 16-byte digest.
 #[derive(Default)]
 pub struct Md5(md5::Md5);
 
@@ -174,6 +206,9 @@ impl Checksum for Md5 {
     }
 }
 
+/// SHA-512 hash, used for `x-amz-checksum-sha512`.
+///
+/// Produces a 64-byte digest.
 #[derive(Default)]
 pub struct Sha512(sha2::Sha512);
 
@@ -195,6 +230,9 @@ impl Checksum for Sha512 {
     }
 }
 
+/// XXHASH64 checksum, used for `x-amz-checksum-xxhash64`.
+///
+/// Produces an 8-byte big-endian digest.
 pub struct XxHash64(xxhash_rust::xxh64::Xxh64);
 
 // Amazon S3 checksum names map to upstream xxHash variants as follows:
@@ -227,6 +265,9 @@ impl Checksum for XxHash64 {
     }
 }
 
+/// XXHASH3 checksum, used for `x-amz-checksum-xxhash3`.
+///
+/// Produces an 8-byte big-endian digest.
 pub struct XxHash3(xxhash_rust::xxh3::Xxh3);
 
 impl Default for XxHash3 {
@@ -251,6 +292,9 @@ impl Checksum for XxHash3 {
     }
 }
 
+/// XXHASH128 checksum, used for `x-amz-checksum-xxhash128`.
+///
+/// Produces a 16-byte big-endian digest.
 pub struct XxHash128(xxhash_rust::xxh3::Xxh3);
 
 impl Default for XxHash128 {

--- a/crates/s3s/src/http/body.rs
+++ b/crates/s3s/src/http/body.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 use crate::error::StdError;
 use crate::stream::ByteStream;
 use crate::stream::DynByteStream;
@@ -19,6 +21,11 @@ type BoxBody = http_body_util::combinators::BoxBody<Bytes, StdError>;
 type UnsyncBoxBody = http_body_util::combinators::UnsyncBoxBody<Bytes, StdError>;
 
 pin_project_lite::pin_project! {
+    /// A flexible HTTP body type for S3 requests and responses.
+    ///
+    /// Supports empty bodies, in-memory [`Bytes`], hyper bodies, boxed
+    /// [`http_body::Body`] implementations (both `Send + Sync` and unsync),
+    /// and [`DynByteStream`].
     #[derive(Default)]
     pub struct Body {
         #[pin]
@@ -55,6 +62,7 @@ pin_project_lite::pin_project! {
 }
 
 impl Body {
+    /// Creates an empty body.
     #[must_use]
     pub fn empty() -> Self {
         Self::default()
@@ -78,6 +86,9 @@ impl Body {
         }
     }
 
+    /// Wraps any [`http_body::Body`] with `Bytes` data.
+    ///
+    /// The wrapped body must be `Send + Sync`.
     #[must_use]
     pub fn http_body<B>(body: B) -> Self
     where
@@ -91,6 +102,10 @@ impl Body {
         }
     }
 
+    /// Wraps any [`http_body::Body`] with `Bytes` data.
+    ///
+    /// The wrapped body does not need to be `Sync`; access is serialized
+    /// through a mutex.
     #[must_use]
     pub fn http_body_unsync<B>(body: B) -> Self
     where
@@ -288,6 +303,9 @@ impl Body {
         Ok(bytes)
     }
 
+    /// Returns the buffered bytes if the body is already fully held in memory,
+    /// without consuming them.
+    #[must_use]
     pub fn bytes(&self) -> Option<Bytes> {
         match &self.kind {
             Kind::Empty => Some(Bytes::new()),
@@ -296,6 +314,8 @@ impl Body {
         }
     }
 
+    /// Takes the buffered bytes if the body is already fully held in memory.
+    #[must_use]
     pub fn take_bytes(&mut self) -> Option<Bytes> {
         match mem::take(&mut self.kind) {
             Kind::Empty => Some(Bytes::new()),

--- a/crates/s3s/src/protocol.rs
+++ b/crates/s3s/src/protocol.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 use crate::Body;
 use crate::StdError;
 use crate::auth::Credentials;
@@ -11,7 +13,14 @@ use http::Uri;
 
 use stdx::default::default;
 
+/// An S3 HTTP request.
+///
+/// Type alias for [`http::Request`] with the default [`Body`].
 pub type HttpRequest<B = Body> = http::Request<B>;
+
+/// An S3 HTTP response.
+///
+/// Type alias for [`http::Response`] with the default [`Body`].
 pub type HttpResponse<B = Body> = http::Response<B>;
 
 /// An error that indicates a failure of an HTTP request.
@@ -20,6 +29,7 @@ pub type HttpResponse<B = Body> = http::Response<B>;
 pub struct HttpError(StdError);
 
 impl HttpError {
+    /// Creates a new `HttpError` from the given error.
     #[must_use]
     pub fn new(err: StdError) -> Self {
         Self(err)

--- a/crates/s3s/src/s3_op.rs
+++ b/crates/s3s/src/s3_op.rs
@@ -1,3 +1,9 @@
+#![deny(missing_docs)]
+
+/// An S3 operation.
+///
+/// Identifies a single S3 API operation, such as `GetObject` or `ListBuckets`.
+/// Instances are passed to access control providers for fine-grained authorization.
 pub struct S3Operation {
     pub(crate) name: &'static str,
 }

--- a/crates/s3s/src/stream.rs
+++ b/crates/s3s/src/stream.rs
@@ -4,6 +4,8 @@
 //! alias for heap-allocated streams, and [`RemainingLength`] which
 //! communicates a known or estimated byte count remaining in a stream.
 
+#![deny(missing_docs)]
+
 use crate::error::StdError;
 
 use std::collections::VecDeque;
@@ -14,14 +16,24 @@ use std::task::{Context, Poll};
 use bytes::Bytes;
 use futures::Stream;
 
+/// A stream of bytes, typically the body of an S3 request or response.
+///
+/// Extends [`Stream`] with a way to report the known or estimated remaining
+/// byte count of the stream.
 pub trait ByteStream: Stream {
+    /// Returns the known or estimated remaining byte count.
     fn remaining_length(&self) -> RemainingLength {
         RemainingLength::unknown()
     }
 }
 
+/// A heap-allocated, object-safe byte stream.
+///
+/// This is the default stream type used by [`crate::Body`] and the DTO
+/// streaming types.
 pub type DynByteStream = Pin<Box<dyn ByteStream<Item = Result<Bytes, StdError>> + Send + Sync + 'static>>;
 
+/// The known or estimated remaining byte count of a stream.
 pub struct RemainingLength {
     lower: usize,
     upper: Option<usize>,
@@ -40,11 +52,13 @@ impl RemainingLength {
         Self { lower, upper }
     }
 
+    /// Creates a `RemainingLength` whose length is unknown.
     #[must_use]
     pub fn unknown() -> Self {
         Self { lower: 0, upper: None }
     }
 
+    /// Creates a `RemainingLength` with an exact known length.
     #[must_use]
     pub fn new_exact(n: usize) -> Self {
         Self {
@@ -53,6 +67,7 @@ impl RemainingLength {
         }
     }
 
+    /// Returns the exact remaining length, if it is exactly known.
     #[must_use]
     pub fn exact(&self) -> Option<usize> {
         self.upper.filter(|&upper| upper == self.lower)

--- a/crates/s3s/src/validation.rs
+++ b/crates/s3s/src/validation.rs
@@ -3,6 +3,8 @@
 //! The [`NameValidation`] trait lets users plug in a custom bucket name validator.
 //! [`AwsNameValidation`] provides the standard AWS bucket naming rules.
 
+#![deny(missing_docs)]
+
 /// Trait for validating S3 bucket names
 ///
 /// Implementations should return `true` for valid names and `false` for invalid ones.
@@ -18,6 +20,7 @@ pub struct AwsNameValidation {
 }
 
 impl AwsNameValidation {
+    /// Creates a new `AwsNameValidation`.
     #[must_use]
     pub const fn new() -> Self {
         Self { _priv: () }


### PR DESCRIPTION
## Summary

Enable `#![deny(missing_docs)]` and complete the public API documentation for eight core modules of the `s3s` crate:

- `auth` (including the `secret_key` and `simple_auth` submodules)
- `s3_op`
- `validation`
- `protocol`
- `checksum`
- `stream`
- `http::body`
- `crypto`

Each module now fails to compile if a public item lacks a doc comment, so future additions to these modules are forced to be documented. One commit per module.

## Changes

- `auth`: document `Credentials` (with its `access_key` / `secret_key` fields), `SecretKey` (zeroized on drop, redacted `Debug`), and `SimpleAuth::from_single`.
- `s3_op`: document `S3Operation`.
- `validation`: document `AwsNameValidation::new`.
- `protocol`: document the `HttpRequest` and `HttpResponse` type aliases and `HttpError::new`.
- `checksum`: document `ChecksumHasher` and all ten algorithm fields (`crc32` … `xxhash128`), each annotated with its corresponding `x-amz-checksum-*` header and the precise algorithm variant (e.g. CRC-32 `(ISO-HDLC)`, CRC-32C `(Castagnoli / iSCSI)`), plus `update` and `finalize`.
- `stream`: document `ByteStream`, `DynByteStream`, and `RemainingLength` (including `unknown`, `new_exact`, and `exact`).
- `http::body`: document `Body` and its constructors / accessors (`empty`, `http_body`, `http_body_unsync`, `bytes`, `take_bytes`).
- `crypto`: document the `Checksum` trait (its `Output` associated type and `new` / `update` / `finalize` / `checksum` methods) and all ten algorithm types (`Crc32`, `Crc32c`, `Crc64Nvme`, `Sha1`, `Sha256`, `Sha512`, `Md5`, `XxHash64`, `XxHash3`, `XxHash128`), each annotated with its algorithm variant and the corresponding `x-amz-checksum-*` header.

No behaviour or API changes: only documentation and lint attributes.

## Verification

- `just ci-rust` — the full CI entry point: `cargo fmt --all --check`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`, workspace-wide tests, `just codegen` (idempotent — no generated changes), and `just assert_unchanged` (clean working tree).
- `cargo clippy -p s3s --all-features` — 0 errors (covers both the default and the `minio` feature variant of these hand-written modules).
- `cargo fmt --check -p s3s` — clean.
- `cargo test -p s3s` — unit tests and doctests pass.
- `cargo clippy -p s3s -- -D missing-docs` and `cargo clippy -p s3s --all-features -- -D missing-docs` — no missing-docs reports for any of the eight modules in either feature variant.