### PR TITLE
test(s3s/host): close the remaining coverage gaps in host.rs

### DIFF
--- a/crates/s3s/src/host.rs
+++ b/crates/s3s/src/host.rs
@@ -437,15 +437,17 @@ mod tests {
         let sd = result.unwrap();
         assert_eq!(sd.base_domain, domain);
 
-        let domain = "example.com.";
-        let result = SingleDomain::new(domain);
-        let err = result.unwrap_err();
-        assert!(matches!(err, DomainError::InvalidDomain));
-
-        let domain = "example.com:";
-        let result = SingleDomain::new(domain);
-        let err = result.unwrap_err();
-        assert!(matches!(err, DomainError::InvalidDomain));
+        for domain in [
+            "",                  // empty input
+            "example.com.",      // empty label
+            "example.com:",      // empty port
+            "example.com:http",  // non-numeric port
+            "example.com:65536", // port above u16::MAX
+            "exa_mple.com",      // character outside [a-zA-Z0-9-]
+        ] {
+            let err = SingleDomain::new(domain).unwrap_err();
+            assert_eq!(err, DomainError::InvalidDomain, "{domain:?}");
+        }
 
         let domain = "example.com:80";
         let result = SingleDomain::new(domain);
@@ -460,9 +462,8 @@ mod tests {
         assert_eq!(md.base_domains, domains);
 
         let domains = ["example.com", "example.com"];
-        let result = MultiDomain::new(&domains);
-        let err = result.unwrap_err();
-        assert!(matches!(err, DomainError::OverlappingSubdomains));
+        let err = MultiDomain::new(&domains).unwrap_err();
+        assert_eq!(err, DomainError::OverlappingSubdomains);
 
         let domains = ["example.com", "example.com.org"];
         let result = MultiDomain::new(&domains);
@@ -489,10 +490,15 @@ mod tests {
             assert_eq!(md.base_domains, domains, "{domains:?}");
         }
 
+        // an invalid domain is rejected wherever it appears in the list
+        for domains in [["", "example.com"], ["example.com", "exa_mple.com"]] {
+            let err = MultiDomain::new(&domains).unwrap_err();
+            assert_eq!(err, DomainError::InvalidDomain, "{domains:?}");
+        }
+
         let domains: [&str; 0] = [];
-        let result = MultiDomain::new(&domains);
-        let err = result.unwrap_err();
-        assert!(matches!(err, DomainError::ZeroDomains));
+        let err = MultiDomain::new(&domains).unwrap_err();
+        assert_eq!(err, DomainError::ZeroDomains);
     }
 
     #[test]
@@ -538,7 +544,7 @@ mod tests {
         let host = "example.com.org.";
         let result = md.parse_host_header(host);
         let err = result.unwrap_err();
-        assert!(matches!(err.code(), S3ErrorCode::InvalidRequest));
+        assert_eq!(err.code(), &S3ErrorCode::InvalidRequest);
 
         let host = "example.com.org.example.com";
         let result = md.parse_host_header(host);


### PR DESCRIPTION
Follow-up to #649, as offered [there](https://github.com/s3s-project/s3s/pull/649#issuecomment-5256676310).

### Problem

`host.rs` had nine partial lines, in two groups.

Four are genuine gaps — early returns nothing ever reached:

| line | branch |
|---|---|
| `is_valid_domain` | empty input |
| `is_valid_domain` | port that is not a number |
| `is_valid_domain` | character outside `[a-zA-Z0-9-]` in a label |
| `MultiDomain::new` | `DomainError::InvalidDomain` |

`is_valid_domain`'s other two rejections (empty port, empty label) were already covered by `"example.com:"` and `"example.com."`, and `MultiDomain::new` had never been handed an invalid domain at all — only `SingleDomain::new` had.

The other five are the `assert!(matches!(..))` artifact from #649: the macro expands to a `match` whose non-matching arm never runs while the test passes, so llvm-cov records an uncovered region and the line reports as partial.

### Fix

Table-drive the invalid inputs so every early return is exercised, and assert error values instead of matching them. `DomainError` and `S3ErrorCode` both derive `PartialEq`, so `assert_eq!` covers the line fully and prints the actual error on failure instead of just "assertion failed".

The new `MultiDomain::new` cases use `["", "example.com"]` and `["example.com", "exa_mple.com"]`, so an invalid entry is rejected from either position rather than only the first.

### Testing

Coverage in the format CI uploads (`cargo llvm-cov -p s3s --all-features --codecov`), `crates/s3s/src/host.rs`:

- **Before:** 313 tracked lines, 9 partial.
- **After:** 316 tracked lines, **0 partial, 0 uncovered**.

`cargo test -p s3s` on Rust 1.96.1 (workspace MSRV): 781 lib tests + 35 doctests pass. `cargo clippy -p s3s --all-targets -- -D warnings` and `cargo fmt --check -p s3s` are clean.

Tests only — no production code is touched.

Note the same `matches!` pattern is used in other modules, `post_policy.rs` most of all. I kept this to `host.rs` since that is what we discussed; happy to do a sweep if you want it.
