### PR TITLE
test(s3s): assert error values instead of matching them

### DIFF
--- a/crates/s3s/src/dto/copy_source.rs
+++ b/crates/s3s/src/dto/copy_source.rs
@@ -60,7 +60,7 @@ pub enum CopySource {
 }
 
 /// [`CopySource`]
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
 pub enum ParseCopySourceError {
     /// pattern mismatch
     #[error("ParseAmzCopySourceError: PatternMismatch")]
@@ -425,7 +425,7 @@ mod tests {
     fn bucket_no_key() {
         let header = "awsexamplebucket";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::PatternMismatch));
+        assert_eq!(err, ParseCopySourceError::PatternMismatch);
     }
 
     // ── Access Point ARN tests ──
@@ -698,70 +698,70 @@ mod tests {
     fn invalid_arn_missing_parts() {
         let header = "arn:aws:s3";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidArn));
+        assert_eq!(err, ParseCopySourceError::InvalidArn);
     }
 
     #[test]
     fn invalid_arn_bad_partition() {
         let header = "arn:invalid:s3:us-west-2:123456789012:accesspoint/ap/object/key";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidArn));
+        assert_eq!(err, ParseCopySourceError::InvalidArn);
     }
 
     #[test]
     fn invalid_arn_bad_service() {
         let header = "arn:aws:ec2:us-west-2:123456789012:accesspoint/ap/object/key";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidArn));
+        assert_eq!(err, ParseCopySourceError::InvalidArn);
     }
 
     #[test]
     fn invalid_arn_empty_region() {
         let header = "arn:aws:s3::123456789012:accesspoint/ap/object/key";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidArn));
+        assert_eq!(err, ParseCopySourceError::InvalidArn);
     }
 
     #[test]
     fn invalid_arn_empty_account_id() {
         let header = "arn:aws:s3:us-west-2::accesspoint/ap/object/key";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidAccountId));
+        assert_eq!(err, ParseCopySourceError::InvalidAccountId);
     }
 
     #[test]
     fn invalid_arn_missing_object_delimiter() {
         let header = "arn:aws:s3:us-west-2:123456789012:accesspoint/my-ap/key";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidArn));
+        assert_eq!(err, ParseCopySourceError::InvalidArn);
     }
 
     #[test]
     fn invalid_arn_empty_access_point_name() {
         let header = "arn:aws:s3:us-west-2:123456789012:accesspoint//object/key";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidAccessPointName));
+        assert_eq!(err, ParseCopySourceError::InvalidAccessPointName);
     }
 
     #[test]
     fn invalid_arn_empty_key() {
         let header = "arn:aws:s3:us-west-2:123456789012:accesspoint/my-ap/object/";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidKey));
+        assert_eq!(err, ParseCopySourceError::InvalidKey);
     }
 
     #[test]
     fn invalid_arn_empty_outpost_id() {
         let header = "arn:aws:s3-outposts:us-west-2:123456789012:outpost//object/key";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidArn));
+        assert_eq!(err, ParseCopySourceError::InvalidArn);
     }
 
     #[test]
     fn invalid_outpost_missing_object_delimiter() {
         let header = "arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/key";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidArn));
+        assert_eq!(err, ParseCopySourceError::InvalidArn);
     }
 
     #[test]
@@ -769,7 +769,7 @@ mod tests {
         // s3 service but resource doesn't start with "accesspoint/"
         let header = "arn:aws:s3:us-west-2:123456789012:bucket/mybucket/object/key";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidArn));
+        assert_eq!(err, ParseCopySourceError::InvalidArn);
     }
 
     #[test]
@@ -777,7 +777,7 @@ mod tests {
         // %80 is an invalid UTF-8 start byte, which causes urlencoding::decode to fail
         let header = "awsexamplebucket/reports/%80";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidEncoding));
+        assert_eq!(err, ParseCopySourceError::InvalidEncoding);
     }
 
     // ── Key with special characters in ARN ──
@@ -860,17 +860,17 @@ mod tests {
         // Name with uppercase
         let header = "arn:aws:s3:us-west-2:123456789012:accesspoint/MyAP/object/key";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidAccessPointName));
+        assert_eq!(err, ParseCopySourceError::InvalidAccessPointName);
 
         // Name too short (2 chars)
         let header = "arn:aws:s3:us-west-2:123456789012:accesspoint/ab/object/key";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidAccessPointName));
+        assert_eq!(err, ParseCopySourceError::InvalidAccessPointName);
 
         // Name with consecutive hyphens
         let header = "arn:aws:s3:us-west-2:123456789012:accesspoint/my--ap/object/key";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidAccessPointName));
+        assert_eq!(err, ParseCopySourceError::InvalidAccessPointName);
     }
 
     // ── Account ID validation tests ──
@@ -900,17 +900,17 @@ mod tests {
         // Too short
         let header = "arn:aws:s3:us-west-2:12345:accesspoint/my-ap/object/key";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidAccountId));
+        assert_eq!(err, ParseCopySourceError::InvalidAccountId);
 
         // Contains letters
         let header = "arn:aws:s3:us-west-2:12345678901a:accesspoint/my-ap/object/key";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidAccountId));
+        assert_eq!(err, ParseCopySourceError::InvalidAccountId);
 
         // Too long
         let header = "arn:aws:s3:us-west-2:1234567890123:accesspoint/my-ap/object/key";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidAccountId));
+        assert_eq!(err, ParseCopySourceError::InvalidAccountId);
     }
 
     // ── Partition roundtrip tests ──
@@ -943,7 +943,7 @@ mod tests {
         // Bucket name too short (1 char)
         let header = "a/some-key";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidBucketName));
+        assert_eq!(err, ParseCopySourceError::InvalidBucketName);
     }
 
     #[test]
@@ -951,14 +951,14 @@ mod tests {
         let long_key = "a".repeat(1025);
         let header = format!("my-bucket/{long_key}");
         let err = CopySource::parse(&header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidKey));
+        assert_eq!(err, ParseCopySourceError::InvalidKey);
     }
 
     #[test]
     fn invalid_outpost_empty_key() {
         let header = "arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/object/";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidKey));
+        assert_eq!(err, ParseCopySourceError::InvalidKey);
     }
 
     #[test]
@@ -966,7 +966,7 @@ mod tests {
         // %80 in versionId triggers InvalidEncoding from extract_version_id
         let header = "my-bucket/key?versionId=%80";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidEncoding));
+        assert_eq!(err, ParseCopySourceError::InvalidEncoding);
     }
 
     #[test]
@@ -974,7 +974,7 @@ mod tests {
         // s3-outposts service but resource doesn't start with "outpost/"
         let header = "arn:aws:s3-outposts:us-west-2:123456789012:accesspoint/my-ap/object/key";
         let err = CopySource::parse(header).unwrap_err();
-        assert!(matches!(err, ParseCopySourceError::InvalidArn));
+        assert_eq!(err, ParseCopySourceError::InvalidArn);
     }
 
     // ── Encoded roundtrip tests ──

--- a/crates/s3s/src/dto/etag.rs
+++ b/crates/s3s/src/dto/etag.rs
@@ -21,7 +21,7 @@ pub enum ETag {
 }
 
 /// Errors returned when parsing an `ETag` header.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
 pub enum ParseETagError {
     /// The bytes do not match the `ETag` syntax.
     #[error("ParseETagError: InvalidFormat")]
@@ -316,30 +316,30 @@ mod tests {
     fn parse_invalid_format_cases() {
         // Empty string should return InvalidFormat
         let err = ETag::parse_http_header(b"").unwrap_err();
-        assert!(matches!(err, ParseETagError::InvalidFormat));
+        assert_eq!(err, ParseETagError::InvalidFormat);
 
         // Malformed quoted values should return InvalidFormat
         let err = ETag::parse_http_header(b"\"unclosed").unwrap_err();
-        assert!(matches!(err, ParseETagError::InvalidFormat));
+        assert_eq!(err, ParseETagError::InvalidFormat);
 
         let err = ETag::parse_http_header(b"W/\"unclosed").unwrap_err();
-        assert!(matches!(err, ParseETagError::InvalidFormat));
+        assert_eq!(err, ParseETagError::InvalidFormat);
 
         let err = ETag::parse_http_header(b"W/xyz").unwrap_err();
-        assert!(matches!(err, ParseETagError::InvalidFormat));
+        assert_eq!(err, ParseETagError::InvalidFormat);
 
         let err = ETag::parse_http_header(b"\"abc\"x").unwrap_err();
-        assert!(matches!(err, ParseETagError::InvalidFormat));
+        assert_eq!(err, ParseETagError::InvalidFormat);
 
         let err = ETag::parse_http_header(b"W/\"abc\"x").unwrap_err();
-        assert!(matches!(err, ParseETagError::InvalidFormat));
+        assert_eq!(err, ParseETagError::InvalidFormat);
 
         // Special characters not allowed in unquoted values
         let err = ETag::parse_http_header(b"**").unwrap_err();
-        assert!(matches!(err, ParseETagError::InvalidFormat));
+        assert_eq!(err, ParseETagError::InvalidFormat);
 
         let err = ETag::parse_http_header(b"* ").unwrap_err();
-        assert!(matches!(err, ParseETagError::InvalidFormat));
+        assert_eq!(err, ParseETagError::InvalidFormat);
     }
 
     #[test]
@@ -364,35 +364,35 @@ mod tests {
     fn parse_invalid_char_cases() {
         // Contains newline/carriage return (quoted)
         let err = ETag::parse_http_header(b"\"a\nb\"").unwrap_err();
-        assert!(matches!(err, ParseETagError::InvalidChar));
+        assert_eq!(err, ParseETagError::InvalidChar);
 
         let err = ETag::parse_http_header(b"W/\"a\rb\"").unwrap_err();
-        assert!(matches!(err, ParseETagError::InvalidChar));
+        assert_eq!(err, ParseETagError::InvalidChar);
 
         // Contains DEL (0x7f) (quoted)
         let err = ETag::parse_http_header(b"\"a\x7fb\"").unwrap_err();
-        assert!(matches!(err, ParseETagError::InvalidChar));
+        assert_eq!(err, ParseETagError::InvalidChar);
 
         let err = ETag::parse_http_header(b"W/\"a\x7fb\"").unwrap_err();
-        assert!(matches!(err, ParseETagError::InvalidChar));
+        assert_eq!(err, ParseETagError::InvalidChar);
 
         // Contains non-ASCII (triggers from_ascii_simd error) (quoted)
         let err = ETag::parse_http_header(b"\"a\xc2\xb5b\"").unwrap_err(); // µ
-        assert!(matches!(err, ParseETagError::InvalidChar));
+        assert_eq!(err, ParseETagError::InvalidChar);
 
         // Invalid chars in unquoted values result in InvalidFormat
         // (since they don't match alphanumeric pattern)
         let err = ETag::parse_http_header(b"a\nb").unwrap_err();
-        assert!(matches!(err, ParseETagError::InvalidFormat));
+        assert_eq!(err, ParseETagError::InvalidFormat);
 
         let err = ETag::parse_http_header(b"a\rb").unwrap_err();
-        assert!(matches!(err, ParseETagError::InvalidFormat));
+        assert_eq!(err, ParseETagError::InvalidFormat);
 
         let err = ETag::parse_http_header(b"a\x7fb").unwrap_err();
-        assert!(matches!(err, ParseETagError::InvalidFormat));
+        assert_eq!(err, ParseETagError::InvalidFormat);
 
         let err = ETag::parse_http_header(b"a\xc2\xb5b").unwrap_err(); // µ
-        assert!(matches!(err, ParseETagError::InvalidFormat));
+        assert_eq!(err, ParseETagError::InvalidFormat);
     }
 
     #[test]

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -854,7 +854,7 @@ mod tests {
         ]);
         let result = extract_amz_content_sha256(&headers).unwrap();
         assert!(result.is_some());
-        assert!(matches!(result.unwrap(), AmzContentSha256::UnsignedPayload));
+        assert_eq!(result.unwrap(), AmzContentSha256::UnsignedPayload);
     }
 
     #[test]

--- a/crates/s3s/src/post_policy.rs
+++ b/crates/s3s/src/post_policy.rs
@@ -583,7 +583,7 @@ mod tests {
         };
 
         let e = PostPolicy::validate_condition(&condition, &multipart, 0, None).unwrap_err();
-        assert!(matches!(e.code(), S3ErrorCode::InvalidPolicyDocument));
+        assert_eq!(e.code(), &S3ErrorCode::InvalidPolicyDocument);
     }
 
     #[test]
@@ -619,7 +619,7 @@ mod tests {
         };
 
         let e = PostPolicy::validate_condition(&condition, &multipart, 0, None).unwrap_err();
-        assert!(matches!(e.code(), S3ErrorCode::InvalidPolicyDocument));
+        assert_eq!(e.code(), &S3ErrorCode::InvalidPolicyDocument);
     }
 
     #[test]
@@ -655,7 +655,7 @@ mod tests {
         let condition = PostPolicyCondition::ContentLengthRange { min: 100, max: 1000 };
 
         let e = PostPolicy::validate_condition(&condition, &multipart, 99, None).unwrap_err();
-        assert!(matches!(e.code(), S3ErrorCode::EntityTooSmall));
+        assert_eq!(e.code(), &S3ErrorCode::EntityTooSmall);
     }
 
     #[test]
@@ -664,7 +664,7 @@ mod tests {
         let condition = PostPolicyCondition::ContentLengthRange { min: 100, max: 1000 };
 
         let e = PostPolicy::validate_condition(&condition, &multipart, 1001, None).unwrap_err();
-        assert!(matches!(e.code(), S3ErrorCode::EntityTooLarge));
+        assert_eq!(e.code(), &S3ErrorCode::EntityTooLarge);
     }
 
     #[test]
@@ -676,7 +676,7 @@ mod tests {
         };
 
         let e = PostPolicy::validate_condition(&condition, &multipart, 0, None).unwrap_err();
-        assert!(matches!(e.code(), S3ErrorCode::InvalidPolicyDocument));
+        assert_eq!(e.code(), &S3ErrorCode::InvalidPolicyDocument);
     }
 
     #[test]
@@ -688,7 +688,7 @@ mod tests {
         };
 
         let e = PostPolicy::validate_condition(&condition, &multipart, 0, None).unwrap_err();
-        assert!(matches!(e.code(), S3ErrorCode::InvalidPolicyDocument));
+        assert_eq!(e.code(), &S3ErrorCode::InvalidPolicyDocument);
     }
 
     #[test]
@@ -712,7 +712,7 @@ mod tests {
         };
 
         let e = PostPolicy::validate_condition(&condition, &multipart, 0, None).unwrap_err();
-        assert!(matches!(e.code(), S3ErrorCode::InvalidPolicyDocument));
+        assert_eq!(e.code(), &S3ErrorCode::InvalidPolicyDocument);
     }
 
     /// Regression test for <https://github.com/rustfs/rustfs/issues/1785>
@@ -743,7 +743,7 @@ mod tests {
 
         // With mismatching url_bucket -> should fail
         let e = PostPolicy::validate_condition(&condition, &multipart, 0, Some("wrongbucket")).unwrap_err();
-        assert!(matches!(e.code(), S3ErrorCode::InvalidPolicyDocument));
+        assert_eq!(e.code(), &S3ErrorCode::InvalidPolicyDocument);
     }
 
     /// When both a `bucket` form field and `url_bucket` are present but conflict,
@@ -759,7 +759,7 @@ mod tests {
 
         // Conflict between form field and url_bucket must be rejected outright
         let e = PostPolicy::validate_condition(&condition, &multipart, 0, Some("url-bucket")).unwrap_err();
-        assert!(matches!(e.code(), S3ErrorCode::InvalidPolicyDocument));
+        assert_eq!(e.code(), &S3ErrorCode::InvalidPolicyDocument);
     }
 
     /// Regression test for <https://github.com/rustfs/rustfs/issues/1785>
@@ -905,7 +905,7 @@ mod tests {
         // "success_action_status" is NOT in the policy but IS in form fields
         let multipart = create_test_multipart(vec![("key", "mykey"), ("success_action_status", "200")], None);
         let err = policy.validate_conditions_only(&multipart, 0, Some("mybucket")).unwrap_err();
-        assert!(matches!(err.code(), S3ErrorCode::AccessDenied));
+        assert_eq!(err.code(), &S3ErrorCode::AccessDenied);
         assert!(
             err.message().unwrap_or("").contains("success_action_status"),
             "error message should mention the undeclared field"


### PR DESCRIPTION
Follow-up to #675, as offered [there](https://github.com/s3s-project/s3s/pull/675).

### Problem

`assert!(matches!(..))` expands to a `match` whose non-matching arm never runs while the test passes, so llvm-cov records an uncovered region and the line reports as partial. It also makes failures hard to read: the panic prints the macro source, never the value that was actually produced.

Across the crate there were 88 partial lines containing `matches!`. Three are in production code (`ops/signature.rs`, `aws_chunked_stream.rs`) where the partial is real branch information and should stay. The other 85 are test assertions.

### Fix

Converted the 52 assertions whose expected value can be compared:

| file | count | type |
|---|---|---|
| `dto/copy_source.rs` | 24 | `ParseCopySourceError` |
| `dto/etag.rs` | 17 | `ParseETagError` |
| `post_policy.rs` | 10 | `S3ErrorCode` via `e.code()` |
| `ops/signature.rs` | 1 | `AmzContentSha256` |

`S3ErrorCode` and `AmzContentSha256` already derive `PartialEq`. `ParseETagError` and `ParseCopySourceError` are plain unit-variant enums with no payloads, so they gain `PartialEq, Eq` — that is the only production change in this PR, two derive lines. It is additive, and comparing these errors is useful to downstream users in its own right. Happy to drop it and leave those 41 assertions alone if you would rather not widen the public API for tests.

### What is left alone

33 assertions still use `matches!`, because their expected value cannot be compared:

- payload-carrying variants — `PostPolicyError::Json(_)`, `AwsChunkedStreamError::Underlying(_)`, `UploadStreamError::Underlying(_)`. These enums wrap `serde_json::Error` and `StdError`, so they cannot derive `PartialEq` at all.
- structural patterns — `Poll::Ready(None)` in `http/body.rs`, `Cow::Borrowed(_)` in `utils/rfc2047.rs`, the multi-line `ETagCondition` matches.
- `DeError` in `xml/mod.rs`, which holds a `quick_xml::Error`.

Rewriting those as `assert_eq!(err.to_string(), "..")` would work and would close the coverage gap, but it trades a type-checked assertion for a string comparison, so I left them. Say the word if you would prefer that.

### Testing

`cargo test -p s3s` on Rust 1.96.1 (workspace MSRV): 786 lib tests + 35 doctests pass. `cargo clippy -p s3s --all-targets -- -D warnings` and `cargo fmt --check -p s3s` are clean.

Coverage in the format CI uploads (`cargo llvm-cov -p s3s --all-features --codecov`):

| file | partial before | after |
|---|---|---|
| `dto/copy_source.rs` | 45 | 21 |
| `dto/etag.rs` | 35 | 18 |
| `post_policy.rs` | 20 | 10 |
| `ops/signature.rs` | 121 | 120 |

Crate-wide that is 30566 → 30514 partial lines, exactly the 52 converted. Worth being honest about the scale: ~29.5k of those partials come from the generated `*_minio.rs` files, so this does not move the crate percentage. The win is the failure output — a mismatch now prints the actual error instead of `assertion failed: matches!(err, ParseETagError::InvalidFormat)`.
