### PR TITLE
ci: make the nightly toolchain leg non-blocking and drop unused Mergify config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
     needs: skip-check
     if: needs.skip-check.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
+    continue-on-error: ${{ contains(matrix.toolchain, 'nightly') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,0 @@
-queue_rules:
-  - merge_method: fast-forward
-    name: default


### PR DESCRIPTION
## Summary

Two small CI hygiene changes:

- Treat failures of the `nightly` toolchain leg in the `rust` job as non-blocking, so a fresh nightly regression cannot hold up merges.
- Remove the unused `.mergify.yml`; Mergify is no longer used in this repository.

## Changes

- `ci.yml`: add `continue-on-error: ${{ contains(matrix.toolchain, 'nightly') }}` to the `rust` job. The MSRV and stable legs remain blocking; only the floating `nightly` leg is allowed to fail. The aggregate `status-check` job therefore still gates merges on every required job.
  - Motivation: the current nightly (1.100.0-nightly, 2026-08-21) hits an internal compiler error ("unexpected rigid alias in layout_of after normalization") on pre-existing async-fn opaque types in `ops::signature`, `http::multipart`, etc. The nightly leg keeps running for early-warning value, but a compiler regression upstream should not block unrelated work.
- `.mergify.yml`: delete the leftover queue rule; merge automation now relies on GitHub's native merge queue.

## Verification

- YAML structure validated locally.
- Expected matrix behavior: `contains(...)` evaluates to false for `1.96.0` and `stable` (unchanged, blocking), true for `nightly` (allowed to fail).
