### PR TITLE
ci: temporarily pin nightly to 2026-08-20 to dodge rustc #161495

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,11 @@ jobs:
         toolchain:
           - 1.96.0 # MSRV
           - stable
-          - nightly
+          # FIXME: unpin once https://github.com/rust-lang/rust/issues/161495
+          # is resolved ("unexpected rigid alias" ICE in layout_of on our
+          # async-fn opaque types; regression introduced between the
+          # 2026-08-20 and 2026-08-21 nightly builds)
+          - nightly-2026-08-20
     steps:
       - uses: actions/checkout@v7
       - uses: taiki-e/install-action@just


### PR DESCRIPTION
## Summary

Pin the `nightly` leg of the `rust` CI matrix to `nightly-2026-08-20`, the last known-good build, until rust-lang/rust#161495 is resolved.

## Background

Nightly builds from 2026-08-21 onward hit an internal compiler error while compiling this workspace:

