### PR TITLE
test(s3s/ops): add route equivalence fixtures captured from current router

### DIFF
--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -30,6 +30,9 @@ mod tests;
 #[cfg(test)]
 mod route_bench;
 
+#[cfg(test)]
+mod route_fixture_check;
+
 use crate::access::{S3Access, S3AccessContext};
 use crate::auth::{Credentials, S3Auth};
 use crate::config::S3ConfigProvider;

--- a/crates/s3s/src/ops/route_fixture_check.rs
+++ b/crates/s3s/src/ops/route_fixture_check.rs
@@ -18,9 +18,9 @@
 //! |---|---|
 //! | `method` | HTTP method |
 //! | `path` | path shape: `Root`, `Bucket` or `Object`; the checker substitutes fixed concrete values (`bucket`, `key.txt`) |
-//! | `qs` | ordered query pairs `[[k, v], ...]`; `[]` means the query string is present but empty, `null` means it is absent entirely. Order and duplicates are significant because some rules distinguish duplicate keys |
+//! | `qs` | query pairs `[[k, v], ...]`; `[]` means the query string is present but empty, `null` means it is absent entirely. Pairs are stored as a list because duplicate keys are significant (see the `duplicate:` cases). The checker feeds them through [`OrderedQs`](crate::http::OrderedQs), which stable-sorts by key, so cross-key order carries no meaning and values must already be URL-decoded |
 //! | `headers` | the request headers consulted by the router (e.g. `x-amz-copy-source`) |
-//! | `expect` | expected operation name; `__NOT_IMPLEMENTED__` means the router must reject the request |
+//! | `expect` | expected operation name; `__NOT_IMPLEMENTED__` means the router must reject the request. This is a frozen answer, not a placeholder (placeholders use the `__CAPTURE__` prefix, see below) |
 //! | `nfb` | expected `needs_full_body` flag |
 //! | `note` | provenance label: which generated rule (or variant) the sample exercises |
 //!
@@ -41,10 +41,12 @@
 //! # Capture mode
 //!
 //! With `ROUTE_FIXTURE_CAPTURE=1` the test rewrites placeholder expectations
-//! (`expect == "__..."`) with the current router's answer and writes the file
-//! back. After an intentional router change, reset the affected entries to
-//! placeholders and re-capture; entries with real expectations are left
-//! untouched and skipped.
+//! (`expect` prefixed with `__CAPTURE__`) with the current router's answer and
+//! writes the file back. After an intentional router change, reset the affected
+//! entries to `__CAPTURE__` placeholders and re-capture; all other entries —
+//! including frozen rejects (`__NOT_IMPLEMENTED__`) — are left untouched and
+//! skipped. A dedicated prefix keeps the two distinguishable, so capture never
+//! silently rewrites frozen expectations.
 //!
 //! # Placement
 //!
@@ -99,10 +101,11 @@ fn s3_path(path: &str) -> S3Path {
     match path {
         "Root" => S3Path::Root,
         "Bucket" => S3Path::Bucket { bucket: "bucket".into() },
-        _ => S3Path::Object {
+        "Object" => S3Path::Object {
             bucket: "bucket".into(),
             key: "key.txt".into(),
         },
+        other => panic!("unknown path kind in fixture: {other}"),
     }
 }
 
@@ -137,7 +140,7 @@ fn route_fixtures_match() {
         };
 
         if capture {
-            if !fx.expect_op.starts_with("__") {
+            if !fx.expect_op.starts_with("__CAPTURE__") {
                 continue;
             }
             let entry = raw.as_mut().unwrap().get_mut(idx).unwrap();

--- a/crates/s3s/src/ops/route_fixture_check.rs
+++ b/crates/s3s/src/ops/route_fixture_check.rs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-2026 The s3s Authors
+
+//! Equivalence fixtures for [`crate::ops::generated::resolve_route`].
+//!
+//! `route_fixtures.json` records, for each request sample, the operation the
+//! router must return together with its `needs_full_body` flag. The data was
+//! captured from the current generated router and must keep passing against
+//! any future router implementation.
+//!
+//! # Data format
+//!
+//! `route_fixtures.json` is a list of request samples. Each entry records one
+//! routing decision: the inputs handed to `resolve_route` and the expected
+//! answer (operation name plus `needs_full_body` flag).
+//!
+//! | field | meaning |
+//! |---|---|
+//! | `method` | HTTP method |
+//! | `path` | path shape: `Root`, `Bucket` or `Object`; the checker substitutes fixed concrete values (`bucket`, `key.txt`) |
+//! | `qs` | ordered query pairs `[[k, v], ...]`; `[]` means the query string is present but empty, `null` means it is absent entirely. Order and duplicates are significant because some rules distinguish duplicate keys |
+//! | `headers` | the request headers consulted by the router (e.g. `x-amz-copy-source`) |
+//! | `expect` | expected operation name; `__NOT_IMPLEMENTED__` means the router must reject the request |
+//! | `nfb` | expected `needs_full_body` flag |
+//! | `note` | provenance label: which generated rule (or variant) the sample exercises |
+//!
+//! # Note conventions
+//!
+//! The `note` field is documentation only; the checker never parses it. It
+//! mirrors the generated router's rule conditions:
+//!
+//! - `if:<cond>`: a minimal sample satisfying the rule `<cond>`
+//! - `noise:<cond>`: the same sample plus a noise key (`prefix=zz`) that must not change the outcome
+//! - `neg-hit:<cond>`: a sample that specifically takes the negated arm of `<cond>` (e.g. `qs.has("analytics") && !qs.has("id")`)
+//! - `wrong-pattern:<key>`: a pattern rule fails because the value is wrong, so routing falls through
+//! - `duplicate:<key>`: a pattern rule fails because the key appears more than once, so routing falls through
+//! - `fallback-empty-qs`: no rule matched; the default operation of the (method, path) group is expected
+//! - `tail:`: a tail rule of the generated chain (HEAD groups)
+//! - `|null-qs` suffix: the same sample with the query string absent (`qs: null`)
+//!
+//! # Capture mode
+//!
+//! With `ROUTE_FIXTURE_CAPTURE=1` the test rewrites placeholder expectations
+//! (`expect == "__..."`) with the current router's answer and writes the file
+//! back. After an intentional router change, reset the affected entries to
+//! placeholders and re-capture; entries with real expectations are left
+//! untouched and skipped.
+//!
+//! # Placement
+//!
+//! This module lives inside the crate because `resolve_route` and the request
+//! types it takes are crate-private, so an integration test could not call
+//! them. Same rationale as the `route_bench` module.
+
+use crate::error::S3Result;
+use crate::http::{OrderedQs, Request};
+use crate::path::S3Path;
+use std::sync::OnceLock;
+
+const FIXTURES_JSON: &str = include_str!("route_fixtures.json");
+
+struct Fixture {
+    method: String,
+    path: String,
+    qs: Option<Vec<(String, String)>>,
+    headers: std::collections::HashMap<String, String>,
+    expect_op: String,
+    expect_nfb: bool,
+}
+
+fn fixtures() -> &'static Vec<Fixture> {
+    static CACHE: OnceLock<Vec<Fixture>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        #[derive(serde::Deserialize)]
+        struct Raw {
+            method: String,
+            path: String,
+            qs: Option<Vec<(String, String)>>,
+            #[serde(default)]
+            headers: std::collections::HashMap<String, String>,
+            expect: String,
+            nfb: bool,
+        }
+        let raw: Vec<Raw> = serde_json::from_str(FIXTURES_JSON).unwrap();
+        raw.into_iter()
+            .map(|r| Fixture {
+                method: r.method,
+                path: r.path,
+                qs: r.qs,
+                headers: r.headers,
+                expect_op: r.expect,
+                expect_nfb: r.nfb,
+            })
+            .collect()
+    })
+}
+
+fn s3_path(path: &str) -> S3Path {
+    match path {
+        "Root" => S3Path::Root,
+        "Bucket" => S3Path::Bucket { bucket: "bucket".into() },
+        _ => S3Path::Object {
+            bucket: "bucket".into(),
+            key: "key.txt".into(),
+        },
+    }
+}
+
+fn make_request(method: &str, headers: &std::collections::HashMap<String, String>) -> Request {
+    let mut builder = hyper::Request::builder()
+        .method(method.parse::<hyper::Method>().unwrap())
+        .uri("http://localhost/bucket");
+    for (k, v) in headers {
+        builder = builder.header(k, v);
+    }
+    Request::from(builder.body(crate::http::Body::empty()).unwrap())
+}
+
+fn resolve_current(fx: &Fixture) -> S3Result<(&'static dyn super::Operation, bool)> {
+    let req = make_request(&fx.method, &fx.headers);
+    let path = s3_path(&fx.path);
+    let qs = fx.qs.as_ref().map(|pairs| OrderedQs::from_vec_unchecked(pairs.clone()));
+    crate::ops::generated::resolve_route(&req, &path, qs.as_ref())
+}
+
+#[test]
+fn route_fixtures_match() {
+    let capture = std::env::var("ROUTE_FIXTURE_CAPTURE").is_ok_and(|v| v == "1");
+    let fixtures = fixtures();
+    let mut raw: Option<Vec<serde_json::Value>> = capture.then(|| serde_json::from_str(FIXTURES_JSON).unwrap());
+    let mut mismatches = Vec::new();
+
+    for (idx, fx) in fixtures.iter().enumerate() {
+        let (got_op, got_nfb) = match resolve_current(fx) {
+            Ok((op, nfb)) => (op.name().to_string(), nfb),
+            Err(_) => ("__NOT_IMPLEMENTED__".to_string(), false),
+        };
+
+        if capture {
+            if !fx.expect_op.starts_with("__") {
+                continue;
+            }
+            let entry = raw.as_mut().unwrap().get_mut(idx).unwrap();
+            entry["expect"] = serde_json::json!(got_op);
+            entry["nfb"] = serde_json::json!(got_nfb);
+        } else {
+            if got_op != fx.expect_op {
+                mismatches.push(format!("{} {} {:?}: got {}, want {}", fx.method, fx.path, fx.qs, got_op, fx.expect_op));
+            }
+            if got_nfb != fx.expect_nfb {
+                mismatches.push(format!(
+                    "{} {} {:?}: needs_full_body got {}, want {}",
+                    fx.method, fx.path, fx.qs, got_nfb, fx.expect_nfb
+                ));
+            }
+        }
+    }
+
+    if capture {
+        std::fs::write(
+            concat!(env!("CARGO_MANIFEST_DIR"), "/src/ops/route_fixtures.json"),
+            serde_json::to_string_pretty(raw.as_ref().unwrap()).unwrap(),
+        )
+        .unwrap();
+        println!("captured {} fixtures", fixtures.len());
+        return;
+    }
+
+    assert!(mismatches.is_empty(), "route fixture mismatches:\n{}", mismatches.join("\n"));
+}

--- a/crates/s3s/src/ops/route_fixtures.json
+++ b/crates/s3s/src/ops/route_fixtures.json
@@ -1,0 +1,3395 @@
+[
+ {
+  "expect": "__NOT_IMPLEMENTED__",
+  "headers": {},
+  "method": "HEAD",
+  "nfb": false,
+  "note": "fallback-empty-qs",
+  "path": "Root",
+  "qs": []
+ },
+ {
+  "expect": "HeadBucket",
+  "headers": {},
+  "method": "HEAD",
+  "nfb": false,
+  "note": "tail:",
+  "path": "Bucket",
+  "qs": []
+ },
+ {
+  "expect": "HeadBucket",
+  "headers": {},
+  "method": "HEAD",
+  "nfb": false,
+  "note": "fallback-empty-qs",
+  "path": "Bucket",
+  "qs": []
+ },
+ {
+  "expect": "HeadObject",
+  "headers": {},
+  "method": "HEAD",
+  "nfb": false,
+  "note": "tail:",
+  "path": "Object",
+  "qs": []
+ },
+ {
+  "expect": "HeadObject",
+  "headers": {},
+  "method": "HEAD",
+  "nfb": false,
+  "note": "fallback-empty-qs",
+  "path": "Object",
+  "qs": []
+ },
+ {
+  "expect": "ListDirectoryBuckets",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:super::check_query_pattern(qs, \"x-id\", \"ListDirectoryBuckets\")",
+  "path": "Root",
+  "qs": [
+   [
+    "x-id",
+    "ListDirectoryBuckets"
+   ]
+  ]
+ },
+ {
+  "expect": "ListBuckets",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "wrong-pattern:x-id",
+  "path": "Root",
+  "qs": [
+   [
+    "x-id",
+    "ListDirectoryBucketsX"
+   ]
+  ]
+ },
+ {
+  "expect": "ListBuckets",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "duplicate:x-id",
+  "path": "Root",
+  "qs": [
+   [
+    "x-id",
+    "ListDirectoryBuckets"
+   ],
+   [
+    "x-id",
+    "ListDirectoryBuckets"
+   ],
+   [
+    "x-id",
+    "ListDirectoryBucketsX"
+   ]
+  ]
+ },
+ {
+  "expect": "ListDirectoryBuckets",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:super::check_query_pattern(qs, \"x-id\", \"ListDirectoryBuckets\")",
+  "path": "Root",
+  "qs": [
+   [
+    "x-id",
+    "ListDirectoryBuckets"
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "ListBuckets",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "fallback-empty-qs",
+  "path": "Root",
+  "qs": []
+ },
+ {
+  "expect": "GetBucketAnalyticsConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"analytics\") && qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "analytics",
+    ""
+   ],
+   [
+    "id",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketAnalyticsConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"analytics\") && qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "analytics",
+    ""
+   ],
+   [
+    "id",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketIntelligentTieringConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"intelligent-tiering\") && qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "intelligent-tiering",
+    ""
+   ],
+   [
+    "id",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketIntelligentTieringConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"intelligent-tiering\") && qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "intelligent-tiering",
+    ""
+   ],
+   [
+    "id",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketInventoryConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"inventory\") && qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "inventory",
+    ""
+   ],
+   [
+    "id",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketInventoryConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"inventory\") && qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "inventory",
+    ""
+   ],
+   [
+    "id",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketMetricsConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"metrics\") && qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metrics",
+    ""
+   ],
+   [
+    "id",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketMetricsConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"metrics\") && qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metrics",
+    ""
+   ],
+   [
+    "id",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "CreateSession",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"session\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "session",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "CreateSession",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"session\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "session",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketAccelerateConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"accelerate\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "accelerate",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketAccelerateConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"accelerate\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "accelerate",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketAcl",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"acl\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "acl",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketAcl",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"acl\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "acl",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketCors",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"cors\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "cors",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketCors",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"cors\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "cors",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketEncryption",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"encryption\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "encryption",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketEncryption",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"encryption\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "encryption",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketLifecycleConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"lifecycle\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "lifecycle",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketLifecycleConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"lifecycle\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "lifecycle",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketLocation",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"location\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "location",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketLocation",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"location\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "location",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketLogging",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"logging\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "logging",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketLogging",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"logging\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "logging",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketMetadataTableConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"metadataTable\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataTable",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketMetadataTableConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"metadataTable\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataTable",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketNotificationConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"notification\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "notification",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketNotificationConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"notification\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "notification",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketOwnershipControls",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"ownershipControls\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "ownershipControls",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketOwnershipControls",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"ownershipControls\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "ownershipControls",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketPolicy",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"policy\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "policy",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketPolicy",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"policy\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "policy",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketPolicyStatus",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"policyStatus\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "policyStatus",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketPolicyStatus",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"policyStatus\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "policyStatus",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketReplication",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"replication\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "replication",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketReplication",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"replication\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "replication",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketRequestPayment",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"requestPayment\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "requestPayment",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketRequestPayment",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"requestPayment\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "requestPayment",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketTagging",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"tagging\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "tagging",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketTagging",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"tagging\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "tagging",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketVersioning",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"versioning\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "versioning",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketVersioning",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"versioning\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "versioning",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketWebsite",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"website\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "website",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketWebsite",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"website\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "website",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetObjectLockConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"object-lock\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "object-lock",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetObjectLockConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"object-lock\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "object-lock",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetPublicAccessBlock",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"publicAccessBlock\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "publicAccessBlock",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetPublicAccessBlock",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"publicAccessBlock\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "publicAccessBlock",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "ListBucketAnalyticsConfigurations",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"analytics\") && !qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "analytics",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketAnalyticsConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "neg-hit:qs.has(\"analytics\") && !qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "analytics",
+    ""
+   ],
+   [
+    "id",
+    "x"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketAnalyticsConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"analytics\") && !qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "analytics",
+    ""
+   ],
+   [
+    "id",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "ListBucketIntelligentTieringConfigurations",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"intelligent-tiering\") && !qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "intelligent-tiering",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketIntelligentTieringConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "neg-hit:qs.has(\"intelligent-tiering\") && !qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "intelligent-tiering",
+    ""
+   ],
+   [
+    "id",
+    "x"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketIntelligentTieringConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"intelligent-tiering\") && !qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "intelligent-tiering",
+    ""
+   ],
+   [
+    "id",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "ListBucketInventoryConfigurations",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"inventory\") && !qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "inventory",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketInventoryConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "neg-hit:qs.has(\"inventory\") && !qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "inventory",
+    ""
+   ],
+   [
+    "id",
+    "x"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketInventoryConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"inventory\") && !qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "inventory",
+    ""
+   ],
+   [
+    "id",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "ListBucketMetricsConfigurations",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"metrics\") && !qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metrics",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketMetricsConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "neg-hit:qs.has(\"metrics\") && !qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metrics",
+    ""
+   ],
+   [
+    "id",
+    "x"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketMetricsConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"metrics\") && !qs.has(\"id\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metrics",
+    ""
+   ],
+   [
+    "id",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "ListMultipartUploads",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"uploads\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "uploads",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "ListMultipartUploads",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"uploads\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "uploads",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "ListObjectVersions",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"versions\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "versions",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "ListObjectVersions",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"versions\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "versions",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "ListObjectsV2",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:super::check_query_pattern(qs, \"list-type\", \"2\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "list-type",
+    "2"
+   ]
+  ]
+ },
+ {
+  "expect": "ListObjects",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "wrong-pattern:list-type",
+  "path": "Bucket",
+  "qs": [
+   [
+    "list-type",
+    "2X"
+   ]
+  ]
+ },
+ {
+  "expect": "ListObjects",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "duplicate:list-type",
+  "path": "Bucket",
+  "qs": [
+   [
+    "list-type",
+    "2"
+   ],
+   [
+    "list-type",
+    "2"
+   ],
+   [
+    "list-type",
+    "2X"
+   ]
+  ]
+ },
+ {
+  "expect": "ListObjectsV2",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:super::check_query_pattern(qs, \"list-type\", \"2\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "list-type",
+    "2"
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "ListObjects",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "fallback-empty-qs",
+  "path": "Bucket",
+  "qs": []
+ },
+ {
+  "expect": "GetObjectAttributes",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"attributes\")",
+  "path": "Object",
+  "qs": [
+   [
+    "attributes",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetObjectAttributes",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"attributes\")",
+  "path": "Object",
+  "qs": [
+   [
+    "attributes",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetObjectAcl",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"acl\")",
+  "path": "Object",
+  "qs": [
+   [
+    "acl",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetObjectAcl",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"acl\")",
+  "path": "Object",
+  "qs": [
+   [
+    "acl",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetObjectLegalHold",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"legal-hold\")",
+  "path": "Object",
+  "qs": [
+   [
+    "legal-hold",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetObjectLegalHold",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"legal-hold\")",
+  "path": "Object",
+  "qs": [
+   [
+    "legal-hold",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetObjectRetention",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"retention\")",
+  "path": "Object",
+  "qs": [
+   [
+    "retention",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetObjectRetention",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"retention\")",
+  "path": "Object",
+  "qs": [
+   [
+    "retention",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetObjectTagging",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"tagging\")",
+  "path": "Object",
+  "qs": [
+   [
+    "tagging",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetObjectTagging",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"tagging\")",
+  "path": "Object",
+  "qs": [
+   [
+    "tagging",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetObjectTorrent",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"torrent\")",
+  "path": "Object",
+  "qs": [
+   [
+    "torrent",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetObjectTorrent",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"torrent\")",
+  "path": "Object",
+  "qs": [
+   [
+    "torrent",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "ListParts",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:let Some(qs) = qs && qs.has(\"uploadId\")",
+  "path": "Object",
+  "qs": [
+   [
+    "uploadId",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "ListParts",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:let Some(qs) = qs && qs.has(\"uploadId\")",
+  "path": "Object",
+  "qs": [
+   [
+    "uploadId",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetObject",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "fallback-empty-qs",
+  "path": "Object",
+  "qs": []
+ },
+ {
+  "expect": "__NOT_IMPLEMENTED__",
+  "headers": {},
+  "method": "POST",
+  "nfb": false,
+  "note": "fallback-empty-qs",
+  "path": "Root",
+  "qs": []
+ },
+ {
+  "expect": "CreateBucketMetadataTableConfiguration",
+  "headers": {},
+  "method": "POST",
+  "nfb": true,
+  "note": "if:qs.has(\"metadataTable\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataTable",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "CreateBucketMetadataTableConfiguration",
+  "headers": {},
+  "method": "POST",
+  "nfb": true,
+  "note": "noise:qs.has(\"metadataTable\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataTable",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteObjects",
+  "headers": {},
+  "method": "POST",
+  "nfb": true,
+  "note": "if:qs.has(\"delete\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "delete",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteObjects",
+  "headers": {},
+  "method": "POST",
+  "nfb": true,
+  "note": "noise:qs.has(\"delete\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "delete",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "WriteGetObjectResponse",
+  "headers": {
+   "x-amz-request-route": "1",
+   "x-amz-request-token": "1"
+  },
+  "method": "POST",
+  "nfb": false,
+  "note": "if:req.headers.contains_key(\"x-amz-request-route\") && req.headers.contains_key(\"x-amz-request-token\")",
+  "path": "Bucket",
+  "qs": []
+ },
+ {
+  "expect": "WriteGetObjectResponse",
+  "headers": {
+   "x-amz-request-route": "1",
+   "x-amz-request-token": "1"
+  },
+  "method": "POST",
+  "nfb": false,
+  "note": "noise:req.headers.contains_key(\"x-amz-request-route\") && req.headers.contains_key(\"x-amz-request-token\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "__NOT_IMPLEMENTED__",
+  "headers": {},
+  "method": "POST",
+  "nfb": false,
+  "note": "fallback-empty-qs",
+  "path": "Bucket",
+  "qs": []
+ },
+ {
+  "expect": "SelectObjectContent",
+  "headers": {},
+  "method": "POST",
+  "nfb": true,
+  "note": "if:qs.has(\"select\") && super::check_query_pattern(qs, \"select-type\", \"2\")",
+  "path": "Object",
+  "qs": [
+   [
+    "select",
+    ""
+   ],
+   [
+    "select-type",
+    "2"
+   ]
+  ]
+ },
+ {
+  "expect": "__NOT_IMPLEMENTED__",
+  "headers": {},
+  "method": "POST",
+  "nfb": false,
+  "note": "wrong-pattern:select-type",
+  "path": "Object",
+  "qs": [
+   [
+    "select-type",
+    "2X"
+   ]
+  ]
+ },
+ {
+  "expect": "__NOT_IMPLEMENTED__",
+  "headers": {},
+  "method": "POST",
+  "nfb": false,
+  "note": "duplicate:select-type",
+  "path": "Object",
+  "qs": [
+   [
+    "select",
+    ""
+   ],
+   [
+    "select-type",
+    "2"
+   ],
+   [
+    "select-type",
+    "2"
+   ],
+   [
+    "select-type",
+    "2X"
+   ]
+  ]
+ },
+ {
+  "expect": "SelectObjectContent",
+  "headers": {},
+  "method": "POST",
+  "nfb": true,
+  "note": "noise:qs.has(\"select\") && super::check_query_pattern(qs, \"select-type\", \"2\")",
+  "path": "Object",
+  "qs": [
+   [
+    "select",
+    ""
+   ],
+   [
+    "select-type",
+    "2"
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "CreateMultipartUpload",
+  "headers": {},
+  "method": "POST",
+  "nfb": false,
+  "note": "if:qs.has(\"uploads\")",
+  "path": "Object",
+  "qs": [
+   [
+    "uploads",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "CreateMultipartUpload",
+  "headers": {},
+  "method": "POST",
+  "nfb": false,
+  "note": "noise:qs.has(\"uploads\")",
+  "path": "Object",
+  "qs": [
+   [
+    "uploads",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "RestoreObject",
+  "headers": {},
+  "method": "POST",
+  "nfb": true,
+  "note": "if:qs.has(\"restore\")",
+  "path": "Object",
+  "qs": [
+   [
+    "restore",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "RestoreObject",
+  "headers": {},
+  "method": "POST",
+  "nfb": true,
+  "note": "noise:qs.has(\"restore\")",
+  "path": "Object",
+  "qs": [
+   [
+    "restore",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "CompleteMultipartUpload",
+  "headers": {},
+  "method": "POST",
+  "nfb": true,
+  "note": "if:let Some(qs) = qs && qs.has(\"uploadId\")",
+  "path": "Object",
+  "qs": [
+   [
+    "uploadId",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "CompleteMultipartUpload",
+  "headers": {},
+  "method": "POST",
+  "nfb": true,
+  "note": "noise:let Some(qs) = qs && qs.has(\"uploadId\")",
+  "path": "Object",
+  "qs": [
+   [
+    "uploadId",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "__NOT_IMPLEMENTED__",
+  "headers": {},
+  "method": "POST",
+  "nfb": false,
+  "note": "fallback-empty-qs",
+  "path": "Object",
+  "qs": []
+ },
+ {
+  "expect": "__NOT_IMPLEMENTED__",
+  "headers": {},
+  "method": "PUT",
+  "nfb": false,
+  "note": "fallback-empty-qs",
+  "path": "Root",
+  "qs": []
+ },
+ {
+  "expect": "PutBucketAnalyticsConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"analytics\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "analytics",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketAnalyticsConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"analytics\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "analytics",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketIntelligentTieringConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"intelligent-tiering\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "intelligent-tiering",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketIntelligentTieringConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"intelligent-tiering\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "intelligent-tiering",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketInventoryConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"inventory\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "inventory",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketInventoryConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"inventory\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "inventory",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketMetricsConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"metrics\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metrics",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketMetricsConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"metrics\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metrics",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketAccelerateConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"accelerate\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "accelerate",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketAccelerateConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"accelerate\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "accelerate",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketAcl",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"acl\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "acl",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketAcl",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"acl\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "acl",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketCors",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"cors\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "cors",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketCors",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"cors\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "cors",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketEncryption",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"encryption\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "encryption",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketEncryption",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"encryption\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "encryption",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketLifecycleConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"lifecycle\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "lifecycle",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketLifecycleConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"lifecycle\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "lifecycle",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketLogging",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"logging\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "logging",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketLogging",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"logging\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "logging",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketNotificationConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"notification\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "notification",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketNotificationConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"notification\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "notification",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketOwnershipControls",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"ownershipControls\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "ownershipControls",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketOwnershipControls",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"ownershipControls\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "ownershipControls",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketPolicy",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"policy\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "policy",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketPolicy",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"policy\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "policy",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketReplication",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"replication\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "replication",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketReplication",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"replication\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "replication",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketRequestPayment",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"requestPayment\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "requestPayment",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketRequestPayment",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"requestPayment\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "requestPayment",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketTagging",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"tagging\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "tagging",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketTagging",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"tagging\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "tagging",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketVersioning",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"versioning\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "versioning",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketVersioning",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"versioning\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "versioning",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketWebsite",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"website\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "website",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketWebsite",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"website\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "website",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutObjectLockConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"object-lock\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "object-lock",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutObjectLockConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"object-lock\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "object-lock",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutPublicAccessBlock",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"publicAccessBlock\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "publicAccessBlock",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutPublicAccessBlock",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"publicAccessBlock\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "publicAccessBlock",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "CreateBucket",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "fallback-empty-qs",
+  "path": "Bucket",
+  "qs": []
+ },
+ {
+  "expect": "PutObjectAcl",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"acl\")",
+  "path": "Object",
+  "qs": [
+   [
+    "acl",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutObjectAcl",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"acl\")",
+  "path": "Object",
+  "qs": [
+   [
+    "acl",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutObjectLegalHold",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"legal-hold\")",
+  "path": "Object",
+  "qs": [
+   [
+    "legal-hold",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutObjectLegalHold",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"legal-hold\")",
+  "path": "Object",
+  "qs": [
+   [
+    "legal-hold",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutObjectRetention",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"retention\")",
+  "path": "Object",
+  "qs": [
+   [
+    "retention",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutObjectRetention",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"retention\")",
+  "path": "Object",
+  "qs": [
+   [
+    "retention",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutObjectTagging",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"tagging\")",
+  "path": "Object",
+  "qs": [
+   [
+    "tagging",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutObjectTagging",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"tagging\")",
+  "path": "Object",
+  "qs": [
+   [
+    "tagging",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "UploadPartCopy",
+  "headers": {
+   "x-amz-copy-source": "1"
+  },
+  "method": "PUT",
+  "nfb": false,
+  "note": "if:let Some(qs) = qs && qs.has(\"partNumber\") && qs.has(\"uploadId\") && req.headers.contains_key(\"x-amz-copy-source\")",
+  "path": "Object",
+  "qs": [
+   [
+    "partNumber",
+    ""
+   ],
+   [
+    "uploadId",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "UploadPartCopy",
+  "headers": {
+   "x-amz-copy-source": "1"
+  },
+  "method": "PUT",
+  "nfb": false,
+  "note": "noise:let Some(qs) = qs && qs.has(\"partNumber\") && qs.has(\"uploadId\") && req.headers.contains_key(\"x-amz-copy-source\")",
+  "path": "Object",
+  "qs": [
+   [
+    "partNumber",
+    ""
+   ],
+   [
+    "uploadId",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "UploadPart",
+  "headers": {},
+  "method": "PUT",
+  "nfb": false,
+  "note": "if:let Some(qs) = qs && qs.has(\"partNumber\") && qs.has(\"uploadId\")",
+  "path": "Object",
+  "qs": [
+   [
+    "partNumber",
+    ""
+   ],
+   [
+    "uploadId",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "UploadPart",
+  "headers": {},
+  "method": "PUT",
+  "nfb": false,
+  "note": "noise:let Some(qs) = qs && qs.has(\"partNumber\") && qs.has(\"uploadId\")",
+  "path": "Object",
+  "qs": [
+   [
+    "partNumber",
+    ""
+   ],
+   [
+    "uploadId",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "CopyObject",
+  "headers": {
+   "x-amz-copy-source": "1"
+  },
+  "method": "PUT",
+  "nfb": false,
+  "note": "if:req.headers.contains_key(\"x-amz-copy-source\")",
+  "path": "Object",
+  "qs": []
+ },
+ {
+  "expect": "CopyObject",
+  "headers": {
+   "x-amz-copy-source": "1"
+  },
+  "method": "PUT",
+  "nfb": false,
+  "note": "noise:req.headers.contains_key(\"x-amz-copy-source\")",
+  "path": "Object",
+  "qs": [
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutObject",
+  "headers": {},
+  "method": "PUT",
+  "nfb": false,
+  "note": "fallback-empty-qs",
+  "path": "Object",
+  "qs": []
+ },
+ {
+  "expect": "__NOT_IMPLEMENTED__",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "fallback-empty-qs",
+  "path": "Root",
+  "qs": []
+ },
+ {
+  "expect": "DeleteBucketAnalyticsConfiguration",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:qs.has(\"analytics\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "analytics",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketAnalyticsConfiguration",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:qs.has(\"analytics\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "analytics",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketIntelligentTieringConfiguration",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:qs.has(\"intelligent-tiering\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "intelligent-tiering",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketIntelligentTieringConfiguration",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:qs.has(\"intelligent-tiering\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "intelligent-tiering",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketInventoryConfiguration",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:qs.has(\"inventory\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "inventory",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketInventoryConfiguration",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:qs.has(\"inventory\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "inventory",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketMetricsConfiguration",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:qs.has(\"metrics\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metrics",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketMetricsConfiguration",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:qs.has(\"metrics\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metrics",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketCors",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:qs.has(\"cors\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "cors",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketCors",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:qs.has(\"cors\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "cors",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketEncryption",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:qs.has(\"encryption\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "encryption",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketEncryption",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:qs.has(\"encryption\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "encryption",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketLifecycle",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:qs.has(\"lifecycle\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "lifecycle",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketLifecycle",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:qs.has(\"lifecycle\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "lifecycle",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketMetadataTableConfiguration",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:qs.has(\"metadataTable\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataTable",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketMetadataTableConfiguration",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:qs.has(\"metadataTable\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataTable",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketOwnershipControls",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:qs.has(\"ownershipControls\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "ownershipControls",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketOwnershipControls",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:qs.has(\"ownershipControls\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "ownershipControls",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketPolicy",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:qs.has(\"policy\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "policy",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketPolicy",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:qs.has(\"policy\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "policy",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketReplication",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:qs.has(\"replication\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "replication",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketReplication",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:qs.has(\"replication\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "replication",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketTagging",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:qs.has(\"tagging\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "tagging",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketTagging",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:qs.has(\"tagging\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "tagging",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketWebsite",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:qs.has(\"website\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "website",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketWebsite",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:qs.has(\"website\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "website",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeletePublicAccessBlock",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:qs.has(\"publicAccessBlock\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "publicAccessBlock",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeletePublicAccessBlock",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:qs.has(\"publicAccessBlock\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "publicAccessBlock",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucket",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "fallback-empty-qs",
+  "path": "Bucket",
+  "qs": []
+ },
+ {
+  "expect": "DeleteObjectTagging",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:qs.has(\"tagging\")",
+  "path": "Object",
+  "qs": [
+   [
+    "tagging",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteObjectTagging",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:qs.has(\"tagging\")",
+  "path": "Object",
+  "qs": [
+   [
+    "tagging",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "AbortMultipartUpload",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:let Some(qs) = qs && qs.has(\"uploadId\")",
+  "path": "Object",
+  "qs": [
+   [
+    "uploadId",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "AbortMultipartUpload",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:let Some(qs) = qs && qs.has(\"uploadId\")",
+  "path": "Object",
+  "qs": [
+   [
+    "uploadId",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteObject",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "fallback-empty-qs",
+  "path": "Object",
+  "qs": []
+ },
+ {
+  "expect": "__NOT_IMPLEMENTED__",
+  "headers": {},
+  "method": "HEAD",
+  "nfb": false,
+  "note": "fallback-empty-qs|null-qs",
+  "path": "Root",
+  "qs": null
+ },
+ {
+  "expect": "HeadBucket",
+  "headers": {},
+  "method": "HEAD",
+  "nfb": false,
+  "note": "tail:|null-qs",
+  "path": "Bucket",
+  "qs": null
+ },
+ {
+  "expect": "HeadObject",
+  "headers": {},
+  "method": "HEAD",
+  "nfb": false,
+  "note": "tail:|null-qs",
+  "path": "Object",
+  "qs": null
+ },
+ {
+  "expect": "ListBuckets",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "fallback-empty-qs|null-qs",
+  "path": "Root",
+  "qs": null
+ },
+ {
+  "expect": "ListObjects",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "fallback-empty-qs|null-qs",
+  "path": "Bucket",
+  "qs": null
+ },
+ {
+  "expect": "GetObject",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "fallback-empty-qs|null-qs",
+  "path": "Object",
+  "qs": null
+ },
+ {
+  "expect": "__NOT_IMPLEMENTED__",
+  "headers": {},
+  "method": "POST",
+  "nfb": false,
+  "note": "fallback-empty-qs|null-qs",
+  "path": "Root",
+  "qs": null
+ },
+ {
+  "expect": "WriteGetObjectResponse",
+  "headers": {
+   "x-amz-request-route": "1",
+   "x-amz-request-token": "1"
+  },
+  "method": "POST",
+  "nfb": false,
+  "note": "if:req.headers.contains_key(\"x-amz-request-route\") && req.headers.contains_key(\"x-amz-request-token\")|null-qs",
+  "path": "Bucket",
+  "qs": null
+ },
+ {
+  "expect": "__NOT_IMPLEMENTED__",
+  "headers": {},
+  "method": "POST",
+  "nfb": false,
+  "note": "fallback-empty-qs|null-qs",
+  "path": "Object",
+  "qs": null
+ },
+ {
+  "expect": "__NOT_IMPLEMENTED__",
+  "headers": {},
+  "method": "PUT",
+  "nfb": false,
+  "note": "fallback-empty-qs|null-qs",
+  "path": "Root",
+  "qs": null
+ },
+ {
+  "expect": "CreateBucket",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "fallback-empty-qs|null-qs",
+  "path": "Bucket",
+  "qs": null
+ },
+ {
+  "expect": "CopyObject",
+  "headers": {
+   "x-amz-copy-source": "1"
+  },
+  "method": "PUT",
+  "nfb": false,
+  "note": "if:req.headers.contains_key(\"x-amz-copy-source\")|null-qs",
+  "path": "Object",
+  "qs": null
+ },
+ {
+  "expect": "__NOT_IMPLEMENTED__",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "fallback-empty-qs|null-qs",
+  "path": "Root",
+  "qs": null
+ },
+ {
+  "expect": "DeleteBucket",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "fallback-empty-qs|null-qs",
+  "path": "Bucket",
+  "qs": null
+ },
+ {
+  "expect": "DeleteObject",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "fallback-empty-qs|null-qs",
+  "path": "Object",
+  "qs": null
+ }
+]


### PR DESCRIPTION

## Summary

Add an equivalence-fixture test for `resolve_route`: 220 request samples frozen as JSON, checked against the generated router's (operation, needs_full_body) answers. Routing changes currently ship with no exhaustive behavioral gate; this pins the current router's observable behavior so any future rework must prove equivalence.

## Design

- `crates/s3s/src/ops/route_fixtures.json` records, per sample: method, path kind (Root/Bucket/Object), ordered query pairs (or `null` for a missing query string), headers, expected operation (`__NOT_IMPLEMENTED__` when the router must reject), and the `needs_full_body` flag.
- `route_fixture_check.rs` (test-only module) parses the JSON once, builds a `Request`/`S3Path`/`OrderedQs` per sample, calls the private `resolve_route`, and diffs both the operation name and `needs_full_body`.
- Capture mode (`ROUTE_FIXTURE_CAPTURE=1`) rewrites placeholder expectations (`expect == "__..."`) with the current router's answers and writes the file back; entries with real expectations are skipped, so after an intentional router change the affected entries are reset to placeholders and re-captured.
- The JSON schema and the `note` label conventions are documented in the module docs of `route_fixture_check.rs`.
- Lives inside the crate, so the private `resolve_route` stays private; `serde_json` is already a regular dependency.

## Coverage

220 samples across all 15 (method × path) groups. Per routing rule: a minimally satisfying query, a noise-key companion, negation-family cases (`has("analytics") && !qs.has("id")` and friends), wrong-value and duplicate-key pattern cases (`list-type`, `select-type`, `x-id`), missing-header fallbacks (`x-amz-copy-source`, `x-amz-request-route`), and empty / null query variants (`?`, absent query string).

## Verification

- `just dev` passes (fmt, codegen idempotent, clippy workspace, full workspace test suite).
- `just spdx-check` passes.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p s3s --no-deps` passes.
- `cargo test -p s3s route_fixtures_match` passes: 220/220 against the current generated router.

