### PR TITLE
refactor(codegen): sink needs_full_body into Operation trait

### DIFF
--- a/codegen/src/v1/ops.rs
+++ b/codegen/src/v1/ops.rs
@@ -211,7 +211,7 @@ fn codegen_http(ops: &Operations, rust_types: &RustTypes) {
         g!("}}");
         g!();
 
-        codegen_op_http_call(op);
+        codegen_op_http_call(op, rust_types);
         g!();
     }
 
@@ -903,7 +903,7 @@ fn codegen_op_http_de_multipart(op: &Operation, rust_types: &RustTypes) {
     g!("}}");
 }
 
-fn codegen_op_http_call(op: &Operation) {
+fn codegen_op_http_call(op: &Operation, rust_types: &RustTypes) {
     g!("#[async_trait::async_trait]");
     g!("impl super::Operation for {} {{", op.name);
 
@@ -911,6 +911,13 @@ fn codegen_op_http_call(op: &Operation) {
     g!("\"{}\"", op.name);
     g!("}}");
     g!();
+
+    if needs_full_body(op, rust_types) {
+        g!("fn needs_full_body(&self) -> bool {{");
+        g!("true");
+        g!("}}");
+        g!();
+    }
 
     g!("async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {{");
 
@@ -1011,7 +1018,6 @@ struct Route<'a> {
     x_id: Option<String>,
     required_headers: Vec<&'a str>,
     required_query_strings: Vec<&'a str>,
-    needs_full_body: bool,
 }
 
 fn collect_routes<'a>(ops: &'a Operations, rust_types: &'a RustTypes) -> HashMap<String, HashMap<PathPattern, Vec<Route<'a>>>> {
@@ -1034,8 +1040,6 @@ fn collect_routes<'a>(ops: &'a Operations, rust_types: &'a RustTypes) -> HashMap
 
             required_headers: required_headers(op, rust_types),
             required_query_strings: required_query_strings(op, rust_types),
-
-            needs_full_body: needs_full_body(op, rust_types),
         });
     }
     for map in ans.values_mut() {
@@ -1124,17 +1128,13 @@ fn codegen_router(ops: &Operations, rust_types: &RustTypes) {
         req: &http::Request, \
         s3_path: &S3Path, \
         qs: Option<&http::OrderedQs>)\
-         -> S3Result<(&'static dyn super::Operation, bool)> {{");
+         -> S3Result<&'static dyn super::Operation> {{");
 
     let succ = |route: &Route, return_: bool| {
         if return_ {
-            g!(
-                "return Ok((&{} as &'static dyn super::Operation, {}));",
-                route.op.name,
-                route.needs_full_body
-            );
+            g!("return Ok(&{} as &'static dyn super::Operation);", route.op.name);
         } else {
-            g!("Ok((&{} as &'static dyn super::Operation, {}))", route.op.name, route.needs_full_body);
+            g!("Ok(&{} as &'static dyn super::Operation)", route.op.name);
         }
     };
 
@@ -1178,7 +1178,6 @@ fn codegen_router(ops: &Operations, rust_types: &RustTypes) {
                         assert!(route.query_tag.is_none());
                         assert_eq!(route.required_headers, Vec::<&str>::new());
                         assert_eq!(route.required_query_strings, Vec::<&str>::new());
-                        assert!(route.needs_full_body.not());
                         succ(route, false);
                     } else {
                         let is_final_op = |route: &Route| {

--- a/codegen/src/v1/ops.rs
+++ b/codegen/src/v1/ops.rs
@@ -325,6 +325,7 @@ fn codegen_post_object_fork_op(rust_types: &RustTypes) {
 
     g(["#[async_trait::async_trait]", "impl super::Operation for PostObject {"]);
     g(["    fn name(&self) -> &'static str {", "        \"PostObject\"", "    }", ""]);
+    g(["    fn needs_full_body(&self) -> bool {", "        false", "    }", ""]);
 
     g([
         "    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {",
@@ -912,12 +913,10 @@ fn codegen_op_http_call(op: &Operation, rust_types: &RustTypes) {
     g!("}}");
     g!();
 
-    if needs_full_body(op, rust_types) {
-        g!("fn needs_full_body(&self) -> bool {{");
-        g!("true");
-        g!("}}");
-        g!();
-    }
+    g!("fn needs_full_body(&self) -> bool {{");
+    g!("{}", needs_full_body(op, rust_types));
+    g!("}}");
+    g!();
 
     g!("async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {{");
 

--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -535,6 +535,10 @@ impl super::Operation for AbortMultipartUpload {
         "AbortMultipartUpload"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -834,6 +838,10 @@ impl super::Operation for CopyObject {
         "CopyObject"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1115,6 +1123,10 @@ impl super::Operation for CreateMultipartUpload {
         "CreateMultipartUpload"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1179,6 +1191,10 @@ impl super::Operation for CreateSession {
         "CreateSession"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1221,6 +1237,10 @@ impl DeleteBucket {
 impl super::Operation for DeleteBucket {
     fn name(&self) -> &'static str {
         "DeleteBucket"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1270,6 +1290,10 @@ impl super::Operation for DeleteBucketAnalyticsConfiguration {
         "DeleteBucketAnalyticsConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1312,6 +1336,10 @@ impl DeleteBucketCors {
 impl super::Operation for DeleteBucketCors {
     fn name(&self) -> &'static str {
         "DeleteBucketCors"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1358,6 +1386,10 @@ impl super::Operation for DeleteBucketEncryption {
         "DeleteBucketEncryption"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1397,6 +1429,10 @@ impl DeleteBucketIntelligentTieringConfiguration {
 impl super::Operation for DeleteBucketIntelligentTieringConfiguration {
     fn name(&self) -> &'static str {
         "DeleteBucketIntelligentTieringConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1446,6 +1482,10 @@ impl super::Operation for DeleteBucketInventoryConfiguration {
         "DeleteBucketInventoryConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1490,6 +1530,10 @@ impl super::Operation for DeleteBucketLifecycle {
         "DeleteBucketLifecycle"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1532,6 +1576,10 @@ impl DeleteBucketMetadataTableConfiguration {
 impl super::Operation for DeleteBucketMetadataTableConfiguration {
     fn name(&self) -> &'static str {
         "DeleteBucketMetadataTableConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1581,6 +1629,10 @@ impl super::Operation for DeleteBucketMetricsConfiguration {
         "DeleteBucketMetricsConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1623,6 +1675,10 @@ impl DeleteBucketOwnershipControls {
 impl super::Operation for DeleteBucketOwnershipControls {
     fn name(&self) -> &'static str {
         "DeleteBucketOwnershipControls"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1669,6 +1725,10 @@ impl super::Operation for DeleteBucketPolicy {
         "DeleteBucketPolicy"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1711,6 +1771,10 @@ impl DeleteBucketReplication {
 impl super::Operation for DeleteBucketReplication {
     fn name(&self) -> &'static str {
         "DeleteBucketReplication"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1757,6 +1821,10 @@ impl super::Operation for DeleteBucketTagging {
         "DeleteBucketTagging"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1799,6 +1867,10 @@ impl DeleteBucketWebsite {
 impl super::Operation for DeleteBucketWebsite {
     fn name(&self) -> &'static str {
         "DeleteBucketWebsite"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1873,6 +1945,10 @@ impl super::Operation for DeleteObject {
         "DeleteObject"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1921,6 +1997,10 @@ impl DeleteObjectTagging {
 impl super::Operation for DeleteObjectTagging {
     fn name(&self) -> &'static str {
         "DeleteObjectTagging"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2034,6 +2114,10 @@ impl super::Operation for DeletePublicAccessBlock {
         "DeletePublicAccessBlock"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2084,6 +2168,10 @@ impl super::Operation for GetBucketAccelerateConfiguration {
         "GetBucketAccelerateConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2128,6 +2216,10 @@ impl GetBucketAcl {
 impl super::Operation for GetBucketAcl {
     fn name(&self) -> &'static str {
         "GetBucketAcl"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2181,6 +2273,10 @@ impl super::Operation for GetBucketAnalyticsConfiguration {
         "GetBucketAnalyticsConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2225,6 +2321,10 @@ impl GetBucketCors {
 impl super::Operation for GetBucketCors {
     fn name(&self) -> &'static str {
         "GetBucketCors"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2275,6 +2375,10 @@ impl super::Operation for GetBucketEncryption {
         "GetBucketEncryption"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2318,6 +2422,10 @@ impl GetBucketIntelligentTieringConfiguration {
 impl super::Operation for GetBucketIntelligentTieringConfiguration {
     fn name(&self) -> &'static str {
         "GetBucketIntelligentTieringConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2371,6 +2479,10 @@ impl super::Operation for GetBucketInventoryConfiguration {
         "GetBucketInventoryConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2422,6 +2534,10 @@ impl super::Operation for GetBucketLifecycleConfiguration {
         "GetBucketLifecycleConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2466,6 +2582,10 @@ impl GetBucketLocation {
 impl super::Operation for GetBucketLocation {
     fn name(&self) -> &'static str {
         "GetBucketLocation"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2514,6 +2634,10 @@ impl super::Operation for GetBucketLogging {
         "GetBucketLogging"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2560,6 +2684,10 @@ impl GetBucketMetadataTableConfiguration {
 impl super::Operation for GetBucketMetadataTableConfiguration {
     fn name(&self) -> &'static str {
         "GetBucketMetadataTableConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2613,6 +2741,10 @@ impl super::Operation for GetBucketMetricsConfiguration {
         "GetBucketMetricsConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2657,6 +2789,10 @@ impl GetBucketNotificationConfiguration {
 impl super::Operation for GetBucketNotificationConfiguration {
     fn name(&self) -> &'static str {
         "GetBucketNotificationConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2707,6 +2843,10 @@ impl super::Operation for GetBucketOwnershipControls {
         "GetBucketOwnershipControls"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2753,6 +2893,10 @@ impl GetBucketPolicy {
 impl super::Operation for GetBucketPolicy {
     fn name(&self) -> &'static str {
         "GetBucketPolicy"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2803,6 +2947,10 @@ impl super::Operation for GetBucketPolicyStatus {
         "GetBucketPolicyStatus"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2851,6 +2999,10 @@ impl super::Operation for GetBucketReplication {
         "GetBucketReplication"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2895,6 +3047,10 @@ impl GetBucketRequestPayment {
 impl super::Operation for GetBucketRequestPayment {
     fn name(&self) -> &'static str {
         "GetBucketRequestPayment"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2943,6 +3099,10 @@ impl super::Operation for GetBucketTagging {
         "GetBucketTagging"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2989,6 +3149,10 @@ impl super::Operation for GetBucketVersioning {
         "GetBucketVersioning"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3033,6 +3197,10 @@ impl GetBucketWebsite {
 impl super::Operation for GetBucketWebsite {
     fn name(&self) -> &'static str {
         "GetBucketWebsite"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -3194,6 +3362,10 @@ impl super::Operation for GetObject {
         "GetObject"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3248,6 +3420,10 @@ impl GetObjectAcl {
 impl super::Operation for GetObjectAcl {
     fn name(&self) -> &'static str {
         "GetObjectAcl"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -3327,6 +3503,10 @@ impl super::Operation for GetObjectAttributes {
         "GetObjectAttributes"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3382,6 +3562,10 @@ impl super::Operation for GetObjectLegalHold {
         "GetObjectLegalHold"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3428,6 +3612,10 @@ impl GetObjectLockConfiguration {
 impl super::Operation for GetObjectLockConfiguration {
     fn name(&self) -> &'static str {
         "GetObjectLockConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -3485,6 +3673,10 @@ impl super::Operation for GetObjectRetention {
         "GetObjectRetention"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3537,6 +3729,10 @@ impl GetObjectTagging {
 impl super::Operation for GetObjectTagging {
     fn name(&self) -> &'static str {
         "GetObjectTagging"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -3592,6 +3788,10 @@ impl super::Operation for GetObjectTorrent {
         "GetObjectTorrent"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3638,6 +3838,10 @@ impl GetPublicAccessBlock {
 impl super::Operation for GetPublicAccessBlock {
     fn name(&self) -> &'static str {
         "GetPublicAccessBlock"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -3687,6 +3891,10 @@ impl HeadBucket {
 impl super::Operation for HeadBucket {
     fn name(&self) -> &'static str {
         "HeadBucket"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -3842,6 +4050,10 @@ impl super::Operation for HeadObject {
         "HeadObject"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3891,6 +4103,10 @@ impl super::Operation for ListBucketAnalyticsConfigurations {
         "ListBucketAnalyticsConfigurations"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3935,6 +4151,10 @@ impl ListBucketIntelligentTieringConfigurations {
 impl super::Operation for ListBucketIntelligentTieringConfigurations {
     fn name(&self) -> &'static str {
         "ListBucketIntelligentTieringConfigurations"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -3986,6 +4206,10 @@ impl super::Operation for ListBucketInventoryConfigurations {
         "ListBucketInventoryConfigurations"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4033,6 +4257,10 @@ impl ListBucketMetricsConfigurations {
 impl super::Operation for ListBucketMetricsConfigurations {
     fn name(&self) -> &'static str {
         "ListBucketMetricsConfigurations"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -4087,6 +4315,10 @@ impl super::Operation for ListBuckets {
         "ListBuckets"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4131,6 +4363,10 @@ impl ListDirectoryBuckets {
 impl super::Operation for ListDirectoryBuckets {
     fn name(&self) -> &'static str {
         "ListDirectoryBuckets"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -4199,6 +4435,10 @@ impl ListMultipartUploads {
 impl super::Operation for ListMultipartUploads {
     fn name(&self) -> &'static str {
         "ListMultipartUploads"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -4273,6 +4513,10 @@ impl super::Operation for ListObjectVersions {
         "ListObjectVersions"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4340,6 +4584,10 @@ impl ListObjects {
 impl super::Operation for ListObjects {
     fn name(&self) -> &'static str {
         "ListObjects"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -4417,6 +4665,10 @@ impl super::Operation for ListObjectsV2 {
         "ListObjectsV2"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4488,6 +4740,10 @@ impl ListParts {
 impl super::Operation for ListParts {
     fn name(&self) -> &'static str {
         "ListParts"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -5904,6 +6160,10 @@ impl super::Operation for PutObject {
         "PutObject"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6580,6 +6840,10 @@ impl super::Operation for UploadPart {
         "UploadPart"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6690,6 +6954,10 @@ impl UploadPartCopy {
 impl super::Operation for UploadPartCopy {
     fn name(&self) -> &'static str {
         "UploadPartCopy"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6883,6 +7151,10 @@ impl super::Operation for WriteGetObjectResponse {
         "WriteGetObjectResponse"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6990,6 +7262,10 @@ impl PostObject {
 impl super::Operation for PostObject {
     fn name(&self) -> &'static str {
         "PostObject"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {

--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -644,6 +644,10 @@ impl super::Operation for CompleteMultipartUpload {
         "CompleteMultipartUpload"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -901,6 +905,10 @@ impl super::Operation for CreateBucket {
         "CreateBucket"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -952,6 +960,10 @@ impl CreateBucketMetadataTableConfiguration {
 impl super::Operation for CreateBucketMetadataTableConfiguration {
     fn name(&self) -> &'static str {
         "CreateBucketMetadataTableConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1972,6 +1984,10 @@ impl DeleteObjects {
 impl super::Operation for DeleteObjects {
     fn name(&self) -> &'static str {
         "DeleteObjects"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -4524,6 +4540,10 @@ impl super::Operation for PutBucketAccelerateConfiguration {
         "PutBucketAccelerateConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4595,6 +4615,10 @@ impl super::Operation for PutBucketAcl {
         "PutBucketAcl"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4643,6 +4667,10 @@ impl PutBucketAnalyticsConfiguration {
 impl super::Operation for PutBucketAnalyticsConfiguration {
     fn name(&self) -> &'static str {
         "PutBucketAnalyticsConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -4698,6 +4726,10 @@ impl super::Operation for PutBucketCors {
         "PutBucketCors"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4751,6 +4783,10 @@ impl super::Operation for PutBucketEncryption {
         "PutBucketEncryption"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4796,6 +4832,10 @@ impl PutBucketIntelligentTieringConfiguration {
 impl super::Operation for PutBucketIntelligentTieringConfiguration {
     fn name(&self) -> &'static str {
         "PutBucketIntelligentTieringConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -4846,6 +4886,10 @@ impl PutBucketInventoryConfiguration {
 impl super::Operation for PutBucketInventoryConfiguration {
     fn name(&self) -> &'static str {
         "PutBucketInventoryConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -4908,6 +4952,10 @@ impl super::Operation for PutBucketLifecycleConfiguration {
         "PutBucketLifecycleConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4961,6 +5009,10 @@ impl super::Operation for PutBucketLogging {
         "PutBucketLogging"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5009,6 +5061,10 @@ impl PutBucketMetricsConfiguration {
 impl super::Operation for PutBucketMetricsConfiguration {
     fn name(&self) -> &'static str {
         "PutBucketMetricsConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -5062,6 +5118,10 @@ impl super::Operation for PutBucketNotificationConfiguration {
         "PutBucketNotificationConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5110,6 +5170,10 @@ impl PutBucketOwnershipControls {
 impl super::Operation for PutBucketOwnershipControls {
     fn name(&self) -> &'static str {
         "PutBucketOwnershipControls"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -5169,6 +5233,10 @@ impl super::Operation for PutBucketPolicy {
         "PutBucketPolicy"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5225,6 +5293,10 @@ impl super::Operation for PutBucketReplication {
         "PutBucketReplication"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5278,6 +5350,10 @@ impl super::Operation for PutBucketRequestPayment {
         "PutBucketRequestPayment"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5329,6 +5405,10 @@ impl PutBucketTagging {
 impl super::Operation for PutBucketTagging {
     fn name(&self) -> &'static str {
         "PutBucketTagging"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -5387,6 +5467,10 @@ impl super::Operation for PutBucketVersioning {
         "PutBucketVersioning"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5438,6 +5522,10 @@ impl PutBucketWebsite {
 impl super::Operation for PutBucketWebsite {
     fn name(&self) -> &'static str {
         "PutBucketWebsite"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -5896,6 +5984,10 @@ impl super::Operation for PutObjectAcl {
         "PutObjectAcl"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5964,6 +6056,10 @@ impl super::Operation for PutObjectLegalHold {
         "PutObjectLegalHold"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6023,6 +6119,10 @@ impl PutObjectLockConfiguration {
 impl super::Operation for PutObjectLockConfiguration {
     fn name(&self) -> &'static str {
         "PutObjectLockConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6097,6 +6197,10 @@ impl super::Operation for PutObjectRetention {
         "PutObjectRetention"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6159,6 +6263,10 @@ impl super::Operation for PutObjectTagging {
         "PutObjectTagging"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6210,6 +6318,10 @@ impl PutPublicAccessBlock {
 impl super::Operation for PutPublicAccessBlock {
     fn name(&self) -> &'static str {
         "PutPublicAccessBlock"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6270,6 +6382,10 @@ impl RestoreObject {
 impl super::Operation for RestoreObject {
     fn name(&self) -> &'static str {
         "RestoreObject"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6333,6 +6449,10 @@ impl SelectObjectContent {
 impl super::Operation for SelectObjectContent {
     fn name(&self) -> &'static str {
         "SelectObjectContent"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6913,147 +7033,147 @@ pub fn resolve_route(
     req: &http::Request,
     s3_path: &S3Path,
     qs: Option<&http::OrderedQs>,
-) -> S3Result<(&'static dyn super::Operation, bool)> {
+) -> S3Result<&'static dyn super::Operation> {
     match req.method {
         hyper::Method::HEAD => match s3_path {
             S3Path::Root => Err(super::unknown_operation()),
-            S3Path::Bucket { .. } => Ok((&HeadBucket as &'static dyn super::Operation, false)),
-            S3Path::Object { .. } => Ok((&HeadObject as &'static dyn super::Operation, false)),
+            S3Path::Bucket { .. } => Ok(&HeadBucket as &'static dyn super::Operation),
+            S3Path::Object { .. } => Ok(&HeadObject as &'static dyn super::Operation),
         },
         hyper::Method::GET => match s3_path {
             S3Path::Root => {
                 if let Some(qs) = qs {
                     if super::check_query_pattern(qs, "x-id", "ListDirectoryBuckets") {
-                        return Ok((&ListDirectoryBuckets as &'static dyn super::Operation, false));
+                        return Ok(&ListDirectoryBuckets as &'static dyn super::Operation);
                     }
                 }
-                Ok((&ListBuckets as &'static dyn super::Operation, false))
+                Ok(&ListBuckets as &'static dyn super::Operation)
             }
             S3Path::Bucket { .. } => {
                 if let Some(qs) = qs {
                     if qs.has("analytics") && qs.has("id") {
-                        return Ok((&GetBucketAnalyticsConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketAnalyticsConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("intelligent-tiering") && qs.has("id") {
-                        return Ok((&GetBucketIntelligentTieringConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketIntelligentTieringConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("inventory") && qs.has("id") {
-                        return Ok((&GetBucketInventoryConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketInventoryConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("metrics") && qs.has("id") {
-                        return Ok((&GetBucketMetricsConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketMetricsConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("session") {
-                        return Ok((&CreateSession as &'static dyn super::Operation, false));
+                        return Ok(&CreateSession as &'static dyn super::Operation);
                     }
                     if qs.has("accelerate") {
-                        return Ok((&GetBucketAccelerateConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketAccelerateConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("acl") {
-                        return Ok((&GetBucketAcl as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketAcl as &'static dyn super::Operation);
                     }
                     if qs.has("cors") {
-                        return Ok((&GetBucketCors as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketCors as &'static dyn super::Operation);
                     }
                     if qs.has("encryption") {
-                        return Ok((&GetBucketEncryption as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketEncryption as &'static dyn super::Operation);
                     }
                     if qs.has("lifecycle") {
-                        return Ok((&GetBucketLifecycleConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketLifecycleConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("location") {
-                        return Ok((&GetBucketLocation as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketLocation as &'static dyn super::Operation);
                     }
                     if qs.has("logging") {
-                        return Ok((&GetBucketLogging as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketLogging as &'static dyn super::Operation);
                     }
                     if qs.has("metadataTable") {
-                        return Ok((&GetBucketMetadataTableConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketMetadataTableConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("notification") {
-                        return Ok((&GetBucketNotificationConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketNotificationConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("ownershipControls") {
-                        return Ok((&GetBucketOwnershipControls as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketOwnershipControls as &'static dyn super::Operation);
                     }
                     if qs.has("policy") {
-                        return Ok((&GetBucketPolicy as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketPolicy as &'static dyn super::Operation);
                     }
                     if qs.has("policyStatus") {
-                        return Ok((&GetBucketPolicyStatus as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketPolicyStatus as &'static dyn super::Operation);
                     }
                     if qs.has("replication") {
-                        return Ok((&GetBucketReplication as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketReplication as &'static dyn super::Operation);
                     }
                     if qs.has("requestPayment") {
-                        return Ok((&GetBucketRequestPayment as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketRequestPayment as &'static dyn super::Operation);
                     }
                     if qs.has("tagging") {
-                        return Ok((&GetBucketTagging as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketTagging as &'static dyn super::Operation);
                     }
                     if qs.has("versioning") {
-                        return Ok((&GetBucketVersioning as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketVersioning as &'static dyn super::Operation);
                     }
                     if qs.has("website") {
-                        return Ok((&GetBucketWebsite as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketWebsite as &'static dyn super::Operation);
                     }
                     if qs.has("object-lock") {
-                        return Ok((&GetObjectLockConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetObjectLockConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("publicAccessBlock") {
-                        return Ok((&GetPublicAccessBlock as &'static dyn super::Operation, false));
+                        return Ok(&GetPublicAccessBlock as &'static dyn super::Operation);
                     }
                     if qs.has("analytics") && !qs.has("id") {
-                        return Ok((&ListBucketAnalyticsConfigurations as &'static dyn super::Operation, false));
+                        return Ok(&ListBucketAnalyticsConfigurations as &'static dyn super::Operation);
                     }
                     if qs.has("intelligent-tiering") && !qs.has("id") {
-                        return Ok((&ListBucketIntelligentTieringConfigurations as &'static dyn super::Operation, false));
+                        return Ok(&ListBucketIntelligentTieringConfigurations as &'static dyn super::Operation);
                     }
                     if qs.has("inventory") && !qs.has("id") {
-                        return Ok((&ListBucketInventoryConfigurations as &'static dyn super::Operation, false));
+                        return Ok(&ListBucketInventoryConfigurations as &'static dyn super::Operation);
                     }
                     if qs.has("metrics") && !qs.has("id") {
-                        return Ok((&ListBucketMetricsConfigurations as &'static dyn super::Operation, false));
+                        return Ok(&ListBucketMetricsConfigurations as &'static dyn super::Operation);
                     }
                     if qs.has("uploads") {
-                        return Ok((&ListMultipartUploads as &'static dyn super::Operation, false));
+                        return Ok(&ListMultipartUploads as &'static dyn super::Operation);
                     }
                     if qs.has("versions") {
-                        return Ok((&ListObjectVersions as &'static dyn super::Operation, false));
+                        return Ok(&ListObjectVersions as &'static dyn super::Operation);
                     }
                     if super::check_query_pattern(qs, "list-type", "2") {
-                        return Ok((&ListObjectsV2 as &'static dyn super::Operation, false));
+                        return Ok(&ListObjectsV2 as &'static dyn super::Operation);
                     }
                 }
-                Ok((&ListObjects as &'static dyn super::Operation, false))
+                Ok(&ListObjects as &'static dyn super::Operation)
             }
             S3Path::Object { .. } => {
                 if let Some(qs) = qs {
                     if qs.has("attributes") {
-                        return Ok((&GetObjectAttributes as &'static dyn super::Operation, false));
+                        return Ok(&GetObjectAttributes as &'static dyn super::Operation);
                     }
                     if qs.has("acl") {
-                        return Ok((&GetObjectAcl as &'static dyn super::Operation, false));
+                        return Ok(&GetObjectAcl as &'static dyn super::Operation);
                     }
                     if qs.has("legal-hold") {
-                        return Ok((&GetObjectLegalHold as &'static dyn super::Operation, false));
+                        return Ok(&GetObjectLegalHold as &'static dyn super::Operation);
                     }
                     if qs.has("retention") {
-                        return Ok((&GetObjectRetention as &'static dyn super::Operation, false));
+                        return Ok(&GetObjectRetention as &'static dyn super::Operation);
                     }
                     if qs.has("tagging") {
-                        return Ok((&GetObjectTagging as &'static dyn super::Operation, false));
+                        return Ok(&GetObjectTagging as &'static dyn super::Operation);
                     }
                     if qs.has("torrent") {
-                        return Ok((&GetObjectTorrent as &'static dyn super::Operation, false));
+                        return Ok(&GetObjectTorrent as &'static dyn super::Operation);
                     }
                 }
                 if let Some(qs) = qs
                     && qs.has("uploadId")
                 {
-                    return Ok((&ListParts as &'static dyn super::Operation, false));
+                    return Ok(&ListParts as &'static dyn super::Operation);
                 }
-                Ok((&GetObject as &'static dyn super::Operation, false))
+                Ok(&GetObject as &'static dyn super::Operation)
             }
         },
         hyper::Method::POST => match s3_path {
@@ -7061,33 +7181,33 @@ pub fn resolve_route(
             S3Path::Bucket { .. } => {
                 if let Some(qs) = qs {
                     if qs.has("metadataTable") {
-                        return Ok((&CreateBucketMetadataTableConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&CreateBucketMetadataTableConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("delete") {
-                        return Ok((&DeleteObjects as &'static dyn super::Operation, true));
+                        return Ok(&DeleteObjects as &'static dyn super::Operation);
                     }
                 }
                 if req.headers.contains_key("x-amz-request-route") && req.headers.contains_key("x-amz-request-token") {
-                    return Ok((&WriteGetObjectResponse as &'static dyn super::Operation, false));
+                    return Ok(&WriteGetObjectResponse as &'static dyn super::Operation);
                 }
                 Err(super::unknown_operation())
             }
             S3Path::Object { .. } => {
                 if let Some(qs) = qs {
                     if qs.has("select") && super::check_query_pattern(qs, "select-type", "2") {
-                        return Ok((&SelectObjectContent as &'static dyn super::Operation, true));
+                        return Ok(&SelectObjectContent as &'static dyn super::Operation);
                     }
                     if qs.has("uploads") {
-                        return Ok((&CreateMultipartUpload as &'static dyn super::Operation, false));
+                        return Ok(&CreateMultipartUpload as &'static dyn super::Operation);
                     }
                     if qs.has("restore") {
-                        return Ok((&RestoreObject as &'static dyn super::Operation, true));
+                        return Ok(&RestoreObject as &'static dyn super::Operation);
                     }
                 }
                 if let Some(qs) = qs
                     && qs.has("uploadId")
                 {
-                    return Ok((&CompleteMultipartUpload as &'static dyn super::Operation, true));
+                    return Ok(&CompleteMultipartUpload as &'static dyn super::Operation);
                 }
                 Err(super::unknown_operation())
             }
@@ -7097,81 +7217,81 @@ pub fn resolve_route(
             S3Path::Bucket { .. } => {
                 if let Some(qs) = qs {
                     if qs.has("analytics") {
-                        return Ok((&PutBucketAnalyticsConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketAnalyticsConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("intelligent-tiering") {
-                        return Ok((&PutBucketIntelligentTieringConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketIntelligentTieringConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("inventory") {
-                        return Ok((&PutBucketInventoryConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketInventoryConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("metrics") {
-                        return Ok((&PutBucketMetricsConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketMetricsConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("accelerate") {
-                        return Ok((&PutBucketAccelerateConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketAccelerateConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("acl") {
-                        return Ok((&PutBucketAcl as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketAcl as &'static dyn super::Operation);
                     }
                     if qs.has("cors") {
-                        return Ok((&PutBucketCors as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketCors as &'static dyn super::Operation);
                     }
                     if qs.has("encryption") {
-                        return Ok((&PutBucketEncryption as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketEncryption as &'static dyn super::Operation);
                     }
                     if qs.has("lifecycle") {
-                        return Ok((&PutBucketLifecycleConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketLifecycleConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("logging") {
-                        return Ok((&PutBucketLogging as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketLogging as &'static dyn super::Operation);
                     }
                     if qs.has("notification") {
-                        return Ok((&PutBucketNotificationConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketNotificationConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("ownershipControls") {
-                        return Ok((&PutBucketOwnershipControls as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketOwnershipControls as &'static dyn super::Operation);
                     }
                     if qs.has("policy") {
-                        return Ok((&PutBucketPolicy as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketPolicy as &'static dyn super::Operation);
                     }
                     if qs.has("replication") {
-                        return Ok((&PutBucketReplication as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketReplication as &'static dyn super::Operation);
                     }
                     if qs.has("requestPayment") {
-                        return Ok((&PutBucketRequestPayment as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketRequestPayment as &'static dyn super::Operation);
                     }
                     if qs.has("tagging") {
-                        return Ok((&PutBucketTagging as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketTagging as &'static dyn super::Operation);
                     }
                     if qs.has("versioning") {
-                        return Ok((&PutBucketVersioning as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketVersioning as &'static dyn super::Operation);
                     }
                     if qs.has("website") {
-                        return Ok((&PutBucketWebsite as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketWebsite as &'static dyn super::Operation);
                     }
                     if qs.has("object-lock") {
-                        return Ok((&PutObjectLockConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&PutObjectLockConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("publicAccessBlock") {
-                        return Ok((&PutPublicAccessBlock as &'static dyn super::Operation, true));
+                        return Ok(&PutPublicAccessBlock as &'static dyn super::Operation);
                     }
                 }
-                Ok((&CreateBucket as &'static dyn super::Operation, true))
+                Ok(&CreateBucket as &'static dyn super::Operation)
             }
             S3Path::Object { .. } => {
                 if let Some(qs) = qs {
                     if qs.has("acl") {
-                        return Ok((&PutObjectAcl as &'static dyn super::Operation, true));
+                        return Ok(&PutObjectAcl as &'static dyn super::Operation);
                     }
                     if qs.has("legal-hold") {
-                        return Ok((&PutObjectLegalHold as &'static dyn super::Operation, true));
+                        return Ok(&PutObjectLegalHold as &'static dyn super::Operation);
                     }
                     if qs.has("retention") {
-                        return Ok((&PutObjectRetention as &'static dyn super::Operation, true));
+                        return Ok(&PutObjectRetention as &'static dyn super::Operation);
                     }
                     if qs.has("tagging") {
-                        return Ok((&PutObjectTagging as &'static dyn super::Operation, true));
+                        return Ok(&PutObjectTagging as &'static dyn super::Operation);
                     }
                 }
                 if let Some(qs) = qs
@@ -7179,18 +7299,18 @@ pub fn resolve_route(
                     && qs.has("uploadId")
                     && req.headers.contains_key("x-amz-copy-source")
                 {
-                    return Ok((&UploadPartCopy as &'static dyn super::Operation, false));
+                    return Ok(&UploadPartCopy as &'static dyn super::Operation);
                 }
                 if let Some(qs) = qs
                     && qs.has("partNumber")
                     && qs.has("uploadId")
                 {
-                    return Ok((&UploadPart as &'static dyn super::Operation, false));
+                    return Ok(&UploadPart as &'static dyn super::Operation);
                 }
                 if req.headers.contains_key("x-amz-copy-source") {
-                    return Ok((&CopyObject as &'static dyn super::Operation, false));
+                    return Ok(&CopyObject as &'static dyn super::Operation);
                 }
-                Ok((&PutObject as &'static dyn super::Operation, false))
+                Ok(&PutObject as &'static dyn super::Operation)
             }
         },
         hyper::Method::DELETE => match s3_path {
@@ -7198,62 +7318,62 @@ pub fn resolve_route(
             S3Path::Bucket { .. } => {
                 if let Some(qs) = qs {
                     if qs.has("analytics") {
-                        return Ok((&DeleteBucketAnalyticsConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketAnalyticsConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("intelligent-tiering") {
-                        return Ok((&DeleteBucketIntelligentTieringConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketIntelligentTieringConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("inventory") {
-                        return Ok((&DeleteBucketInventoryConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketInventoryConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("metrics") {
-                        return Ok((&DeleteBucketMetricsConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketMetricsConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("cors") {
-                        return Ok((&DeleteBucketCors as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketCors as &'static dyn super::Operation);
                     }
                     if qs.has("encryption") {
-                        return Ok((&DeleteBucketEncryption as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketEncryption as &'static dyn super::Operation);
                     }
                     if qs.has("lifecycle") {
-                        return Ok((&DeleteBucketLifecycle as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketLifecycle as &'static dyn super::Operation);
                     }
                     if qs.has("metadataTable") {
-                        return Ok((&DeleteBucketMetadataTableConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketMetadataTableConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("ownershipControls") {
-                        return Ok((&DeleteBucketOwnershipControls as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketOwnershipControls as &'static dyn super::Operation);
                     }
                     if qs.has("policy") {
-                        return Ok((&DeleteBucketPolicy as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketPolicy as &'static dyn super::Operation);
                     }
                     if qs.has("replication") {
-                        return Ok((&DeleteBucketReplication as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketReplication as &'static dyn super::Operation);
                     }
                     if qs.has("tagging") {
-                        return Ok((&DeleteBucketTagging as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketTagging as &'static dyn super::Operation);
                     }
                     if qs.has("website") {
-                        return Ok((&DeleteBucketWebsite as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketWebsite as &'static dyn super::Operation);
                     }
                     if qs.has("publicAccessBlock") {
-                        return Ok((&DeletePublicAccessBlock as &'static dyn super::Operation, false));
+                        return Ok(&DeletePublicAccessBlock as &'static dyn super::Operation);
                     }
                 }
-                Ok((&DeleteBucket as &'static dyn super::Operation, false))
+                Ok(&DeleteBucket as &'static dyn super::Operation)
             }
             S3Path::Object { .. } => {
                 if let Some(qs) = qs {
                     if qs.has("tagging") {
-                        return Ok((&DeleteObjectTagging as &'static dyn super::Operation, false));
+                        return Ok(&DeleteObjectTagging as &'static dyn super::Operation);
                     }
                 }
                 if let Some(qs) = qs
                     && qs.has("uploadId")
                 {
-                    return Ok((&AbortMultipartUpload as &'static dyn super::Operation, false));
+                    return Ok(&AbortMultipartUpload as &'static dyn super::Operation);
                 }
-                Ok((&DeleteObject as &'static dyn super::Operation, false))
+                Ok(&DeleteObject as &'static dyn super::Operation)
             }
         },
         _ => Err(super::unknown_operation()),

--- a/crates/s3s/src/ops/generated_minio.rs
+++ b/crates/s3s/src/ops/generated_minio.rs
@@ -535,6 +535,10 @@ impl super::Operation for AbortMultipartUpload {
         "AbortMultipartUpload"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -837,6 +841,10 @@ impl super::Operation for CopyObject {
         "CopyObject"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1121,6 +1129,10 @@ impl super::Operation for CreateMultipartUpload {
         "CreateMultipartUpload"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1185,6 +1197,10 @@ impl super::Operation for CreateSession {
         "CreateSession"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1230,6 +1246,10 @@ impl DeleteBucket {
 impl super::Operation for DeleteBucket {
     fn name(&self) -> &'static str {
         "DeleteBucket"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1279,6 +1299,10 @@ impl super::Operation for DeleteBucketAnalyticsConfiguration {
         "DeleteBucketAnalyticsConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1321,6 +1345,10 @@ impl DeleteBucketCors {
 impl super::Operation for DeleteBucketCors {
     fn name(&self) -> &'static str {
         "DeleteBucketCors"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1367,6 +1395,10 @@ impl super::Operation for DeleteBucketEncryption {
         "DeleteBucketEncryption"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1406,6 +1438,10 @@ impl DeleteBucketIntelligentTieringConfiguration {
 impl super::Operation for DeleteBucketIntelligentTieringConfiguration {
     fn name(&self) -> &'static str {
         "DeleteBucketIntelligentTieringConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1455,6 +1491,10 @@ impl super::Operation for DeleteBucketInventoryConfiguration {
         "DeleteBucketInventoryConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1499,6 +1539,10 @@ impl super::Operation for DeleteBucketLifecycle {
         "DeleteBucketLifecycle"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1541,6 +1585,10 @@ impl DeleteBucketMetadataTableConfiguration {
 impl super::Operation for DeleteBucketMetadataTableConfiguration {
     fn name(&self) -> &'static str {
         "DeleteBucketMetadataTableConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1590,6 +1638,10 @@ impl super::Operation for DeleteBucketMetricsConfiguration {
         "DeleteBucketMetricsConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1632,6 +1684,10 @@ impl DeleteBucketOwnershipControls {
 impl super::Operation for DeleteBucketOwnershipControls {
     fn name(&self) -> &'static str {
         "DeleteBucketOwnershipControls"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1678,6 +1734,10 @@ impl super::Operation for DeleteBucketPolicy {
         "DeleteBucketPolicy"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1720,6 +1780,10 @@ impl DeleteBucketReplication {
 impl super::Operation for DeleteBucketReplication {
     fn name(&self) -> &'static str {
         "DeleteBucketReplication"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1766,6 +1830,10 @@ impl super::Operation for DeleteBucketTagging {
         "DeleteBucketTagging"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1808,6 +1876,10 @@ impl DeleteBucketWebsite {
 impl super::Operation for DeleteBucketWebsite {
     fn name(&self) -> &'static str {
         "DeleteBucketWebsite"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1882,6 +1954,10 @@ impl super::Operation for DeleteObject {
         "DeleteObject"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1930,6 +2006,10 @@ impl DeleteObjectTagging {
 impl super::Operation for DeleteObjectTagging {
     fn name(&self) -> &'static str {
         "DeleteObjectTagging"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2043,6 +2123,10 @@ impl super::Operation for DeletePublicAccessBlock {
         "DeletePublicAccessBlock"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2093,6 +2177,10 @@ impl super::Operation for GetBucketAccelerateConfiguration {
         "GetBucketAccelerateConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2137,6 +2225,10 @@ impl GetBucketAcl {
 impl super::Operation for GetBucketAcl {
     fn name(&self) -> &'static str {
         "GetBucketAcl"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2190,6 +2282,10 @@ impl super::Operation for GetBucketAnalyticsConfiguration {
         "GetBucketAnalyticsConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2234,6 +2330,10 @@ impl GetBucketCors {
 impl super::Operation for GetBucketCors {
     fn name(&self) -> &'static str {
         "GetBucketCors"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2284,6 +2384,10 @@ impl super::Operation for GetBucketEncryption {
         "GetBucketEncryption"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2327,6 +2431,10 @@ impl GetBucketIntelligentTieringConfiguration {
 impl super::Operation for GetBucketIntelligentTieringConfiguration {
     fn name(&self) -> &'static str {
         "GetBucketIntelligentTieringConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2380,6 +2488,10 @@ impl super::Operation for GetBucketInventoryConfiguration {
         "GetBucketInventoryConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2431,6 +2543,10 @@ impl super::Operation for GetBucketLifecycleConfiguration {
         "GetBucketLifecycleConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2475,6 +2591,10 @@ impl GetBucketLocation {
 impl super::Operation for GetBucketLocation {
     fn name(&self) -> &'static str {
         "GetBucketLocation"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2523,6 +2643,10 @@ impl super::Operation for GetBucketLogging {
         "GetBucketLogging"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2569,6 +2693,10 @@ impl GetBucketMetadataTableConfiguration {
 impl super::Operation for GetBucketMetadataTableConfiguration {
     fn name(&self) -> &'static str {
         "GetBucketMetadataTableConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2622,6 +2750,10 @@ impl super::Operation for GetBucketMetricsConfiguration {
         "GetBucketMetricsConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2666,6 +2798,10 @@ impl GetBucketNotificationConfiguration {
 impl super::Operation for GetBucketNotificationConfiguration {
     fn name(&self) -> &'static str {
         "GetBucketNotificationConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2716,6 +2852,10 @@ impl super::Operation for GetBucketOwnershipControls {
         "GetBucketOwnershipControls"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2762,6 +2902,10 @@ impl GetBucketPolicy {
 impl super::Operation for GetBucketPolicy {
     fn name(&self) -> &'static str {
         "GetBucketPolicy"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2812,6 +2956,10 @@ impl super::Operation for GetBucketPolicyStatus {
         "GetBucketPolicyStatus"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2860,6 +3008,10 @@ impl super::Operation for GetBucketReplication {
         "GetBucketReplication"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2904,6 +3056,10 @@ impl GetBucketRequestPayment {
 impl super::Operation for GetBucketRequestPayment {
     fn name(&self) -> &'static str {
         "GetBucketRequestPayment"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -2952,6 +3108,10 @@ impl super::Operation for GetBucketTagging {
         "GetBucketTagging"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2998,6 +3158,10 @@ impl super::Operation for GetBucketVersioning {
         "GetBucketVersioning"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3042,6 +3206,10 @@ impl GetBucketWebsite {
 impl super::Operation for GetBucketWebsite {
     fn name(&self) -> &'static str {
         "GetBucketWebsite"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -3203,6 +3371,10 @@ impl super::Operation for GetObject {
         "GetObject"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3257,6 +3429,10 @@ impl GetObjectAcl {
 impl super::Operation for GetObjectAcl {
     fn name(&self) -> &'static str {
         "GetObjectAcl"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -3336,6 +3512,10 @@ impl super::Operation for GetObjectAttributes {
         "GetObjectAttributes"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3391,6 +3571,10 @@ impl super::Operation for GetObjectLegalHold {
         "GetObjectLegalHold"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3437,6 +3621,10 @@ impl GetObjectLockConfiguration {
 impl super::Operation for GetObjectLockConfiguration {
     fn name(&self) -> &'static str {
         "GetObjectLockConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -3494,6 +3682,10 @@ impl super::Operation for GetObjectRetention {
         "GetObjectRetention"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3546,6 +3738,10 @@ impl GetObjectTagging {
 impl super::Operation for GetObjectTagging {
     fn name(&self) -> &'static str {
         "GetObjectTagging"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -3601,6 +3797,10 @@ impl super::Operation for GetObjectTorrent {
         "GetObjectTorrent"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3647,6 +3847,10 @@ impl GetPublicAccessBlock {
 impl super::Operation for GetPublicAccessBlock {
     fn name(&self) -> &'static str {
         "GetPublicAccessBlock"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -3696,6 +3900,10 @@ impl HeadBucket {
 impl super::Operation for HeadBucket {
     fn name(&self) -> &'static str {
         "HeadBucket"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -3851,6 +4059,10 @@ impl super::Operation for HeadObject {
         "HeadObject"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3900,6 +4112,10 @@ impl super::Operation for ListBucketAnalyticsConfigurations {
         "ListBucketAnalyticsConfigurations"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3944,6 +4160,10 @@ impl ListBucketIntelligentTieringConfigurations {
 impl super::Operation for ListBucketIntelligentTieringConfigurations {
     fn name(&self) -> &'static str {
         "ListBucketIntelligentTieringConfigurations"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -3995,6 +4215,10 @@ impl super::Operation for ListBucketInventoryConfigurations {
         "ListBucketInventoryConfigurations"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4042,6 +4266,10 @@ impl ListBucketMetricsConfigurations {
 impl super::Operation for ListBucketMetricsConfigurations {
     fn name(&self) -> &'static str {
         "ListBucketMetricsConfigurations"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -4096,6 +4324,10 @@ impl super::Operation for ListBuckets {
         "ListBuckets"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4140,6 +4372,10 @@ impl ListDirectoryBuckets {
 impl super::Operation for ListDirectoryBuckets {
     fn name(&self) -> &'static str {
         "ListDirectoryBuckets"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -4208,6 +4444,10 @@ impl ListMultipartUploads {
 impl super::Operation for ListMultipartUploads {
     fn name(&self) -> &'static str {
         "ListMultipartUploads"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -4282,6 +4522,10 @@ impl super::Operation for ListObjectVersions {
         "ListObjectVersions"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4349,6 +4593,10 @@ impl ListObjects {
 impl super::Operation for ListObjects {
     fn name(&self) -> &'static str {
         "ListObjects"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -4426,6 +4674,10 @@ impl super::Operation for ListObjectsV2 {
         "ListObjectsV2"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4497,6 +4749,10 @@ impl ListParts {
 impl super::Operation for ListParts {
     fn name(&self) -> &'static str {
         "ListParts"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -5920,6 +6176,10 @@ impl super::Operation for PutObject {
         "PutObject"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6597,6 +6857,10 @@ impl super::Operation for UploadPart {
         "UploadPart"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6707,6 +6971,10 @@ impl UploadPartCopy {
 impl super::Operation for UploadPartCopy {
     fn name(&self) -> &'static str {
         "UploadPartCopy"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6900,6 +7168,10 @@ impl super::Operation for WriteGetObjectResponse {
         "WriteGetObjectResponse"
     }
 
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -7007,6 +7279,10 @@ impl PostObject {
 impl super::Operation for PostObject {
     fn name(&self) -> &'static str {
         "PostObject"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {

--- a/crates/s3s/src/ops/generated_minio.rs
+++ b/crates/s3s/src/ops/generated_minio.rs
@@ -644,6 +644,10 @@ impl super::Operation for CompleteMultipartUpload {
         "CompleteMultipartUpload"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -904,6 +908,10 @@ impl super::Operation for CreateBucket {
         "CreateBucket"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -955,6 +963,10 @@ impl CreateBucketMetadataTableConfiguration {
 impl super::Operation for CreateBucketMetadataTableConfiguration {
     fn name(&self) -> &'static str {
         "CreateBucketMetadataTableConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1981,6 +1993,10 @@ impl DeleteObjects {
 impl super::Operation for DeleteObjects {
     fn name(&self) -> &'static str {
         "DeleteObjects"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -4533,6 +4549,10 @@ impl super::Operation for PutBucketAccelerateConfiguration {
         "PutBucketAccelerateConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4604,6 +4624,10 @@ impl super::Operation for PutBucketAcl {
         "PutBucketAcl"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4652,6 +4676,10 @@ impl PutBucketAnalyticsConfiguration {
 impl super::Operation for PutBucketAnalyticsConfiguration {
     fn name(&self) -> &'static str {
         "PutBucketAnalyticsConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -4707,6 +4735,10 @@ impl super::Operation for PutBucketCors {
         "PutBucketCors"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4760,6 +4792,10 @@ impl super::Operation for PutBucketEncryption {
         "PutBucketEncryption"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4805,6 +4841,10 @@ impl PutBucketIntelligentTieringConfiguration {
 impl super::Operation for PutBucketIntelligentTieringConfiguration {
     fn name(&self) -> &'static str {
         "PutBucketIntelligentTieringConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -4855,6 +4895,10 @@ impl PutBucketInventoryConfiguration {
 impl super::Operation for PutBucketInventoryConfiguration {
     fn name(&self) -> &'static str {
         "PutBucketInventoryConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -4917,6 +4961,10 @@ impl super::Operation for PutBucketLifecycleConfiguration {
         "PutBucketLifecycleConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4970,6 +5018,10 @@ impl super::Operation for PutBucketLogging {
         "PutBucketLogging"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5018,6 +5070,10 @@ impl PutBucketMetricsConfiguration {
 impl super::Operation for PutBucketMetricsConfiguration {
     fn name(&self) -> &'static str {
         "PutBucketMetricsConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -5071,6 +5127,10 @@ impl super::Operation for PutBucketNotificationConfiguration {
         "PutBucketNotificationConfiguration"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5119,6 +5179,10 @@ impl PutBucketOwnershipControls {
 impl super::Operation for PutBucketOwnershipControls {
     fn name(&self) -> &'static str {
         "PutBucketOwnershipControls"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -5178,6 +5242,10 @@ impl super::Operation for PutBucketPolicy {
         "PutBucketPolicy"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5234,6 +5302,10 @@ impl super::Operation for PutBucketReplication {
         "PutBucketReplication"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5287,6 +5359,10 @@ impl super::Operation for PutBucketRequestPayment {
         "PutBucketRequestPayment"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5338,6 +5414,10 @@ impl PutBucketTagging {
 impl super::Operation for PutBucketTagging {
     fn name(&self) -> &'static str {
         "PutBucketTagging"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -5397,6 +5477,10 @@ impl super::Operation for PutBucketVersioning {
         "PutBucketVersioning"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5448,6 +5532,10 @@ impl PutBucketWebsite {
 impl super::Operation for PutBucketWebsite {
     fn name(&self) -> &'static str {
         "PutBucketWebsite"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -5912,6 +6000,10 @@ impl super::Operation for PutObjectAcl {
         "PutObjectAcl"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5980,6 +6072,10 @@ impl super::Operation for PutObjectLegalHold {
         "PutObjectLegalHold"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6040,6 +6136,10 @@ impl PutObjectLockConfiguration {
 impl super::Operation for PutObjectLockConfiguration {
     fn name(&self) -> &'static str {
         "PutObjectLockConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6114,6 +6214,10 @@ impl super::Operation for PutObjectRetention {
         "PutObjectRetention"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6176,6 +6280,10 @@ impl super::Operation for PutObjectTagging {
         "PutObjectTagging"
     }
 
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6227,6 +6335,10 @@ impl PutPublicAccessBlock {
 impl super::Operation for PutPublicAccessBlock {
     fn name(&self) -> &'static str {
         "PutPublicAccessBlock"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6287,6 +6399,10 @@ impl RestoreObject {
 impl super::Operation for RestoreObject {
     fn name(&self) -> &'static str {
         "RestoreObject"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6350,6 +6466,10 @@ impl SelectObjectContent {
 impl super::Operation for SelectObjectContent {
     fn name(&self) -> &'static str {
         "SelectObjectContent"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6930,147 +7050,147 @@ pub fn resolve_route(
     req: &http::Request,
     s3_path: &S3Path,
     qs: Option<&http::OrderedQs>,
-) -> S3Result<(&'static dyn super::Operation, bool)> {
+) -> S3Result<&'static dyn super::Operation> {
     match req.method {
         hyper::Method::HEAD => match s3_path {
             S3Path::Root => Err(super::unknown_operation()),
-            S3Path::Bucket { .. } => Ok((&HeadBucket as &'static dyn super::Operation, false)),
-            S3Path::Object { .. } => Ok((&HeadObject as &'static dyn super::Operation, false)),
+            S3Path::Bucket { .. } => Ok(&HeadBucket as &'static dyn super::Operation),
+            S3Path::Object { .. } => Ok(&HeadObject as &'static dyn super::Operation),
         },
         hyper::Method::GET => match s3_path {
             S3Path::Root => {
                 if let Some(qs) = qs {
                     if super::check_query_pattern(qs, "x-id", "ListDirectoryBuckets") {
-                        return Ok((&ListDirectoryBuckets as &'static dyn super::Operation, false));
+                        return Ok(&ListDirectoryBuckets as &'static dyn super::Operation);
                     }
                 }
-                Ok((&ListBuckets as &'static dyn super::Operation, false))
+                Ok(&ListBuckets as &'static dyn super::Operation)
             }
             S3Path::Bucket { .. } => {
                 if let Some(qs) = qs {
                     if qs.has("analytics") && qs.has("id") {
-                        return Ok((&GetBucketAnalyticsConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketAnalyticsConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("intelligent-tiering") && qs.has("id") {
-                        return Ok((&GetBucketIntelligentTieringConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketIntelligentTieringConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("inventory") && qs.has("id") {
-                        return Ok((&GetBucketInventoryConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketInventoryConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("metrics") && qs.has("id") {
-                        return Ok((&GetBucketMetricsConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketMetricsConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("session") {
-                        return Ok((&CreateSession as &'static dyn super::Operation, false));
+                        return Ok(&CreateSession as &'static dyn super::Operation);
                     }
                     if qs.has("accelerate") {
-                        return Ok((&GetBucketAccelerateConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketAccelerateConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("acl") {
-                        return Ok((&GetBucketAcl as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketAcl as &'static dyn super::Operation);
                     }
                     if qs.has("cors") {
-                        return Ok((&GetBucketCors as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketCors as &'static dyn super::Operation);
                     }
                     if qs.has("encryption") {
-                        return Ok((&GetBucketEncryption as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketEncryption as &'static dyn super::Operation);
                     }
                     if qs.has("lifecycle") {
-                        return Ok((&GetBucketLifecycleConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketLifecycleConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("location") {
-                        return Ok((&GetBucketLocation as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketLocation as &'static dyn super::Operation);
                     }
                     if qs.has("logging") {
-                        return Ok((&GetBucketLogging as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketLogging as &'static dyn super::Operation);
                     }
                     if qs.has("metadataTable") {
-                        return Ok((&GetBucketMetadataTableConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketMetadataTableConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("notification") {
-                        return Ok((&GetBucketNotificationConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketNotificationConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("ownershipControls") {
-                        return Ok((&GetBucketOwnershipControls as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketOwnershipControls as &'static dyn super::Operation);
                     }
                     if qs.has("policy") {
-                        return Ok((&GetBucketPolicy as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketPolicy as &'static dyn super::Operation);
                     }
                     if qs.has("policyStatus") {
-                        return Ok((&GetBucketPolicyStatus as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketPolicyStatus as &'static dyn super::Operation);
                     }
                     if qs.has("replication") {
-                        return Ok((&GetBucketReplication as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketReplication as &'static dyn super::Operation);
                     }
                     if qs.has("requestPayment") {
-                        return Ok((&GetBucketRequestPayment as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketRequestPayment as &'static dyn super::Operation);
                     }
                     if qs.has("tagging") {
-                        return Ok((&GetBucketTagging as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketTagging as &'static dyn super::Operation);
                     }
                     if qs.has("versioning") {
-                        return Ok((&GetBucketVersioning as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketVersioning as &'static dyn super::Operation);
                     }
                     if qs.has("website") {
-                        return Ok((&GetBucketWebsite as &'static dyn super::Operation, false));
+                        return Ok(&GetBucketWebsite as &'static dyn super::Operation);
                     }
                     if qs.has("object-lock") {
-                        return Ok((&GetObjectLockConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&GetObjectLockConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("publicAccessBlock") {
-                        return Ok((&GetPublicAccessBlock as &'static dyn super::Operation, false));
+                        return Ok(&GetPublicAccessBlock as &'static dyn super::Operation);
                     }
                     if qs.has("analytics") && !qs.has("id") {
-                        return Ok((&ListBucketAnalyticsConfigurations as &'static dyn super::Operation, false));
+                        return Ok(&ListBucketAnalyticsConfigurations as &'static dyn super::Operation);
                     }
                     if qs.has("intelligent-tiering") && !qs.has("id") {
-                        return Ok((&ListBucketIntelligentTieringConfigurations as &'static dyn super::Operation, false));
+                        return Ok(&ListBucketIntelligentTieringConfigurations as &'static dyn super::Operation);
                     }
                     if qs.has("inventory") && !qs.has("id") {
-                        return Ok((&ListBucketInventoryConfigurations as &'static dyn super::Operation, false));
+                        return Ok(&ListBucketInventoryConfigurations as &'static dyn super::Operation);
                     }
                     if qs.has("metrics") && !qs.has("id") {
-                        return Ok((&ListBucketMetricsConfigurations as &'static dyn super::Operation, false));
+                        return Ok(&ListBucketMetricsConfigurations as &'static dyn super::Operation);
                     }
                     if qs.has("uploads") {
-                        return Ok((&ListMultipartUploads as &'static dyn super::Operation, false));
+                        return Ok(&ListMultipartUploads as &'static dyn super::Operation);
                     }
                     if qs.has("versions") {
-                        return Ok((&ListObjectVersions as &'static dyn super::Operation, false));
+                        return Ok(&ListObjectVersions as &'static dyn super::Operation);
                     }
                     if super::check_query_pattern(qs, "list-type", "2") {
-                        return Ok((&ListObjectsV2 as &'static dyn super::Operation, false));
+                        return Ok(&ListObjectsV2 as &'static dyn super::Operation);
                     }
                 }
-                Ok((&ListObjects as &'static dyn super::Operation, false))
+                Ok(&ListObjects as &'static dyn super::Operation)
             }
             S3Path::Object { .. } => {
                 if let Some(qs) = qs {
                     if qs.has("attributes") {
-                        return Ok((&GetObjectAttributes as &'static dyn super::Operation, false));
+                        return Ok(&GetObjectAttributes as &'static dyn super::Operation);
                     }
                     if qs.has("acl") {
-                        return Ok((&GetObjectAcl as &'static dyn super::Operation, false));
+                        return Ok(&GetObjectAcl as &'static dyn super::Operation);
                     }
                     if qs.has("legal-hold") {
-                        return Ok((&GetObjectLegalHold as &'static dyn super::Operation, false));
+                        return Ok(&GetObjectLegalHold as &'static dyn super::Operation);
                     }
                     if qs.has("retention") {
-                        return Ok((&GetObjectRetention as &'static dyn super::Operation, false));
+                        return Ok(&GetObjectRetention as &'static dyn super::Operation);
                     }
                     if qs.has("tagging") {
-                        return Ok((&GetObjectTagging as &'static dyn super::Operation, false));
+                        return Ok(&GetObjectTagging as &'static dyn super::Operation);
                     }
                     if qs.has("torrent") {
-                        return Ok((&GetObjectTorrent as &'static dyn super::Operation, false));
+                        return Ok(&GetObjectTorrent as &'static dyn super::Operation);
                     }
                 }
                 if let Some(qs) = qs
                     && qs.has("uploadId")
                 {
-                    return Ok((&ListParts as &'static dyn super::Operation, false));
+                    return Ok(&ListParts as &'static dyn super::Operation);
                 }
-                Ok((&GetObject as &'static dyn super::Operation, false))
+                Ok(&GetObject as &'static dyn super::Operation)
             }
         },
         hyper::Method::POST => match s3_path {
@@ -7078,33 +7198,33 @@ pub fn resolve_route(
             S3Path::Bucket { .. } => {
                 if let Some(qs) = qs {
                     if qs.has("metadataTable") {
-                        return Ok((&CreateBucketMetadataTableConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&CreateBucketMetadataTableConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("delete") {
-                        return Ok((&DeleteObjects as &'static dyn super::Operation, true));
+                        return Ok(&DeleteObjects as &'static dyn super::Operation);
                     }
                 }
                 if req.headers.contains_key("x-amz-request-route") && req.headers.contains_key("x-amz-request-token") {
-                    return Ok((&WriteGetObjectResponse as &'static dyn super::Operation, false));
+                    return Ok(&WriteGetObjectResponse as &'static dyn super::Operation);
                 }
                 Err(super::unknown_operation())
             }
             S3Path::Object { .. } => {
                 if let Some(qs) = qs {
                     if qs.has("select") && super::check_query_pattern(qs, "select-type", "2") {
-                        return Ok((&SelectObjectContent as &'static dyn super::Operation, true));
+                        return Ok(&SelectObjectContent as &'static dyn super::Operation);
                     }
                     if qs.has("uploads") {
-                        return Ok((&CreateMultipartUpload as &'static dyn super::Operation, false));
+                        return Ok(&CreateMultipartUpload as &'static dyn super::Operation);
                     }
                     if qs.has("restore") {
-                        return Ok((&RestoreObject as &'static dyn super::Operation, true));
+                        return Ok(&RestoreObject as &'static dyn super::Operation);
                     }
                 }
                 if let Some(qs) = qs
                     && qs.has("uploadId")
                 {
-                    return Ok((&CompleteMultipartUpload as &'static dyn super::Operation, true));
+                    return Ok(&CompleteMultipartUpload as &'static dyn super::Operation);
                 }
                 Err(super::unknown_operation())
             }
@@ -7114,81 +7234,81 @@ pub fn resolve_route(
             S3Path::Bucket { .. } => {
                 if let Some(qs) = qs {
                     if qs.has("analytics") {
-                        return Ok((&PutBucketAnalyticsConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketAnalyticsConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("intelligent-tiering") {
-                        return Ok((&PutBucketIntelligentTieringConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketIntelligentTieringConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("inventory") {
-                        return Ok((&PutBucketInventoryConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketInventoryConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("metrics") {
-                        return Ok((&PutBucketMetricsConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketMetricsConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("accelerate") {
-                        return Ok((&PutBucketAccelerateConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketAccelerateConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("acl") {
-                        return Ok((&PutBucketAcl as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketAcl as &'static dyn super::Operation);
                     }
                     if qs.has("cors") {
-                        return Ok((&PutBucketCors as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketCors as &'static dyn super::Operation);
                     }
                     if qs.has("encryption") {
-                        return Ok((&PutBucketEncryption as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketEncryption as &'static dyn super::Operation);
                     }
                     if qs.has("lifecycle") {
-                        return Ok((&PutBucketLifecycleConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketLifecycleConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("logging") {
-                        return Ok((&PutBucketLogging as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketLogging as &'static dyn super::Operation);
                     }
                     if qs.has("notification") {
-                        return Ok((&PutBucketNotificationConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketNotificationConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("ownershipControls") {
-                        return Ok((&PutBucketOwnershipControls as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketOwnershipControls as &'static dyn super::Operation);
                     }
                     if qs.has("policy") {
-                        return Ok((&PutBucketPolicy as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketPolicy as &'static dyn super::Operation);
                     }
                     if qs.has("replication") {
-                        return Ok((&PutBucketReplication as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketReplication as &'static dyn super::Operation);
                     }
                     if qs.has("requestPayment") {
-                        return Ok((&PutBucketRequestPayment as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketRequestPayment as &'static dyn super::Operation);
                     }
                     if qs.has("tagging") {
-                        return Ok((&PutBucketTagging as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketTagging as &'static dyn super::Operation);
                     }
                     if qs.has("versioning") {
-                        return Ok((&PutBucketVersioning as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketVersioning as &'static dyn super::Operation);
                     }
                     if qs.has("website") {
-                        return Ok((&PutBucketWebsite as &'static dyn super::Operation, true));
+                        return Ok(&PutBucketWebsite as &'static dyn super::Operation);
                     }
                     if qs.has("object-lock") {
-                        return Ok((&PutObjectLockConfiguration as &'static dyn super::Operation, true));
+                        return Ok(&PutObjectLockConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("publicAccessBlock") {
-                        return Ok((&PutPublicAccessBlock as &'static dyn super::Operation, true));
+                        return Ok(&PutPublicAccessBlock as &'static dyn super::Operation);
                     }
                 }
-                Ok((&CreateBucket as &'static dyn super::Operation, true))
+                Ok(&CreateBucket as &'static dyn super::Operation)
             }
             S3Path::Object { .. } => {
                 if let Some(qs) = qs {
                     if qs.has("acl") {
-                        return Ok((&PutObjectAcl as &'static dyn super::Operation, true));
+                        return Ok(&PutObjectAcl as &'static dyn super::Operation);
                     }
                     if qs.has("legal-hold") {
-                        return Ok((&PutObjectLegalHold as &'static dyn super::Operation, true));
+                        return Ok(&PutObjectLegalHold as &'static dyn super::Operation);
                     }
                     if qs.has("retention") {
-                        return Ok((&PutObjectRetention as &'static dyn super::Operation, true));
+                        return Ok(&PutObjectRetention as &'static dyn super::Operation);
                     }
                     if qs.has("tagging") {
-                        return Ok((&PutObjectTagging as &'static dyn super::Operation, true));
+                        return Ok(&PutObjectTagging as &'static dyn super::Operation);
                     }
                 }
                 if let Some(qs) = qs
@@ -7196,18 +7316,18 @@ pub fn resolve_route(
                     && qs.has("uploadId")
                     && req.headers.contains_key("x-amz-copy-source")
                 {
-                    return Ok((&UploadPartCopy as &'static dyn super::Operation, false));
+                    return Ok(&UploadPartCopy as &'static dyn super::Operation);
                 }
                 if let Some(qs) = qs
                     && qs.has("partNumber")
                     && qs.has("uploadId")
                 {
-                    return Ok((&UploadPart as &'static dyn super::Operation, false));
+                    return Ok(&UploadPart as &'static dyn super::Operation);
                 }
                 if req.headers.contains_key("x-amz-copy-source") {
-                    return Ok((&CopyObject as &'static dyn super::Operation, false));
+                    return Ok(&CopyObject as &'static dyn super::Operation);
                 }
-                Ok((&PutObject as &'static dyn super::Operation, false))
+                Ok(&PutObject as &'static dyn super::Operation)
             }
         },
         hyper::Method::DELETE => match s3_path {
@@ -7215,62 +7335,62 @@ pub fn resolve_route(
             S3Path::Bucket { .. } => {
                 if let Some(qs) = qs {
                     if qs.has("analytics") {
-                        return Ok((&DeleteBucketAnalyticsConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketAnalyticsConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("intelligent-tiering") {
-                        return Ok((&DeleteBucketIntelligentTieringConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketIntelligentTieringConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("inventory") {
-                        return Ok((&DeleteBucketInventoryConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketInventoryConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("metrics") {
-                        return Ok((&DeleteBucketMetricsConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketMetricsConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("cors") {
-                        return Ok((&DeleteBucketCors as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketCors as &'static dyn super::Operation);
                     }
                     if qs.has("encryption") {
-                        return Ok((&DeleteBucketEncryption as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketEncryption as &'static dyn super::Operation);
                     }
                     if qs.has("lifecycle") {
-                        return Ok((&DeleteBucketLifecycle as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketLifecycle as &'static dyn super::Operation);
                     }
                     if qs.has("metadataTable") {
-                        return Ok((&DeleteBucketMetadataTableConfiguration as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketMetadataTableConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("ownershipControls") {
-                        return Ok((&DeleteBucketOwnershipControls as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketOwnershipControls as &'static dyn super::Operation);
                     }
                     if qs.has("policy") {
-                        return Ok((&DeleteBucketPolicy as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketPolicy as &'static dyn super::Operation);
                     }
                     if qs.has("replication") {
-                        return Ok((&DeleteBucketReplication as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketReplication as &'static dyn super::Operation);
                     }
                     if qs.has("tagging") {
-                        return Ok((&DeleteBucketTagging as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketTagging as &'static dyn super::Operation);
                     }
                     if qs.has("website") {
-                        return Ok((&DeleteBucketWebsite as &'static dyn super::Operation, false));
+                        return Ok(&DeleteBucketWebsite as &'static dyn super::Operation);
                     }
                     if qs.has("publicAccessBlock") {
-                        return Ok((&DeletePublicAccessBlock as &'static dyn super::Operation, false));
+                        return Ok(&DeletePublicAccessBlock as &'static dyn super::Operation);
                     }
                 }
-                Ok((&DeleteBucket as &'static dyn super::Operation, false))
+                Ok(&DeleteBucket as &'static dyn super::Operation)
             }
             S3Path::Object { .. } => {
                 if let Some(qs) = qs {
                     if qs.has("tagging") {
-                        return Ok((&DeleteObjectTagging as &'static dyn super::Operation, false));
+                        return Ok(&DeleteObjectTagging as &'static dyn super::Operation);
                     }
                 }
                 if let Some(qs) = qs
                     && qs.has("uploadId")
                 {
-                    return Ok((&AbortMultipartUpload as &'static dyn super::Operation, false));
+                    return Ok(&AbortMultipartUpload as &'static dyn super::Operation);
                 }
-                Ok((&DeleteObject as &'static dyn super::Operation, false))
+                Ok(&DeleteObject as &'static dyn super::Operation)
             }
         },
         _ => Err(super::unknown_operation()),

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -70,11 +70,9 @@ pub trait Operation: Send + Sync + 'static {
     /// Whether this operation requires the request body to be fully read
     /// before being dispatched to the user-implemented [`S3`] handler.
     ///
-    /// Overridden by XML-payload operations (e.g. `DeleteObjects`,
+    /// `true` for XML-payload operations (e.g. `DeleteObjects`,
     /// `CompleteMultipartUpload`) and PUT configuration operations.
-    fn needs_full_body(&self) -> bool {
-        false
-    }
+    fn needs_full_body(&self) -> bool;
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut Request) -> S3Result<Response>;
 }

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -67,6 +67,15 @@ use tracing::{debug, error, warn};
 pub trait Operation: Send + Sync + 'static {
     fn name(&self) -> &'static str;
 
+    /// Whether this operation requires the request body to be fully read
+    /// before being dispatched to the user-implemented [`S3`] handler.
+    ///
+    /// Overridden by XML-payload operations (e.g. `DeleteObjects`,
+    /// `CompleteMultipartUpload`) and PUT configuration operations.
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut Request) -> S3Result<Response>;
 }
 
@@ -546,7 +555,7 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
         return Ok(Prepare::CustomRoute);
     }
 
-    let (op, needs_full_body) = 'resolve: {
+    let op = 'resolve: {
         if let Some(multipart) = &mut req.s3ext.multipart
             && req.method == Method::POST
         {
@@ -604,7 +613,7 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
                         req.s3ext.post_policy = Some(policy);
                     }
 
-                    break 'resolve (&PostObject as &'static dyn Operation, false);
+                    break 'resolve &PostObject as &'static dyn Operation;
                 }
                 // FIXME: POST /bucket/key hits this branch
                 S3Path::Object { .. } => return Err(s3_error!(MethodNotAllowed)),
@@ -666,7 +675,7 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
 
     debug!(op = %op.name(), ?s3_path, "checked access");
 
-    if needs_full_body {
+    if op.needs_full_body() {
         let config = ccx.config.snapshot();
         extract_full_body(content_length, &mut req.body, config.xml_max_body_size).await?;
     }

--- a/crates/s3s/src/ops/route_bench.rs
+++ b/crates/s3s/src/ops/route_bench.rs
@@ -162,7 +162,7 @@ fn route_bench() {
 
         // Sanity check: routing must match the expected operation.
         {
-            let (op, _) = resolve_route(black_box(&req), black_box(path), Some(black_box(&qs))).unwrap();
+            let op = resolve_route(black_box(&req), black_box(path), Some(black_box(&qs))).unwrap();
             assert_eq!(op.name(), c.expect_op, "case `{}` routed to wrong op", c.name);
         }
 

--- a/crates/s3s/src/ops/route_fixture_check.rs
+++ b/crates/s3s/src/ops/route_fixture_check.rs
@@ -4,9 +4,10 @@
 //! Equivalence fixtures for [`crate::ops::generated::resolve_route`].
 //!
 //! `route_fixtures.json` records, for each request sample, the operation the
-//! router must return together with its `needs_full_body` flag. The data was
-//! captured from the current generated router and must keep passing against
-//! any future router implementation.
+//! router must return together with the operation's
+//! [`Operation::needs_full_body`](super::Operation::needs_full_body) flag. The
+//! data was captured from the current generated router and must keep passing
+//! against any future router implementation.
 //!
 //! # Data format
 //!
@@ -119,7 +120,7 @@ fn make_request(method: &str, headers: &std::collections::HashMap<String, String
     Request::from(builder.body(crate::http::Body::empty()).unwrap())
 }
 
-fn resolve_current(fx: &Fixture) -> S3Result<(&'static dyn super::Operation, bool)> {
+fn resolve_current(fx: &Fixture) -> S3Result<&'static dyn super::Operation> {
     let req = make_request(&fx.method, &fx.headers);
     let path = s3_path(&fx.path);
     let qs = fx.qs.as_ref().map(|pairs| OrderedQs::from_vec_unchecked(pairs.clone()));
@@ -135,7 +136,7 @@ fn route_fixtures_match() {
 
     for (idx, fx) in fixtures.iter().enumerate() {
         let (got_op, got_nfb) = match resolve_current(fx) {
-            Ok((op, nfb)) => (op.name().to_string(), nfb),
+            Ok(op) => (op.name().to_string(), op.needs_full_body()),
             Err(_) => ("__NOT_IMPLEMENTED__".to_string(), false),
         };
 

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -2679,10 +2679,10 @@ fn create_session_route_resolved() {
         bucket: "my-bucket".into(),
     };
     let qs = OrderedQs::parse("session").unwrap();
-    let (op, needs_full_body) = generated::resolve_route(&req, &s3_path, Some(&qs)).unwrap();
+    let op = generated::resolve_route(&req, &s3_path, Some(&qs)).unwrap();
 
     assert_eq!(op.name(), "CreateSession");
-    assert!(!needs_full_body);
+    assert!(!op.needs_full_body());
 }
 
 #[test]
@@ -2748,10 +2748,10 @@ fn list_directory_buckets_route_resolved() {
 
     let s3_path = S3Path::Root;
     let qs = OrderedQs::parse("x-id=ListDirectoryBuckets").unwrap();
-    let (op, needs_full_body) = generated::resolve_route(&req, &s3_path, Some(&qs)).unwrap();
+    let op = generated::resolve_route(&req, &s3_path, Some(&qs)).unwrap();
 
     assert_eq!(op.name(), "ListDirectoryBuckets");
-    assert!(!needs_full_body);
+    assert!(!op.needs_full_body());
 }
 
 #[test]
@@ -2770,7 +2770,7 @@ fn list_buckets_route_still_default() {
 
     let s3_path = S3Path::Root;
     let qs = OrderedQs::parse("x-id=ListBuckets").unwrap();
-    let (op, _) = generated::resolve_route(&req, &s3_path, Some(&qs)).unwrap();
+    let op = generated::resolve_route(&req, &s3_path, Some(&qs)).unwrap();
     assert_eq!(op.name(), "ListBuckets");
 
     // Without any query string
@@ -2781,7 +2781,7 @@ fn list_buckets_route_still_default() {
             .body(Body::empty())
             .unwrap(),
     );
-    let (op2, _) = generated::resolve_route(&req2, &s3_path, None).unwrap();
+    let op2 = generated::resolve_route(&req2, &s3_path, None).unwrap();
     assert_eq!(op2.name(), "ListBuckets");
 }
 


### PR DESCRIPTION
## Summary

The `needs_full_body` flag is a static property of each operation (computed at codegen time from the Smithy model), but today it is baked into every return point of the generated router and shipped back to `prepare()` as a `(&dyn Operation, bool)` tuple. This PR sinks the flag into the `Operation` trait as a required method implemented explicitly by every operation, and lets the router return the operation alone, making an op/flag mismatch impossible by construction.

## Changes

- `Operation` gains a required `fn needs_full_body(&self) -> bool` method (no default); the generated router's signature shrinks to `resolve_route(...) -> S3Result<&'static dyn Operation>`.
- Codegen implements the method explicitly for every operation, emitting the `true`/`false` literal computed by the same `needs_full_body()` codegen predicate that previously baked the flag into the router, so the two cannot drift.
- `prepare()` queries `op.needs_full_body()` instead of unpacking a tuple; the multipart `PostObject` branch drops its hardcoded `false`, with `PostObject` now implementing the method as `false` explicitly.
- Route fixtures: the 220-entry `route_fixtures.json` is untouched — `nfb` expectations are now sourced from the trait method, with identical values.
- Test/bench consumers (`tests.rs`, `route_bench.rs`, `route_fixture_check.rs`) updated to the single-value return.

## Impact

- No observable behavior change: all operations keep the same flag values (30 `true`, 69 `false`, matching the old router's baked flags, gated by the unchanged 220-fixture equivalence test).
- No public API change: the `ops` module is crate-private, so neither the trait addition nor the router signature change is reachable downstream; cargo-semver-checks reports no semver update required.

## Verification

- `just codegen` is idempotent for both generated variants (`generated.rs` / `generated_minio.rs`).
- `cargo test --workspace --all-features --all-targets` passes (818 unit tests, including `route_fixtures_match` 220/220, plus doctests); the `minio` feature variant passes as well.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-features --all-targets -- -D warnings` pass.
