### PR TITLE
feat(data): refresh STS Smithy model from aws-sdk-rust

### DIFF
--- a/data/crawl.py
+++ b/data/crawl.py
@@ -43,7 +43,7 @@ def download_s3_model():
 @cli.command()
 def download_sts_model():
     # https://github.com/awslabs/aws-sdk-rust/commits/main/aws-models/sts.json
-    download_aws_sdk("sts", commit="13eb310a6cbb4912f0a44db2fb2fca0b2bfee5d1")
+    download_aws_sdk("sts", commit="97e6a2936175d03ec1de31284613e0ef94d2f9cb")
 
 
 @cli.command()

--- a/data/sts.json
+++ b/data/sts.json
@@ -55,10 +55,16 @@
                     "target": "com.amazonaws.sts#GetCallerIdentity"
                 },
                 {
+                    "target": "com.amazonaws.sts#GetDelegatedAccessToken"
+                },
+                {
                     "target": "com.amazonaws.sts#GetFederationToken"
                 },
                 {
                     "target": "com.amazonaws.sts#GetSessionToken"
+                },
+                {
+                    "target": "com.amazonaws.sts#GetWebIdentityToken"
                 }
             ],
             "traits": {
@@ -72,11 +78,424 @@
                 "aws.auth#sigv4": {
                     "name": "sts"
                 },
+                "aws.auth#sigv4a": {
+                    "name": "sts"
+                },
                 "aws.protocols#awsQuery": {},
+                "smithy.api#auth": [
+                    "aws.auth#sigv4",
+                    "aws.auth#sigv4a"
+                ],
                 "smithy.api#documentation": "<fullname>Security Token Service</fullname>\n         <p>Security Token Service (STS) enables you to request temporary, limited-privilege \n      credentials for users. This guide provides descriptions of the STS API. For \n      more information about using this service, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html\">Temporary Security Credentials</a>.</p>",
                 "smithy.api#title": "AWS Security Token Service",
                 "smithy.api#xmlNamespace": {
                     "uri": "https://sts.amazonaws.com/doc/2011-06-15/"
+                },
+                "smithy.rules#endpointBdd": {
+                    "version": "1.1",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "string"
+                        },
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "boolean"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "string"
+                        },
+                        "UseGlobalEndpoint": {
+                            "builtIn": "AWS::STS::UseGlobalEndpoint",
+                            "required": true,
+                            "default": false,
+                            "documentation": "Whether the global endpoint should be used, rather then the regional endpoint for us-east-1.",
+                            "type": "boolean"
+                        }
+                    },
+                    "conditions": [
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Endpoint"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "aws.partition",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ],
+                            "assign": "PartitionResult"
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseFIPS"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseDualStack"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "aws-global"
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseGlobalEndpoint"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "eu-central-1"
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsDualStack"
+                                    ]
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "supportsFIPS"
+                                    ]
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "ap-south-1"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "eu-north-1"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "eu-west-1"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "eu-west-2"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "eu-west-3"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "sa-east-1"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "us-east-1"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "us-east-2"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "us-west-2"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "us-west-1"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "ca-central-1"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "ap-southeast-1"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "ap-northeast-1"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "ap-southeast-2"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "PartitionResult"
+                                        },
+                                        "name"
+                                    ]
+                                },
+                                "aws-us-gov"
+                            ]
+                        }
+                    ],
+                    "results": [
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://sts.amazonaws.com",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "name": "sigv4",
+                                            "signingName": "sts",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://sts.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "name": "sigv4",
+                                            "signingName": "sts",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": {
+                                    "ref": "Endpoint"
+                                },
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://sts-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://sts.{Region}.amazonaws.com",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://sts-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "FIPS is enabled but this partition does not support FIPS",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://sts.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "DualStack is enabled but this partition does not support DualStack",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://sts.{Region}.{PartitionResult#dnsSuffix}",
+                                "properties": {},
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Configuration: Missing Region",
+                            "type": "error"
+                        }
+                    ],
+                    "root": 2,
+                    "nodeCount": 31,
+                    "nodes": "/////wAAAAH/////AAAAAAAAAB4AAAADAAAAAQAAAAQF9eEOAAAAAgAAAAUF9eEOAAAAAwAAABkAAAAGAAAABAAAABgAAAAHAAAABQX14QEAAAAIAAAABgAAAAkF9eENAAAABwX14QEAAAAKAAAACgX14QEAAAALAAAACwX14QEAAAAMAAAADAX14QEAAAANAAAADQX14QEAAAAOAAAADgX14QEAAAAPAAAADwX14QEAAAAQAAAAEAX14QEAAAARAAAAEQX14QEAAAASAAAAEgX14QEAAAATAAAAEwX14QEAAAAUAAAAFAX14QEAAAAVAAAAFQX14QEAAAAWAAAAFgX14QEAAAAXAAAAFwX14QEF9eECAAAACAX14QsF9eEMAAAABAAAABwAAAAaAAAACQAAABsF9eEKAAAAGAX14QgF9eEJAAAACAAAAB0F9eEHAAAACQX14QYF9eEHAAAAAwX14QMAAAAfAAAABAX14QQF9eEF"
                 },
                 "smithy.rules#endpointRuleSet": {
                     "version": "1.0",
@@ -85,34 +504,34 @@
                             "builtIn": "AWS::Region",
                             "required": false,
                             "documentation": "The AWS region used to dispatch the request.",
-                            "type": "String"
+                            "type": "string"
                         },
                         "UseDualStack": {
                             "builtIn": "AWS::UseDualStack",
                             "required": true,
                             "default": false,
                             "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
-                            "type": "Boolean"
+                            "type": "boolean"
                         },
                         "UseFIPS": {
                             "builtIn": "AWS::UseFIPS",
                             "required": true,
                             "default": false,
                             "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
-                            "type": "Boolean"
+                            "type": "boolean"
                         },
                         "Endpoint": {
                             "builtIn": "SDK::Endpoint",
                             "required": false,
                             "documentation": "Override the endpoint used to send this request",
-                            "type": "String"
+                            "type": "string"
                         },
                         "UseGlobalEndpoint": {
                             "builtIn": "AWS::STS::UseGlobalEndpoint",
                             "required": true,
                             "default": false,
                             "documentation": "Whether the global endpoint should be used, rather then the regional endpoint for us-east-1.",
-                            "type": "Boolean"
+                            "type": "boolean"
                         }
                     },
                     "rules": [
@@ -1522,17 +1941,6 @@
                             }
                         },
                         {
-                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
-                            },
-                            "params": {
-                                "Region": "us-iso-east-1",
-                                "UseFIPS": true,
-                                "UseDualStack": true
-                            }
-                        },
-                        {
                             "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
@@ -1543,17 +1951,6 @@
                                 "Region": "us-iso-east-1",
                                 "UseFIPS": true,
                                 "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "error": "DualStack is enabled but this partition does not support DualStack"
-                            },
-                            "params": {
-                                "Region": "us-iso-east-1",
-                                "UseFIPS": false,
-                                "UseDualStack": true
                             }
                         },
                         {
@@ -1570,17 +1967,6 @@
                             }
                         },
                         {
-                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
-                            },
-                            "params": {
-                                "Region": "us-isob-east-1",
-                                "UseFIPS": true,
-                                "UseDualStack": true
-                            }
-                        },
-                        {
                             "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
@@ -1591,17 +1977,6 @@
                                 "Region": "us-isob-east-1",
                                 "UseFIPS": true,
                                 "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "error": "DualStack is enabled but this partition does not support DualStack"
-                            },
-                            "params": {
-                                "Region": "us-isob-east-1",
-                                "UseFIPS": false,
-                                "UseDualStack": true
                             }
                         },
                         {
@@ -2280,7 +2655,7 @@
                         "input": {
                             "RoleArn": "arn:aws:iam::123456789012:role/demo",
                             "RoleSessionName": "testAssumeRoleSession",
-                            "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Action\":\"s3:ListAllMyBuckets\",\"Resource\":\"*\"}]}",
+                            "Policy": "escaped-JSON-IAM-POLICY",
                             "Tags": [
                                 {
                                     "Key": "Project",
@@ -2331,7 +2706,7 @@
                 "RoleSessionName": {
                     "target": "com.amazonaws.sts#roleSessionNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>An identifier for the assumed role session.</p>\n         <p>Use the role session name to uniquely identify a session when the same role is assumed\n         by different principals or for different reasons. In cross-account scenarios, the role\n         session name is visible to, and can be logged by the account that owns the role. The role\n         session name is also used in the ARN of the assumed role principal. This means that\n         subsequent cross-account API requests that use the temporary security credentials will\n         expose the role session name to the external account in their CloudTrail logs.</p>\n         <p>For security purposes, administrators can view this field in <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html#cloudtrail-integration_signin-tempcreds\">CloudTrail logs</a> to help identify who performed an action in Amazon Web Services. Your\n         administrator might require that you specify your user name as the session name when you\n         assume the role. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html#ck_rolesessionname\">\n               <code>sts:RoleSessionName</code>\n            </a>.</p>\n         <p>The regex used to validate this parameter is a string of characters \n    consisting of upper- and lower-case alphanumeric characters with no spaces. You can \n    also include underscores or any of the following characters: =,.@-</p>",
+                        "smithy.api#documentation": "<p>An identifier for the assumed role session.</p>\n         <p>Use the role session name to uniquely identify a session when the same role is assumed\n         by different principals or for different reasons. In cross-account scenarios, the role\n         session name is visible to, and can be logged by the account that owns the role. The role\n         session name is also used in the ARN of the assumed role principal. This means that\n         subsequent cross-account API requests that use the temporary security credentials will\n         expose the role session name to the external account in their CloudTrail logs.</p>\n         <p>For security purposes, administrators can view this field in <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html#cloudtrail-integration_signin-tempcreds\">CloudTrail logs</a> to help identify who performed an action in Amazon Web Services. Your\n         administrator might require that you specify your user name as the session name when you\n         assume the role. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html#ck_rolesessionname\">\n               <code>sts:RoleSessionName</code>\n            </a>.</p>\n         <p>The regex used to validate this parameter is a string of \n    characters consisting of upper- and lower-case alphanumeric characters with no spaces. \n    You can also include underscores or any of the following characters: +=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -2368,13 +2743,13 @@
                 "ExternalId": {
                     "target": "com.amazonaws.sts#externalIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>A unique identifier that might be required when you assume a role in another account. If\n         the administrator of the account to which the role belongs provided you with an external\n         ID, then provide that value in the <code>ExternalId</code> parameter. This value can be any\n         string, such as a passphrase or account number. A cross-account role is usually set up to\n         trust everyone in an account. Therefore, the administrator of the trusting account might\n         send an external ID to the administrator of the trusted account. That way, only someone\n         with the ID can assume the role, rather than everyone in the account. For more information\n         about the external ID, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html\">How to Use an External ID\n            When Granting Access to Your Amazon Web Services Resources to a Third Party</a> in the\n            <i>IAM User Guide</i>.</p>\n         <p>The regex used to validate this parameter is a string of \n    characters consisting of upper- and lower-case alphanumeric characters with no spaces. \n    You can also include underscores or any of the following characters: =,.@:/-</p>"
+                        "smithy.api#documentation": "<p>A unique identifier that might be required when you assume a role in another account. If\n         the administrator of the account to which the role belongs provided you with an external\n         ID, then provide that value in the <code>ExternalId</code> parameter. This value can be any\n         string, such as a passphrase or account number. A cross-account role is usually set up to\n         trust everyone in an account. Therefore, the administrator of the trusting account might\n         send an external ID to the administrator of the trusted account. That way, only someone\n         with the ID can assume the role, rather than everyone in the account. For more information\n         about the external ID, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html\">How to Use an External ID\n            When Granting Access to Your Amazon Web Services Resources to a Third Party</a> in the\n            <i>IAM User Guide</i>.</p>\n         <p>The regex used to validate this parameter is a string of \n    characters consisting of upper- and lower-case alphanumeric characters with no spaces. \n    You can also include underscores or any of the following characters: +=,.@:\\/-</p>"
                     }
                 },
                 "SerialNumber": {
                     "target": "com.amazonaws.sts#serialNumberType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The identification number of the MFA device that is associated with the user who is\n         making the <code>AssumeRole</code> call. Specify this value if the trust policy of the role\n         being assumed includes a condition that requires MFA authentication. The value is either\n         the serial number for a hardware device (such as <code>GAHT12345678</code>) or an Amazon\n         Resource Name (ARN) for a virtual device (such as\n            <code>arn:aws:iam::123456789012:mfa/user</code>).</p>\n         <p>The regex used to validate this parameter is a string of characters \n    consisting of upper- and lower-case alphanumeric characters with no spaces. You can \n    also include underscores or any of the following characters: =,.@-</p>"
+                        "smithy.api#documentation": "<p>The identification number of the MFA device that is associated with the user who is\n         making the <code>AssumeRole</code> call. Specify this value if the trust policy of the role\n         being assumed includes a condition that requires MFA authentication. The value is either\n         the serial number for a hardware device (such as <code>GAHT12345678</code>) or an Amazon\n         Resource Name (ARN) for a virtual device (such as\n            <code>arn:aws:iam::123456789012:mfa/user</code>).</p>\n         <p>The regex used to validate this parameter is a string of \n    characters consisting of upper- and lower-case alphanumeric characters with no spaces. \n    You can also include underscores or any of the following characters: +=/:,.@-</p>"
                     }
                 },
                 "TokenCode": {
@@ -2462,7 +2837,8 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns a set of temporary security credentials for users who have been authenticated\n         via a SAML authentication response. This operation provides a mechanism for tying an\n         enterprise identity store or directory to role-based Amazon Web Services access without user-specific\n         credentials or configuration. For a comparison of <code>AssumeRoleWithSAML</code> with the\n         other API operations that produce temporary credentials, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html\">Requesting Temporary Security\n            Credentials</a> and <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_sts-comparison.html\">Compare STS\n            credentials</a> in the <i>IAM User Guide</i>.</p>\n         <p>The temporary security credentials returned by this operation consist of an access key\n         ID, a secret access key, and a security token. Applications can use these temporary\n         security credentials to sign calls to Amazon Web Services services.</p>\n         <p>\n            <b>Session Duration</b>\n         </p>\n         <p>By default, the temporary security credentials created by\n            <code>AssumeRoleWithSAML</code> last for one hour. However, you can use the optional\n            <code>DurationSeconds</code> parameter to specify the duration of your session. Your\n         role session lasts for the duration that you specify, or until the time specified in the\n         SAML authentication response's <code>SessionNotOnOrAfter</code> value, whichever is\n         shorter. You can provide a <code>DurationSeconds</code> value from 900 seconds (15 minutes)\n         up to the maximum session duration setting for the role. This setting can have a value from\n         1 hour to 12 hours. To learn how to view the maximum value for your role, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session\">View the\n            Maximum Session Duration Setting for a Role</a> in the\n            <i>IAM User Guide</i>. The maximum session duration limit applies when\n         you use the <code>AssumeRole*</code> API operations or the <code>assume-role*</code> CLI\n         commands. However the limit does not apply when you use those operations to create a\n         console URL. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html\">Using IAM Roles</a> in the\n            <i>IAM User Guide</i>.</p>\n         <note>\n            <p>\n               <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#iam-term-role-chaining\">Role chaining</a> limits your CLI or Amazon Web Services API role\n            session to a maximum of one hour. When you use the <code>AssumeRole</code> API operation\n            to assume a role, you can specify the duration of your role session with the\n               <code>DurationSeconds</code> parameter. You can specify a parameter value of up to\n            43200 seconds (12 hours), depending on the maximum session duration setting for your\n            role. However, if you assume a role using role chaining and provide a\n               <code>DurationSeconds</code> parameter value greater than one hour, the operation\n            fails.</p>\n         </note>\n         <p>\n            <b>Permissions</b>\n         </p>\n         <p>The temporary security credentials created by <code>AssumeRoleWithSAML</code> can be\n         used to make API calls to any Amazon Web Services service with the following exception: you cannot call\n         the STS <code>GetFederationToken</code> or <code>GetSessionToken</code> API\n         operations.</p>\n         <p>(Optional) You can pass inline or managed <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session\">session policies</a> to\n         this operation. You can pass a single JSON policy document to use as an inline session\n         policy. You can also specify up to 10 managed policy Amazon Resource Names (ARNs) to use as\n         managed session policies. The plaintext that you use for both inline and managed session\n         policies can't exceed 2,048 characters. Passing policies to this operation returns new \n         temporary credentials. The resulting session's permissions are the intersection of the \n         role's identity-based policy and the session policies. You can use the role's temporary \n         credentials in subsequent Amazon Web Services API calls to access resources in the account that owns \n         the role. You cannot use session policies to grant more permissions than those allowed \n         by the identity-based policy of the role that is being assumed. For more information, see\n            <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session\">Session\n            Policies</a> in the <i>IAM User Guide</i>.</p>\n         <p>Calling <code>AssumeRoleWithSAML</code> does not require the use of Amazon Web Services security\n         credentials. The identity of the caller is validated by using keys in the metadata document\n         that is uploaded for the SAML provider entity for your identity provider. </p>\n         <important>\n            <p>Calling <code>AssumeRoleWithSAML</code> can result in an entry in your CloudTrail logs.\n            The entry includes the value in the <code>NameID</code> element of the SAML assertion.\n            We recommend that you use a <code>NameIDType</code> that is not associated with any\n            personally identifiable information (PII). For example, you could instead use the\n            persistent identifier\n            (<code>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</code>).</p>\n         </important>\n         <p>\n            <b>Tags</b>\n         </p>\n         <p>(Optional) You can configure your IdP to pass attributes into your SAML assertion as\n         session tags. Each session tag consists of a key name and an associated value. For more\n         information about session tags, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html\">Passing Session Tags in STS</a> in the\n            <i>IAM User Guide</i>.</p>\n         <p>You can pass up to 50 session tags. The plaintext session tag keys can’t exceed 128\n         characters and the values can’t exceed 256 characters. For these and additional limits, see\n            <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length\">IAM\n            and STS Character Limits</a> in the <i>IAM User Guide</i>.</p>\n         <note>\n            <p>An Amazon Web Services conversion compresses the passed inline session policy, managed policy ARNs,\n            and session tags into a packed binary format that has a separate limit. Your request can\n            fail for this limit even if your plaintext meets the other requirements. The\n               <code>PackedPolicySize</code> response element indicates by percentage how close the\n            policies and tags for your request are to the upper size limit.</p>\n         </note>\n         <p>You can pass a session tag with the same key as a tag that is attached to the role. When\n         you do, session tags override the role's tags with the same key.</p>\n         <p>An administrator must grant you the permissions necessary to pass session tags. The\n         administrator can also create granular permissions to allow you to pass only specific\n         session tags. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html\">Tutorial: Using Tags\n            for Attribute-Based Access Control</a> in the\n         <i>IAM User Guide</i>.</p>\n         <p>You can set the session tags as transitive. Transitive tags persist during role\n         chaining. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_role-chaining\">Chaining Roles\n            with Session Tags</a> in the <i>IAM User Guide</i>.</p>\n         <p>\n            <b>SAML Configuration</b>\n         </p>\n         <p>Before your application can call <code>AssumeRoleWithSAML</code>, you must configure\n         your SAML identity provider (IdP) to issue the claims required by Amazon Web Services. Additionally, you\n         must use Identity and Access Management (IAM) to create a SAML provider entity in your Amazon Web Services account that\n         represents your identity provider. You must also create an IAM role that specifies this\n         SAML provider in its trust policy. </p>\n         <p>For more information, see the following resources:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_saml.html\">About\n                  SAML 2.0-based Federation</a> in the <i>IAM User Guide</i>.\n            </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml.html\">Creating SAML Identity Providers</a> in the\n                  <i>IAM User Guide</i>. </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_relying-party.html\">Configuring\n                  a Relying Party and Claims</a> in the <i>IAM User Guide</i>.\n            </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_saml.html\">Creating a Role for SAML 2.0 Federation</a> in the\n                  <i>IAM User Guide</i>. </p>\n            </li>\n         </ul>",
+                "smithy.api#auth": [],
+                "smithy.api#documentation": "<p>Returns a set of temporary security credentials for users who have been authenticated\n         via a SAML authentication response. This operation provides a mechanism for tying an\n         enterprise identity store or directory to role-based Amazon Web Services access without user-specific\n         credentials or configuration. For a comparison of <code>AssumeRoleWithSAML</code> with the\n         other API operations that produce temporary credentials, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html\">Requesting Temporary Security\n            Credentials</a> and <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_sts-comparison.html\">Compare STS\n            credentials</a> in the <i>IAM User Guide</i>.</p>\n         <p>The temporary security credentials returned by this operation consist of an access key\n         ID, a secret access key, and a security token. Applications can use these temporary\n         security credentials to sign calls to Amazon Web Services services.</p>\n         <note>\n            <p>AssumeRoleWithSAML will not work on IAM Identity Center managed roles. These roles' names start\n            with <code>AWSReservedSSO_</code>.</p>\n         </note>\n         <p>\n            <b>Session Duration</b>\n         </p>\n         <p>By default, the temporary security credentials created by\n            <code>AssumeRoleWithSAML</code> last for one hour. However, you can use the optional\n            <code>DurationSeconds</code> parameter to specify the duration of your session. Your\n         role session lasts for the duration that you specify, or until the time specified in the\n         SAML authentication response's <code>SessionNotOnOrAfter</code> value, whichever is\n         shorter. You can provide a <code>DurationSeconds</code> value from 900 seconds (15 minutes)\n         up to the maximum session duration setting for the role. This setting can have a value from\n         1 hour to 12 hours. To learn how to view the maximum value for your role, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html#id_roles_use_view-role-max-session\">View the\n            Maximum Session Duration Setting for a Role</a> in the\n            <i>IAM User Guide</i>. The maximum session duration limit applies when\n         you use the <code>AssumeRole*</code> API operations or the <code>assume-role*</code> CLI\n         commands. However the limit does not apply when you use those operations to create a\n         console URL. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html\">Using IAM Roles</a> in the\n            <i>IAM User Guide</i>.</p>\n         <note>\n            <p>\n               <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#iam-term-role-chaining\">Role chaining</a> limits your CLI or Amazon Web Services API role\n            session to a maximum of one hour. When you use the <code>AssumeRole</code> API operation\n            to assume a role, you can specify the duration of your role session with the\n               <code>DurationSeconds</code> parameter. You can specify a parameter value of up to\n            43200 seconds (12 hours), depending on the maximum session duration setting for your\n            role. However, if you assume a role using role chaining and provide a\n               <code>DurationSeconds</code> parameter value greater than one hour, the operation\n            fails.</p>\n         </note>\n         <p>\n            <b>Permissions</b>\n         </p>\n         <p>The temporary security credentials created by <code>AssumeRoleWithSAML</code> can be\n         used to make API calls to any Amazon Web Services service with the following exception: you cannot call\n         the STS <code>GetFederationToken</code> or <code>GetSessionToken</code> API\n         operations.</p>\n         <p>(Optional) You can pass inline or managed <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session\">session policies</a> to\n         this operation. You can pass a single JSON policy document to use as an inline session\n         policy. You can also specify up to 10 managed policy Amazon Resource Names (ARNs) to use as\n         managed session policies. The plaintext that you use for both inline and managed session\n         policies can't exceed 2,048 characters. Passing policies to this operation returns new \n         temporary credentials. The resulting session's permissions are the intersection of the \n         role's identity-based policy and the session policies. You can use the role's temporary \n         credentials in subsequent Amazon Web Services API calls to access resources in the account that owns \n         the role. You cannot use session policies to grant more permissions than those allowed \n         by the identity-based policy of the role that is being assumed. For more information, see\n            <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session\">Session\n            Policies</a> in the <i>IAM User Guide</i>.</p>\n         <p>Calling <code>AssumeRoleWithSAML</code> does not require the use of Amazon Web Services security\n         credentials. The identity of the caller is validated by using keys in the metadata document\n         that is uploaded for the SAML provider entity for your identity provider. </p>\n         <important>\n            <p>Calling <code>AssumeRoleWithSAML</code> can result in an entry in your CloudTrail logs.\n            The entry includes the value in the <code>NameID</code> element of the SAML assertion.\n            We recommend that you use a <code>NameIDType</code> that is not associated with any\n            personally identifiable information (PII). For example, you could instead use the\n            persistent identifier\n            (<code>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</code>).</p>\n         </important>\n         <p>\n            <b>Tags</b>\n         </p>\n         <p>(Optional) You can configure your IdP to pass attributes into your SAML assertion as\n         session tags. Each session tag consists of a key name and an associated value. For more\n         information about session tags, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html\">Passing Session Tags in STS</a> in the\n            <i>IAM User Guide</i>.</p>\n         <p>You can pass up to 50 session tags. The plaintext session tag keys can’t exceed 128\n         characters and the values can’t exceed 256 characters. For these and additional limits, see\n            <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length\">IAM\n            and STS Character Limits</a> in the <i>IAM User Guide</i>.</p>\n         <note>\n            <p>An Amazon Web Services conversion compresses the passed inline session policy, managed policy ARNs,\n            and session tags into a packed binary format that has a separate limit. Your request can\n            fail for this limit even if your plaintext meets the other requirements. The\n               <code>PackedPolicySize</code> response element indicates by percentage how close the\n            policies and tags for your request are to the upper size limit.</p>\n         </note>\n         <p>You can pass a session tag with the same key as a tag that is attached to the role. When\n         you do, session tags override the role's tags with the same key.</p>\n         <p>An administrator must grant you the permissions necessary to pass session tags. The\n         administrator can also create granular permissions to allow you to pass only specific\n         session tags. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html\">Tutorial: Using Tags\n            for Attribute-Based Access Control</a> in the\n         <i>IAM User Guide</i>.</p>\n         <p>You can set the session tags as transitive. Transitive tags persist during role\n         chaining. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_role-chaining\">Chaining Roles\n            with Session Tags</a> in the <i>IAM User Guide</i>.</p>\n         <p>\n            <b>SAML Configuration</b>\n         </p>\n         <p>Before your application can call <code>AssumeRoleWithSAML</code>, you must configure\n         your SAML identity provider (IdP) to issue the claims required by Amazon Web Services. Additionally, you\n         must use Identity and Access Management (IAM) to create a SAML provider entity in your Amazon Web Services account that\n         represents your identity provider. You must also create an IAM role that specifies this\n         SAML provider in its trust policy. </p>\n         <p>For more information, see the following resources:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_saml.html\">About\n                  SAML 2.0-based Federation</a> in the <i>IAM User Guide</i>.\n            </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml.html\">Creating SAML Identity Providers</a> in the\n                  <i>IAM User Guide</i>. </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_relying-party.html\">Configuring\n                  a Relying Party and Claims</a> in the <i>IAM User Guide</i>.\n            </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_saml.html\">Creating a Role for SAML 2.0 Federation</a> in the\n                  <i>IAM User Guide</i>. </p>\n            </li>\n         </ul>",
                 "smithy.api#examples": [
                     {
                         "title": "To assume a role using a SAML assertion",
@@ -2492,7 +2868,8 @@
                             "Subject": "SamlExample"
                         }
                     }
-                ]
+                ],
+                "smithy.api#optionalAuth": {}
             }
         },
         "com.amazonaws.sts#AssumeRoleWithSAMLRequest": {
@@ -2637,7 +3014,8 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns a set of temporary security credentials for users who have been authenticated in\n         a mobile or web application with a web identity provider. Example providers include the\n         OAuth 2.0 providers Login with Amazon and Facebook, or any OpenID Connect-compatible\n         identity provider such as Google or <a href=\"https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html\">Amazon Cognito federated identities</a>.</p>\n         <note>\n            <p>For mobile applications, we recommend that you use Amazon Cognito. You can use Amazon Cognito with the\n               <a href=\"http://aws.amazon.com/sdkforios/\">Amazon Web Services SDK for iOS Developer Guide</a> and the <a href=\"http://aws.amazon.com/sdkforandroid/\">Amazon Web Services SDK for Android Developer Guide</a> to uniquely\n            identify a user. You can also supply the user with a consistent identity throughout the\n            lifetime of an application.</p>\n            <p>To learn more about Amazon Cognito, see <a href=\"https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html\">Amazon Cognito identity\n               pools</a> in <i>Amazon Cognito Developer Guide</i>.</p>\n         </note>\n         <p>Calling <code>AssumeRoleWithWebIdentity</code> does not require the use of Amazon Web Services\n         security credentials. Therefore, you can distribute an application (for example, on mobile\n         devices) that requests temporary security credentials without including long-term Amazon Web Services\n         credentials in the application. You also don't need to deploy server-based proxy services\n         that use long-term Amazon Web Services credentials. Instead, the identity of the caller is validated by\n         using a token from the web identity provider. For a comparison of\n            <code>AssumeRoleWithWebIdentity</code> with the other API operations that produce\n         temporary credentials, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html\">Requesting Temporary Security\n            Credentials</a> and <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_sts-comparison.html\">Compare STS\n            credentials</a> in the <i>IAM User Guide</i>.</p>\n         <p>The temporary security credentials returned by this API consist of an access key ID, a\n         secret access key, and a security token. Applications can use these temporary security\n         credentials to sign calls to Amazon Web Services service API operations.</p>\n         <p>\n            <b>Session Duration</b>\n         </p>\n         <p>By default, the temporary security credentials created by\n            <code>AssumeRoleWithWebIdentity</code> last for one hour. However, you can use the\n         optional <code>DurationSeconds</code> parameter to specify the duration of your session.\n         You can provide a value from 900 seconds (15 minutes) up to the maximum session duration\n         setting for the role. This setting can have a value from 1 hour to 12 hours. To learn how\n         to view the maximum value for your role, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_update-role-settings.html#id_roles_update-session-duration\">Update the maximum session duration for a role </a> in the\n            <i>IAM User Guide</i>. The maximum session duration limit applies when\n         you use the <code>AssumeRole*</code> API operations or the <code>assume-role*</code> CLI\n         commands. However the limit does not apply when you use those operations to create a\n         console URL. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html\">Using IAM Roles</a> in the\n            <i>IAM User Guide</i>. </p>\n         <p>\n            <b>Permissions</b>\n         </p>\n         <p>The temporary security credentials created by <code>AssumeRoleWithWebIdentity</code> can\n         be used to make API calls to any Amazon Web Services service with the following exception: you cannot\n         call the STS <code>GetFederationToken</code> or <code>GetSessionToken</code> API\n         operations.</p>\n         <p>(Optional) You can pass inline or managed <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session\">session policies</a> to\n         this operation. You can pass a single JSON policy document to use as an inline session\n         policy. You can also specify up to 10 managed policy Amazon Resource Names (ARNs) to use as\n         managed session policies. The plaintext that you use for both inline and managed session\n         policies can't exceed 2,048 characters. Passing policies to this operation returns new \n         temporary credentials. The resulting session's permissions are the intersection of the \n         role's identity-based policy and the session policies. You can use the role's temporary \n         credentials in subsequent Amazon Web Services API calls to access resources in the account that owns \n         the role. You cannot use session policies to grant more permissions than those allowed \n         by the identity-based policy of the role that is being assumed. For more information, see\n            <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session\">Session\n            Policies</a> in the <i>IAM User Guide</i>.</p>\n         <p>\n            <b>Tags</b>\n         </p>\n         <p>(Optional) You can configure your IdP to pass attributes into your web identity token as\n         session tags. Each session tag consists of a key name and an associated value. For more\n         information about session tags, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html\">Passing Session Tags in STS</a> in the\n            <i>IAM User Guide</i>.</p>\n         <p>You can pass up to 50 session tags. The plaintext session tag keys can’t exceed 128\n         characters and the values can’t exceed 256 characters. For these and additional limits, see\n            <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length\">IAM\n            and STS Character Limits</a> in the <i>IAM User Guide</i>.</p>\n         <note>\n            <p>An Amazon Web Services conversion compresses the passed inline session policy, managed policy ARNs,\n            and session tags into a packed binary format that has a separate limit. Your request can\n            fail for this limit even if your plaintext meets the other requirements. The\n               <code>PackedPolicySize</code> response element indicates by percentage how close the\n            policies and tags for your request are to the upper size limit.</p>\n         </note>\n         <p>You can pass a session tag with the same key as a tag that is attached to the role. When\n         you do, the session tag overrides the role tag with the same key.</p>\n         <p>An administrator must grant you the permissions necessary to pass session tags. The\n         administrator can also create granular permissions to allow you to pass only specific\n         session tags. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html\">Tutorial: Using Tags\n            for Attribute-Based Access Control</a> in the\n         <i>IAM User Guide</i>.</p>\n         <p>You can set the session tags as transitive. Transitive tags persist during role\n         chaining. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_role-chaining\">Chaining Roles\n            with Session Tags</a> in the <i>IAM User Guide</i>.</p>\n         <p>\n            <b>Identities</b>\n         </p>\n         <p>Before your application can call <code>AssumeRoleWithWebIdentity</code>, you must have\n         an identity token from a supported identity provider and create a role that the application\n         can assume. The role that your application assumes must trust the identity provider that is\n         associated with the identity token. In other words, the identity provider must be specified\n         in the role's trust policy. </p>\n         <important>\n            <p>Calling <code>AssumeRoleWithWebIdentity</code> can result in an entry in your\n            CloudTrail logs. The entry includes the <a href=\"http://openid.net/specs/openid-connect-core-1_0.html#Claims\">Subject</a> of\n            the provided web identity token. We recommend that you avoid using any personally\n            identifiable information (PII) in this field. For example, you could instead use a GUID\n            or a pairwise identifier, as <a href=\"http://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes\">suggested\n               in the OIDC specification</a>.</p>\n         </important>\n         <p>For more information about how to use OIDC federation and the\n            <code>AssumeRoleWithWebIdentity</code> API, see the following resources: </p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc_manual.html\">Using Web Identity Federation API Operations for Mobile Apps</a> and <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithwebidentity\">Federation Through a Web-based Identity Provider</a>. </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"http://aws.amazon.com/sdkforios/\">Amazon Web Services SDK for iOS Developer Guide</a> and <a href=\"http://aws.amazon.com/sdkforandroid/\">Amazon Web Services SDK for Android Developer Guide</a>. These toolkits\n               contain sample apps that show how to invoke the identity providers. The toolkits then\n               show how to use the information from these providers to get and use temporary\n               security credentials. </p>\n            </li>\n         </ul>",
+                "smithy.api#auth": [],
+                "smithy.api#documentation": "<p>Returns a set of temporary security credentials for users who have been authenticated in\n         a mobile or web application with a web identity provider. Example providers include the\n         OAuth 2.0 providers Login with Amazon and Facebook, or any OpenID Connect-compatible\n         identity provider such as Google or <a href=\"https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html\">Amazon Cognito federated identities</a>.</p>\n         <note>\n            <p>For mobile applications, we recommend that you use Amazon Cognito. You can use Amazon Cognito with the\n               <a href=\"http://aws.amazon.com/sdkforios/\">Amazon Web Services SDK for iOS Developer Guide</a> and the <a href=\"http://aws.amazon.com/sdkforandroid/\">Amazon Web Services SDK for Android Developer Guide</a> to uniquely\n            identify a user. You can also supply the user with a consistent identity throughout the\n            lifetime of an application.</p>\n            <p>To learn more about Amazon Cognito, see <a href=\"https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html\">Amazon Cognito identity\n               pools</a> in <i>Amazon Cognito Developer Guide</i>.</p>\n         </note>\n         <p>Calling <code>AssumeRoleWithWebIdentity</code> does not require the use of Amazon Web Services\n         security credentials. Therefore, you can distribute an application (for example, on mobile\n         devices) that requests temporary security credentials without including long-term Amazon Web Services\n         credentials in the application. You also don't need to deploy server-based proxy services\n         that use long-term Amazon Web Services credentials. Instead, the identity of the caller is validated by\n         using a token from the web identity provider. For a comparison of\n            <code>AssumeRoleWithWebIdentity</code> with the other API operations that produce\n         temporary credentials, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html\">Requesting Temporary Security\n            Credentials</a> and <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_sts-comparison.html\">Compare STS\n            credentials</a> in the <i>IAM User Guide</i>.</p>\n         <p>The temporary security credentials returned by this API consist of an access key ID, a\n         secret access key, and a security token. Applications can use these temporary security\n         credentials to sign calls to Amazon Web Services service API operations.</p>\n         <p>\n            <b>Session Duration</b>\n         </p>\n         <p>By default, the temporary security credentials created by\n            <code>AssumeRoleWithWebIdentity</code> last for one hour. However, you can use the\n         optional <code>DurationSeconds</code> parameter to specify the duration of your session.\n         You can provide a value from 900 seconds (15 minutes) up to the maximum session duration\n         setting for the role. This setting can have a value from 1 hour to 12 hours. To learn how\n         to view the maximum value for your role, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_update-role-settings.html#id_roles_update-session-duration\">Update the maximum session duration for a role </a> in the\n            <i>IAM User Guide</i>. The maximum session duration limit applies when\n         you use the <code>AssumeRole*</code> API operations or the <code>assume-role*</code> CLI\n         commands. However the limit does not apply when you use those operations to create a\n         console URL. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html\">Using IAM Roles</a> in the\n            <i>IAM User Guide</i>. </p>\n         <p>\n            <b>Permissions</b>\n         </p>\n         <p>The temporary security credentials created by <code>AssumeRoleWithWebIdentity</code> can\n         be used to make API calls to any Amazon Web Services service with the following exception: you cannot\n         call the STS <code>GetFederationToken</code> or <code>GetSessionToken</code> API\n         operations.</p>\n         <p>(Optional) You can pass inline or managed <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session\">session policies</a> to\n         this operation. You can pass a single JSON policy document to use as an inline session\n         policy. You can also specify up to 10 managed policy Amazon Resource Names (ARNs) to use as\n         managed session policies. The plaintext that you use for both inline and managed session\n         policies can't exceed 2,048 characters. Passing policies to this operation returns new \n         temporary credentials. The resulting session's permissions are the intersection of the \n         role's identity-based policy and the session policies. You can use the role's temporary \n         credentials in subsequent Amazon Web Services API calls to access resources in the account that owns \n         the role. You cannot use session policies to grant more permissions than those allowed \n         by the identity-based policy of the role that is being assumed. For more information, see\n            <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_session\">Session\n            Policies</a> in the <i>IAM User Guide</i>.</p>\n         <p>\n            <b>Tags</b>\n         </p>\n         <p>(Optional) You can configure your IdP to pass attributes into your web identity token as\n         session tags. Each session tag consists of a key name and an associated value. For more\n         information about session tags, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_adding-assume-role-idp\">Passing\n            session tags using AssumeRoleWithWebIdentity</a> in the\n            <i>IAM User Guide</i>.</p>\n         <p>You can pass up to 50 session tags. The plaintext session tag keys can’t exceed 128\n         characters and the values can’t exceed 256 characters. For these and additional limits, see\n            <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length\">IAM\n            and STS Character Limits</a> in the <i>IAM User Guide</i>.</p>\n         <note>\n            <p>An Amazon Web Services conversion compresses the passed inline session policy, managed policy ARNs,\n            and session tags into a packed binary format that has a separate limit. Your request can\n            fail for this limit even if your plaintext meets the other requirements. The\n               <code>PackedPolicySize</code> response element indicates by percentage how close the\n            policies and tags for your request are to the upper size limit.</p>\n         </note>\n         <p>You can pass a session tag with the same key as a tag that is attached to the role. When\n         you do, the session tag overrides the role tag with the same key.</p>\n         <p>An administrator must grant you the permissions necessary to pass session tags. The\n         administrator can also create granular permissions to allow you to pass only specific\n         session tags. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_attribute-based-access-control.html\">Tutorial: Using Tags\n            for Attribute-Based Access Control</a> in the\n         <i>IAM User Guide</i>.</p>\n         <p>You can set the session tags as transitive. Transitive tags persist during role\n         chaining. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_role-chaining\">Chaining Roles\n            with Session Tags</a> in the <i>IAM User Guide</i>.</p>\n         <p>\n            <b>Identities</b>\n         </p>\n         <p>Before your application can call <code>AssumeRoleWithWebIdentity</code>, you must have\n         an identity token from a supported identity provider and create a role that the application\n         can assume. The role that your application assumes must trust the identity provider that is\n         associated with the identity token. In other words, the identity provider must be specified\n         in the role's trust policy. </p>\n         <important>\n            <p>Calling <code>AssumeRoleWithWebIdentity</code> can result in an entry in your\n            CloudTrail logs. The entry includes the <a href=\"http://openid.net/specs/openid-connect-core-1_0.html#Claims\">Subject</a> of\n            the provided web identity token. We recommend that you avoid using any personally\n            identifiable information (PII) in this field. For example, you could instead use a GUID\n            or a pairwise identifier, as <a href=\"http://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes\">suggested\n               in the OIDC specification</a>.</p>\n         </important>\n         <p>For more information about how to use OIDC federation and the\n            <code>AssumeRoleWithWebIdentity</code> API, see the following resources: </p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc_manual.html\">Using Web Identity Federation API Operations for Mobile Apps</a> and <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_assumerolewithwebidentity\">Federation Through a Web-based Identity Provider</a>. </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"http://aws.amazon.com/sdkforios/\">Amazon Web Services SDK for iOS Developer Guide</a> and <a href=\"http://aws.amazon.com/sdkforandroid/\">Amazon Web Services SDK for Android Developer Guide</a>. These toolkits\n               contain sample apps that show how to invoke the identity providers. The toolkits then\n               show how to use the information from these providers to get and use temporary\n               security credentials. </p>\n            </li>\n         </ul>",
                 "smithy.api#examples": [
                     {
                         "title": "To assume a role as an OpenID Connect-federated user",
@@ -2645,7 +3023,7 @@
                         "input": {
                             "RoleArn": "arn:aws:iam::123456789012:role/FederatedWebIdentityRole",
                             "RoleSessionName": "app1",
-                            "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Action\":\"s3:ListAllMyBuckets\",\"Resource\":\"*\"}]}",
+                            "Policy": "escaped-JSON-IAM-POLICY",
                             "WebIdentityToken": "Atza%7CIQEBLjAsAhRFiXuWpUXuRvQ9PZL3GMFcYevydwIUFAHZwXZXXXXXXXXJnrulxKDHwy87oGKPznh0D6bEQZTSCzyoCtL_8S07pLpr0zMbn6w1lfVZKNTBdDansFBmtGnIsIapjI6xKR02Yc_2bQ8LZbUXSGm6Ry6_BG7PrtLZtj_dfCTj92xNGed-CrKqjG7nPBjNIL016GGvuS5gSvPRUxWES3VYfm1wl7WTI7jn-Pcb6M-buCgHhFOzTQxod27L9CqnOLio7N3gZAGpsp6n1-AJBOCJckcyXe2c6uD0srOJeZlKUm2eTDVMf8IehDVI0r1QOnTV6KzzAI3OY87Vd_cVMQ",
                             "ProviderId": "www.amazon.com",
                             "DurationSeconds": 3600
@@ -2667,7 +3045,8 @@
                             "Audience": "client.5498841531868486423.1548@apps.example.com"
                         }
                     }
-                ]
+                ],
+                "smithy.api#optionalAuth": {}
             }
         },
         "com.amazonaws.sts#AssumeRoleWithWebIdentityRequest": {
@@ -2791,7 +3170,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns a set of short term credentials you can use to perform privileged tasks on a\n         member account in your organization.</p>\n         <p>Before you can launch a privileged session, you must have centralized root access in\n         your organization. For steps to enable this feature, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-enable-root-access.html\">Centralize root access for\n            member accounts</a> in the <i>IAM User Guide</i>.</p>\n         <note>\n            <p>The STS global endpoint is not supported for AssumeRoot. You must send this request\n            to a Regional STS endpoint. For more information, see <a href=\"https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html#sts-endpoints\">Endpoints</a>.</p>\n         </note>\n         <p>You can track AssumeRoot in CloudTrail logs to determine what actions were performed in a\n         session. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-track-privileged-tasks.html\">Track privileged tasks\n            in CloudTrail</a> in the <i>IAM User Guide</i>.</p>",
+                "smithy.api#documentation": "<p>Returns a set of short term credentials you can use to perform privileged tasks on a\n         member account in your organization. You must use credentials from an Organizations management\n         account or a delegated administrator account for IAM to call <code>AssumeRoot</code>. You\n         cannot use root user credentials to make this call.</p>\n         <p>Before you can launch a privileged session, you must have centralized root access in\n         your organization. For steps to enable this feature, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-enable-root-access.html\">Centralize root access for\n            member accounts</a> in the <i>IAM User Guide</i>.</p>\n         <note>\n            <p>The STS global endpoint is not supported for AssumeRoot. You must send this request\n            to a Regional STS endpoint. For more information, see <a href=\"https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html#sts-endpoints\">Endpoints</a>.</p>\n         </note>\n         <p>You can track AssumeRoot in CloudTrail logs to determine what actions were performed in a\n         session. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-track-privileged-tasks.html\">Track privileged tasks\n            in CloudTrail</a> in the <i>IAM User Guide</i>.</p>\n         <p>When granting access to privileged tasks you should only grant the necessary permissions\n         required to perform that task. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html\">Security best practices in\n         IAM</a>. In addition, you can use <a href=\"https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html\">service control\n            policies</a> (SCPs) to manage and limit permissions in your organization. See <a href=\"https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps_examples_general.html\">General examples</a> in the <i>Organizations User\n            Guide</i> for more information on SCPs.</p>",
                 "smithy.api#examples": [
                     {
                         "title": "To launch a privileged session",
@@ -2829,7 +3208,7 @@
                 "TaskPolicyArn": {
                     "target": "com.amazonaws.sts#PolicyDescriptorType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The identity based policy that scopes the session to the privileged tasks that can be\n         performed. You can use one of following Amazon Web Services managed policies to scope root session\n         actions.</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/security-iam-awsmanpol.html#security-iam-awsmanpol-IAMAuditRootUserCredentials\">IAMAuditRootUserCredentials</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/security-iam-awsmanpol.html#security-iam-awsmanpol-IAMCreateRootUserPassword\">IAMCreateRootUserPassword</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/security-iam-awsmanpol.html#security-iam-awsmanpol-IAMDeleteRootUserCredentials\">IAMDeleteRootUserCredentials</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/security-iam-awsmanpol.html#security-iam-awsmanpol-S3UnlockBucketPolicy\">S3UnlockBucketPolicy</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/security-iam-awsmanpol.html#security-iam-awsmanpol-SQSUnlockQueuePolicy\">SQSUnlockQueuePolicy</a>\n               </p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>The identity based policy that scopes the session to the privileged tasks that can be\n         performed. You must\n         \n         use one of following Amazon Web Services managed policies to scope root session\n         actions:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/security-iam-awsmanpol.html#security-iam-awsmanpol-IAMAuditRootUserCredentials\">IAMAuditRootUserCredentials</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/security-iam-awsmanpol.html#security-iam-awsmanpol-IAMCreateRootUserPassword\">IAMCreateRootUserPassword</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/security-iam-awsmanpol.html#security-iam-awsmanpol-IAMDeleteRootUserCredentials\">IAMDeleteRootUserCredentials</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/security-iam-awsmanpol.html#security-iam-awsmanpol-S3UnlockBucketPolicy\">S3UnlockBucketPolicy</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/security-iam-awsmanpol.html#security-iam-awsmanpol-SQSUnlockQueuePolicy\">SQSUnlockQueuePolicy</a>\n               </p>\n            </li>\n         </ul>",
                         "smithy.api#required": {}
                     }
                 },
@@ -3001,6 +3380,23 @@
                 "smithy.api#httpError": 400
             }
         },
+        "com.amazonaws.sts#ExpiredTradeInTokenException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.sts#expiredTradeInTokenExceptionMessage"
+                }
+            },
+            "traits": {
+                "aws.protocols#awsQueryError": {
+                    "code": "ExpiredTradeInTokenException",
+                    "httpResponseCode": 400
+                },
+                "smithy.api#documentation": "<p>The trade-in token provided in the request has expired and can no longer be exchanged\n            for credentials. Request a new token and retry the operation.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
         "com.amazonaws.sts#FederatedUser": {
             "type": "structure",
             "members": {
@@ -3139,6 +3535,67 @@
                 "smithy.api#output": {}
             }
         },
+        "com.amazonaws.sts#GetDelegatedAccessToken": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.sts#GetDelegatedAccessTokenRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.sts#GetDelegatedAccessTokenResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.sts#ExpiredTradeInTokenException"
+                },
+                {
+                    "target": "com.amazonaws.sts#PackedPolicyTooLargeException"
+                },
+                {
+                    "target": "com.amazonaws.sts#RegionDisabledException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Exchanges a trade-in token for temporary Amazon Web Services credentials with the permissions\n         associated with the assumed principal. This operation allows you to obtain credentials for\n         a specific principal based on a trade-in token, enabling delegation of access to Amazon Web Services\n         resources.</p>"
+            }
+        },
+        "com.amazonaws.sts#GetDelegatedAccessTokenRequest": {
+            "type": "structure",
+            "members": {
+                "TradeInToken": {
+                    "target": "com.amazonaws.sts#tradeInTokenType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The token to exchange for temporary Amazon Web Services credentials. This token must be valid and\n         unexpired at the time of the request.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.sts#GetDelegatedAccessTokenResponse": {
+            "type": "structure",
+            "members": {
+                "Credentials": {
+                    "target": "com.amazonaws.sts#Credentials"
+                },
+                "PackedPolicySize": {
+                    "target": "com.amazonaws.sts#nonNegativeIntegerType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The percentage of the maximum policy size that is used by the session policy. The policy\n         size is calculated as the sum of all the session policies and permission boundaries\n         attached to the session. If the packed size exceeds 100%, the request fails.</p>"
+                    }
+                },
+                "AssumedPrincipal": {
+                    "target": "com.amazonaws.sts#arnType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the principal that was assumed when obtaining the\n         delegated access token. This ARN identifies the IAM entity whose permissions are granted\n         by the temporary credentials.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
         "com.amazonaws.sts#GetFederationToken": {
             "type": "operation",
             "input": {
@@ -3166,7 +3623,7 @@
                         "documentation": "",
                         "input": {
                             "Name": "testFedUserSession",
-                            "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Action\":\"s3:ListAllMyBuckets\",\"Resource\":\"*\"}]}",
+                            "Policy": "escaped-JSON-IAM-POLICY",
                             "DurationSeconds": 3600,
                             "Tags": [
                                 {
@@ -3339,6 +3796,83 @@
                 "smithy.api#output": {}
             }
         },
+        "com.amazonaws.sts#GetWebIdentityToken": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.sts#GetWebIdentityTokenRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.sts#GetWebIdentityTokenResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.sts#JWTPayloadSizeExceededException"
+                },
+                {
+                    "target": "com.amazonaws.sts#OutboundWebIdentityFederationDisabledException"
+                },
+                {
+                    "target": "com.amazonaws.sts#SessionDurationEscalationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Returns a signed JSON Web Token (JWT) that represents the calling Amazon Web Services identity. \n         The returned JWT can be used to authenticate with external services that support OIDC discovery. \n         The token is signed by Amazon Web Services STS and can be publicly verified using the verification keys published at the issuer's JWKS endpoint.</p>"
+            }
+        },
+        "com.amazonaws.sts#GetWebIdentityTokenRequest": {
+            "type": "structure",
+            "members": {
+                "Audience": {
+                    "target": "com.amazonaws.sts#webIdentityTokenAudienceListType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The intended recipient of the web identity token. This value populates the\n            <code>aud</code> claim in the JWT and should identify the service or application that\n         will validate and use the token. The external service should verify this claim to ensure the token was intended for their use.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DurationSeconds": {
+                    "target": "com.amazonaws.sts#webIdentityTokenDurationSecondsType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The duration, in seconds, for which the JSON Web Token (JWT) will remain valid. \n         The value can range from 60 seconds (1 minute) to 3600 seconds (1 hour). If not specified, \n         the default duration is 300 seconds (5 minutes). The token is designed to be short-lived and \n         should be used for proof of identity, then exchanged for credentials or short-lived tokens in the external service.</p>"
+                    }
+                },
+                "SigningAlgorithm": {
+                    "target": "com.amazonaws.sts#jwtAlgorithmType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The cryptographic algorithm to use for signing the JSON Web Token (JWT). Valid values are \n         RS256 (RSA with SHA-256) and ES384 (ECDSA using P-384 curve with SHA-384). </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Tags": {
+                    "target": "com.amazonaws.sts#tagListType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An optional list of tags to include in the JSON Web Token (JWT). These tags are added as custom \n         claims to the JWT and can be used by the downstream service for authorization decisions. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.sts#GetWebIdentityTokenResponse": {
+            "type": "structure",
+            "members": {
+                "WebIdentityToken": {
+                    "target": "com.amazonaws.sts#webIdentityTokenType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A signed JSON Web Token (JWT) that represents the caller's Amazon Web Services identity. The token contains \n         standard JWT claims such as subject, audience, expiration time, and additional identity attributes \n         added by STS as custom claims. You can also add your own custom claims to the token by passing tags \n         as request parameters to the <code>GetWebIdentityToken</code> API. The token is signed using the specified signing \n         algorithm and can be verified using the verification keys available at the issuer's JWKS endpoint.</p>"
+                    }
+                },
+                "Expiration": {
+                    "target": "com.amazonaws.sts#dateType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time when the web identity token expires, in UTC. The expiration is\n         determined by adding the <code>DurationSeconds</code> value to the time the token was\n         issued. After this time, the token should no longer be considered valid.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
         "com.amazonaws.sts#IDPCommunicationErrorException": {
             "type": "structure",
             "members": {
@@ -3410,6 +3944,26 @@
         "com.amazonaws.sts#Issuer": {
             "type": "string"
         },
+        "com.amazonaws.sts#JWTPayloadSizeExceededException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.sts#JWTPayloadSizeExceededException2"
+                }
+            },
+            "traits": {
+                "aws.protocols#awsQueryError": {
+                    "code": "JWTPayloadSizeExceededException",
+                    "httpResponseCode": 400
+                },
+                "smithy.api#documentation": "<p>The requested token payload size exceeds the maximum allowed size. Reduce the number of request tags included in the <code>GetWebIdentityToken</code> API call to reduce the token payload size.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.sts#JWTPayloadSizeExceededException2": {
+            "type": "string"
+        },
         "com.amazonaws.sts#MalformedPolicyDocumentException": {
             "type": "structure",
             "members": {
@@ -3428,6 +3982,26 @@
             }
         },
         "com.amazonaws.sts#NameQualifier": {
+            "type": "string"
+        },
+        "com.amazonaws.sts#OutboundWebIdentityFederationDisabledException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.sts#OutboundWebIdentityFederationDisabledException2"
+                }
+            },
+            "traits": {
+                "aws.protocols#awsQueryError": {
+                    "code": "OutboundWebIdentityFederationDisabledException",
+                    "httpResponseCode": 403
+                },
+                "smithy.api#documentation": "<p>The outbound web identity federation feature is not enabled for this account. To use\n            this feature, you must first enable it through the Amazon Web Services Management Console or API.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 403
+            }
+        },
+        "com.amazonaws.sts#OutboundWebIdentityFederationDisabledException2": {
             "type": "string"
         },
         "com.amazonaws.sts#PackedPolicyTooLargeException": {
@@ -3488,7 +4062,7 @@
             },
             "traits": {
                 "smithy.api#length": {
-                    "min": 0,
+                    "min": 1,
                     "max": 5
                 }
             }
@@ -3505,7 +4079,7 @@
                     "code": "RegionDisabledException",
                     "httpResponseCode": 403
                 },
-                "smithy.api#documentation": "<p>STS is not activated in the requested region for the account that is being asked to\n            generate credentials. The account administrator must use the IAM console to activate\n            STS in that region. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html\">Activating and\n                Deactivating STS in an Amazon Web Services Region</a> in the <i>IAM User\n                Guide</i>.</p>",
+                "smithy.api#documentation": "<p>STS is not activated in the requested region for the account that is being asked to\n            generate credentials. The account administrator must use the IAM console to activate\n            STS in that region. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html#sts-regions-activate-deactivate\">Activating and Deactivating STS in an Amazon Web Services Region</a> in the <i>IAM\n                User Guide</i>.</p>",
                 "smithy.api#error": "client",
                 "smithy.api#httpError": 403
             }
@@ -3528,6 +4102,26 @@
                 },
                 "smithy.api#sensitive": {}
             }
+        },
+        "com.amazonaws.sts#SessionDurationEscalationException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.sts#SessionDurationEscalationException2"
+                }
+            },
+            "traits": {
+                "aws.protocols#awsQueryError": {
+                    "code": "SessionDurationEscalationException",
+                    "httpResponseCode": 403
+                },
+                "smithy.api#documentation": "<p>The requested token duration would extend the session beyond its original expiration time. \n            You cannot use this operation to extend the lifetime of a session beyond what was granted when the session was originally created.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 403
+            }
+        },
+        "com.amazonaws.sts#SessionDurationEscalationException2": {
+            "type": "string"
         },
         "com.amazonaws.sts#Subject": {
             "type": "string"
@@ -3651,6 +4245,9 @@
         "com.amazonaws.sts#expiredIdentityTokenMessage": {
             "type": "string"
         },
+        "com.amazonaws.sts#expiredTradeInTokenExceptionMessage": {
+            "type": "string"
+        },
         "com.amazonaws.sts#externalIdType": {
             "type": "string",
             "traits": {
@@ -3682,6 +4279,15 @@
         },
         "com.amazonaws.sts#invalidIdentityTokenMessage": {
             "type": "string"
+        },
+        "com.amazonaws.sts#jwtAlgorithmType": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 5,
+                    "max": 5
+                }
+            }
         },
         "com.amazonaws.sts#malformedPolicyDocumentMessage": {
             "type": "string"
@@ -3812,6 +4418,12 @@
         "com.amazonaws.sts#tokenType": {
             "type": "string"
         },
+        "com.amazonaws.sts#tradeInTokenType": {
+            "type": "string",
+            "traits": {
+                "smithy.api#sensitive": {}
+            }
+        },
         "com.amazonaws.sts#unrestrictedSessionPolicyDocumentType": {
             "type": "string",
             "traits": {
@@ -3850,6 +4462,42 @@
                     "min": 6,
                     "max": 255
                 }
+            }
+        },
+        "com.amazonaws.sts#webIdentityTokenAudienceListType": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.sts#webIdentityTokenAudienceStringType"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 10
+                }
+            }
+        },
+        "com.amazonaws.sts#webIdentityTokenAudienceStringType": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1000
+                }
+            }
+        },
+        "com.amazonaws.sts#webIdentityTokenDurationSecondsType": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 60,
+                    "max": 3600
+                }
+            }
+        },
+        "com.amazonaws.sts#webIdentityTokenType": {
+            "type": "string",
+            "traits": {
+                "smithy.api#sensitive": {}
             }
         }
     }


### PR DESCRIPTION
## Summary

Refresh `data/sts.json` from awslabs/aws-sdk-rust: lock `13eb310` (2025-01-10) → `97e6a29` (2026-06-02), 289225 → 319545 bytes. Data-only sync; no generated-code changes.

## Changes

- `data/crawl.py`: update the STS model lock commit.
- `data/sts.json`:
  - +2 operations: `GetDelegatedAccessToken`, `GetWebIdentityToken`
  - +20 shapes (requests/responses, 4 new error structures + message variants, web-identity/trade-in token types), 0 removed
  - trait updates: `AssumeRoleWithSAML` / `AssumeRoleWithWebIdentity` gain `smithy.api#auth` + `smithy.api#optionalAuth`; the service shape gains `smithy.api#auth`, `smithy.rules#endpointBdd`, `aws.auth#sigv4a`

## Non-goals

- The two new operations are **not exposed** in `S3Service`: the STS codegen `reduce()` whitelist keeps only AssumeRole-related shapes, so the generated code is byte-identical.
- No behavioral change for the existing STS (AssumeRole) handling.

## Verification

- `just dev` passes (fetch / fmt / codegen / clippy / workspace tests).
- `just codegen` is idempotent — working tree stays clean.
- Downloaded file matches upstream raw byte-for-byte (SHA256 `1645206cfffb5c92e39b10c54cac340592954ef67a872092ca1bd6941a5e6840`).
