### PR TITLE
feat(data): refresh S3 Smithy model from aws-sdk-rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7816e98ee912159f45d307e5ee6bfea4a335a55aee15f7f3e32f81a6f3000f1d"
+checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.138.1"
+version = "1.143.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa59420755799fec8aac71f562aa37ba82263f5b1926bba8b5d3465d2f7a73f"
+checksum = "a0ade5433c9561daac7c0c6bc910f1240b4f8ec0d6148b0b463aac0691d747c9"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -253,7 +253,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
  "aws-smithy-types",
- "aws-smithy-xml",
+ "aws-smithy-xml 0.62.0",
  "aws-types",
  "bytes",
  "fastrand",
@@ -288,7 +288,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
  "aws-smithy-types",
- "aws-smithy-xml",
+ "aws-smithy-xml 0.61.1",
  "aws-types",
  "fastrand",
  "http 0.2.12",
@@ -358,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9381123ab62d20c13082b151f30f962a3b112b727345394536dfa39a482944"
+checksum = "6de526c7b567420a31bc283657a7921b45c4cafe0827fdf2490713dcc770c28f"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
+checksum = "ebfd138fac0337cee7516c352757ea73b9f2266e57d0bcb5bc70e9547e45aef1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea94a9ff8464016338c851e24b472d7131c388c88898a502e781815b2ee6045"
+checksum = "b82e438d30e02a825d363bd639a9efaed68a8089d86101054b0081e7e0d3e606"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
+checksum = "954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -558,10 +558,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-types"
-version = "1.4.0"
+name = "aws-smithy-xml"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e957a6c6dbce82b7a91f44231c09273159703769f447cbe85e854dfe9cf67f86"
+checksum = "ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ opendal = { version = "0.58.0", default-features = false }
 # AWS SDK
 aws-config = { version = "1.9.0", default-features = false }
 aws-credential-types = "1.3.0"
-aws-sdk-s3 = { version = "1.138.0", default-features = false, features = ["default-https-client", "http-1x", "rt-tokio", "sigv4a"] }
+aws-sdk-s3 = { version = "1.143.0", default-features = false, features = ["default-https-client", "http-1x", "rt-tokio", "sigv4a"] }
 aws-sdk-sts = { version = "1.108.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-smithy-runtime-api = "1.13.0"
 aws-smithy-types = "1.6.1"

--- a/crates/s3s-aws/src/conv/generated.rs
+++ b/crates/s3s-aws/src/conv/generated.rs
@@ -1630,6 +1630,7 @@ impl AwsConversion for s3s::dto::DeleteBucketIntelligentTieringConfigurationInpu
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(Self {
             bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
             id: unwrap_from_aws(x.id, "id")?,
         })
     }
@@ -1637,6 +1638,7 @@ impl AwsConversion for s3s::dto::DeleteBucketIntelligentTieringConfigurationInpu
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         let mut y = Self::Target::builder();
         y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
         y = y.set_id(Some(try_into_aws(x.id)?));
         y.build().map_err(S3Error::internal_error)
     }
@@ -2764,6 +2766,7 @@ impl AwsConversion for s3s::dto::GetBucketIntelligentTieringConfigurationInput {
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(Self {
             bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
             id: unwrap_from_aws(x.id, "id")?,
         })
     }
@@ -2771,6 +2774,7 @@ impl AwsConversion for s3s::dto::GetBucketIntelligentTieringConfigurationInput {
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         let mut y = Self::Target::builder();
         y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
         y = y.set_id(Some(try_into_aws(x.id)?));
         y.build().map_err(S3Error::internal_error)
     }
@@ -4839,6 +4843,7 @@ impl AwsConversion for s3s::dto::ListBucketIntelligentTieringConfigurationsInput
         Ok(Self {
             bucket: unwrap_from_aws(x.bucket, "bucket")?,
             continuation_token: try_from_aws(x.continuation_token)?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
         })
     }
 
@@ -4846,6 +4851,7 @@ impl AwsConversion for s3s::dto::ListBucketIntelligentTieringConfigurationsInput
         let mut y = Self::Target::builder();
         y = y.set_bucket(Some(try_into_aws(x.bucket)?));
         y = y.set_continuation_token(try_into_aws(x.continuation_token)?);
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
         y.build().map_err(S3Error::internal_error)
     }
 }
@@ -6846,6 +6852,7 @@ impl AwsConversion for s3s::dto::PutBucketIntelligentTieringConfigurationInput {
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(Self {
             bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
             id: unwrap_from_aws(x.id, "id")?,
             intelligent_tiering_configuration: unwrap_from_aws(
                 x.intelligent_tiering_configuration,
@@ -6857,6 +6864,7 @@ impl AwsConversion for s3s::dto::PutBucketIntelligentTieringConfigurationInput {
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         let mut y = Self::Target::builder();
         y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
         y = y.set_id(Some(try_into_aws(x.id)?));
         y = y.set_intelligent_tiering_configuration(Some(try_into_aws(x.intelligent_tiering_configuration)?));
         y.build().map_err(S3Error::internal_error)

--- a/crates/s3s-aws/src/conv/generated.rs
+++ b/crates/s3s-aws/src/conv/generated.rs
@@ -7087,6 +7087,7 @@ impl AwsConversion for s3s::dto::PutBucketOwnershipControlsInput {
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(Self {
             bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            checksum_algorithm: try_from_aws(x.checksum_algorithm)?,
             content_md5: try_from_aws(x.content_md5)?,
             expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
             ownership_controls: unwrap_from_aws(x.ownership_controls, "ownership_controls")?,
@@ -7096,6 +7097,7 @@ impl AwsConversion for s3s::dto::PutBucketOwnershipControlsInput {
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         let mut y = Self::Target::builder();
         y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_checksum_algorithm(try_into_aws(x.checksum_algorithm)?);
         y = y.set_content_md5(try_into_aws(x.content_md5)?);
         y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
         y = y.set_ownership_controls(Some(try_into_aws(x.ownership_controls)?));

--- a/crates/s3s-aws/src/conv/generated.rs
+++ b/crates/s3s-aws/src/conv/generated.rs
@@ -389,6 +389,7 @@ impl AwsConversion for s3s::dto::BucketLocationConstraint {
             aws_sdk_s3::types::BucketLocationConstraint::Eu => Self::from_static(Self::EU),
             aws_sdk_s3::types::BucketLocationConstraint::AfSouth1 => Self::from_static(Self::AF_SOUTH_1),
             aws_sdk_s3::types::BucketLocationConstraint::ApEast1 => Self::from_static(Self::AP_EAST_1),
+            aws_sdk_s3::types::BucketLocationConstraint::ApEast2 => Self::from_static(Self::AP_EAST_2),
             aws_sdk_s3::types::BucketLocationConstraint::ApNortheast1 => Self::from_static(Self::AP_NORTHEAST_1),
             aws_sdk_s3::types::BucketLocationConstraint::ApNortheast2 => Self::from_static(Self::AP_NORTHEAST_2),
             aws_sdk_s3::types::BucketLocationConstraint::ApNortheast3 => Self::from_static(Self::AP_NORTHEAST_3),
@@ -399,7 +400,10 @@ impl AwsConversion for s3s::dto::BucketLocationConstraint {
             aws_sdk_s3::types::BucketLocationConstraint::ApSoutheast3 => Self::from_static(Self::AP_SOUTHEAST_3),
             aws_sdk_s3::types::BucketLocationConstraint::ApSoutheast4 => Self::from_static(Self::AP_SOUTHEAST_4),
             aws_sdk_s3::types::BucketLocationConstraint::ApSoutheast5 => Self::from_static(Self::AP_SOUTHEAST_5),
+            aws_sdk_s3::types::BucketLocationConstraint::ApSoutheast6 => Self::from_static(Self::AP_SOUTHEAST_6),
+            aws_sdk_s3::types::BucketLocationConstraint::ApSoutheast7 => Self::from_static(Self::AP_SOUTHEAST_7),
             aws_sdk_s3::types::BucketLocationConstraint::CaCentral1 => Self::from_static(Self::CA_CENTRAL_1),
+            aws_sdk_s3::types::BucketLocationConstraint::CaWest1 => Self::from_static(Self::CA_WEST_1),
             aws_sdk_s3::types::BucketLocationConstraint::CnNorth1 => Self::from_static(Self::CN_NORTH_1),
             aws_sdk_s3::types::BucketLocationConstraint::CnNorthwest1 => Self::from_static(Self::CN_NORTHWEST_1),
             aws_sdk_s3::types::BucketLocationConstraint::EuCentral1 => Self::from_static(Self::EU_CENTRAL_1),
@@ -413,6 +417,7 @@ impl AwsConversion for s3s::dto::BucketLocationConstraint {
             aws_sdk_s3::types::BucketLocationConstraint::IlCentral1 => Self::from_static(Self::IL_CENTRAL_1),
             aws_sdk_s3::types::BucketLocationConstraint::MeCentral1 => Self::from_static(Self::ME_CENTRAL_1),
             aws_sdk_s3::types::BucketLocationConstraint::MeSouth1 => Self::from_static(Self::ME_SOUTH_1),
+            aws_sdk_s3::types::BucketLocationConstraint::MxCentral1 => Self::from_static(Self::MX_CENTRAL_1),
             aws_sdk_s3::types::BucketLocationConstraint::SaEast1 => Self::from_static(Self::SA_EAST_1),
             aws_sdk_s3::types::BucketLocationConstraint::UsEast2 => Self::from_static(Self::US_EAST_2),
             aws_sdk_s3::types::BucketLocationConstraint::UsGovEast1 => Self::from_static(Self::US_GOV_EAST_1),
@@ -6193,8 +6198,12 @@ impl AwsConversion for s3s::dto::ObjectStorageClass {
 
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(match x {
+            aws_sdk_s3::types::ObjectStorageClass::AwsBackupLowCostWarm => Self::from_static(Self::AWS_BACKUP_LOW_COST_WARM),
+            aws_sdk_s3::types::ObjectStorageClass::AwsBackupWarm => Self::from_static(Self::AWS_BACKUP_WARM),
             aws_sdk_s3::types::ObjectStorageClass::DeepArchive => Self::from_static(Self::DEEP_ARCHIVE),
             aws_sdk_s3::types::ObjectStorageClass::ExpressOnezone => Self::from_static(Self::EXPRESS_ONEZONE),
+            aws_sdk_s3::types::ObjectStorageClass::FsxOntap => Self::from_static(Self::FSX_ONTAP),
+            aws_sdk_s3::types::ObjectStorageClass::FsxOpenzfs => Self::from_static(Self::FSX_OPENZFS),
             aws_sdk_s3::types::ObjectStorageClass::Glacier => Self::from_static(Self::GLACIER),
             aws_sdk_s3::types::ObjectStorageClass::GlacierIr => Self::from_static(Self::GLACIER_IR),
             aws_sdk_s3::types::ObjectStorageClass::IntelligentTiering => Self::from_static(Self::INTELLIGENT_TIERING),
@@ -8771,8 +8780,12 @@ impl AwsConversion for s3s::dto::StorageClass {
 
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(match x {
+            aws_sdk_s3::types::StorageClass::AwsBackupLowCostWarm => Self::from_static(Self::AWS_BACKUP_LOW_COST_WARM),
+            aws_sdk_s3::types::StorageClass::AwsBackupWarm => Self::from_static(Self::AWS_BACKUP_WARM),
             aws_sdk_s3::types::StorageClass::DeepArchive => Self::from_static(Self::DEEP_ARCHIVE),
             aws_sdk_s3::types::StorageClass::ExpressOnezone => Self::from_static(Self::EXPRESS_ONEZONE),
+            aws_sdk_s3::types::StorageClass::FsxOntap => Self::from_static(Self::FSX_ONTAP),
+            aws_sdk_s3::types::StorageClass::FsxOpenzfs => Self::from_static(Self::FSX_OPENZFS),
             aws_sdk_s3::types::StorageClass::Glacier => Self::from_static(Self::GLACIER),
             aws_sdk_s3::types::StorageClass::GlacierIr => Self::from_static(Self::GLACIER_IR),
             aws_sdk_s3::types::StorageClass::IntelligentTiering => Self::from_static(Self::INTELLIGENT_TIERING),

--- a/crates/s3s-aws/src/conv/generated.rs
+++ b/crates/s3s-aws/src/conv/generated.rs
@@ -4540,6 +4540,9 @@ impl AwsConversion for s3s::dto::InventoryOptionalField {
             }
             aws_sdk_s3::types::InventoryOptionalField::IsMultipartUploaded => Self::from_static(Self::IS_MULTIPART_UPLOADED),
             aws_sdk_s3::types::InventoryOptionalField::LastModifiedDate => Self::from_static(Self::LAST_MODIFIED_DATE),
+            aws_sdk_s3::types::InventoryOptionalField::LifecycleExpirationDate => {
+                Self::from_static(Self::LIFECYCLE_EXPIRATION_DATE)
+            }
             aws_sdk_s3::types::InventoryOptionalField::ObjectAccessControlList => {
                 Self::from_static(Self::OBJECT_ACCESS_CONTROL_LIST)
             }

--- a/crates/s3s-aws/src/conv/generated_minio.rs
+++ b/crates/s3s-aws/src/conv/generated_minio.rs
@@ -7094,6 +7094,7 @@ impl AwsConversion for s3s::dto::PutBucketOwnershipControlsInput {
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(Self {
             bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            checksum_algorithm: try_from_aws(x.checksum_algorithm)?,
             content_md5: try_from_aws(x.content_md5)?,
             expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
             ownership_controls: unwrap_from_aws(x.ownership_controls, "ownership_controls")?,
@@ -7103,6 +7104,7 @@ impl AwsConversion for s3s::dto::PutBucketOwnershipControlsInput {
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         let mut y = Self::Target::builder();
         y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_checksum_algorithm(try_into_aws(x.checksum_algorithm)?);
         y = y.set_content_md5(try_into_aws(x.content_md5)?);
         y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
         y = y.set_ownership_controls(Some(try_into_aws(x.ownership_controls)?));

--- a/crates/s3s-aws/src/conv/generated_minio.rs
+++ b/crates/s3s-aws/src/conv/generated_minio.rs
@@ -1634,6 +1634,7 @@ impl AwsConversion for s3s::dto::DeleteBucketIntelligentTieringConfigurationInpu
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(Self {
             bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
             id: unwrap_from_aws(x.id, "id")?,
         })
     }
@@ -1641,6 +1642,7 @@ impl AwsConversion for s3s::dto::DeleteBucketIntelligentTieringConfigurationInpu
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         let mut y = Self::Target::builder();
         y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
         y = y.set_id(Some(try_into_aws(x.id)?));
         y.build().map_err(S3Error::internal_error)
     }
@@ -2768,6 +2770,7 @@ impl AwsConversion for s3s::dto::GetBucketIntelligentTieringConfigurationInput {
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(Self {
             bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
             id: unwrap_from_aws(x.id, "id")?,
         })
     }
@@ -2775,6 +2778,7 @@ impl AwsConversion for s3s::dto::GetBucketIntelligentTieringConfigurationInput {
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         let mut y = Self::Target::builder();
         y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
         y = y.set_id(Some(try_into_aws(x.id)?));
         y.build().map_err(S3Error::internal_error)
     }
@@ -4846,6 +4850,7 @@ impl AwsConversion for s3s::dto::ListBucketIntelligentTieringConfigurationsInput
         Ok(Self {
             bucket: unwrap_from_aws(x.bucket, "bucket")?,
             continuation_token: try_from_aws(x.continuation_token)?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
         })
     }
 
@@ -4853,6 +4858,7 @@ impl AwsConversion for s3s::dto::ListBucketIntelligentTieringConfigurationsInput
         let mut y = Self::Target::builder();
         y = y.set_bucket(Some(try_into_aws(x.bucket)?));
         y = y.set_continuation_token(try_into_aws(x.continuation_token)?);
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
         y.build().map_err(S3Error::internal_error)
     }
 }
@@ -6853,6 +6859,7 @@ impl AwsConversion for s3s::dto::PutBucketIntelligentTieringConfigurationInput {
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(Self {
             bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
             id: unwrap_from_aws(x.id, "id")?,
             intelligent_tiering_configuration: unwrap_from_aws(
                 x.intelligent_tiering_configuration,
@@ -6864,6 +6871,7 @@ impl AwsConversion for s3s::dto::PutBucketIntelligentTieringConfigurationInput {
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         let mut y = Self::Target::builder();
         y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
         y = y.set_id(Some(try_into_aws(x.id)?));
         y = y.set_intelligent_tiering_configuration(Some(try_into_aws(x.intelligent_tiering_configuration)?));
         y.build().map_err(S3Error::internal_error)

--- a/crates/s3s-aws/src/conv/generated_minio.rs
+++ b/crates/s3s-aws/src/conv/generated_minio.rs
@@ -4544,6 +4544,9 @@ impl AwsConversion for s3s::dto::InventoryOptionalField {
             }
             aws_sdk_s3::types::InventoryOptionalField::IsMultipartUploaded => Self::from_static(Self::IS_MULTIPART_UPLOADED),
             aws_sdk_s3::types::InventoryOptionalField::LastModifiedDate => Self::from_static(Self::LAST_MODIFIED_DATE),
+            aws_sdk_s3::types::InventoryOptionalField::LifecycleExpirationDate => {
+                Self::from_static(Self::LIFECYCLE_EXPIRATION_DATE)
+            }
             aws_sdk_s3::types::InventoryOptionalField::ObjectAccessControlList => {
                 Self::from_static(Self::OBJECT_ACCESS_CONTROL_LIST)
             }

--- a/crates/s3s-aws/src/conv/generated_minio.rs
+++ b/crates/s3s-aws/src/conv/generated_minio.rs
@@ -390,6 +390,7 @@ impl AwsConversion for s3s::dto::BucketLocationConstraint {
             aws_sdk_s3::types::BucketLocationConstraint::Eu => Self::from_static(Self::EU),
             aws_sdk_s3::types::BucketLocationConstraint::AfSouth1 => Self::from_static(Self::AF_SOUTH_1),
             aws_sdk_s3::types::BucketLocationConstraint::ApEast1 => Self::from_static(Self::AP_EAST_1),
+            aws_sdk_s3::types::BucketLocationConstraint::ApEast2 => Self::from_static(Self::AP_EAST_2),
             aws_sdk_s3::types::BucketLocationConstraint::ApNortheast1 => Self::from_static(Self::AP_NORTHEAST_1),
             aws_sdk_s3::types::BucketLocationConstraint::ApNortheast2 => Self::from_static(Self::AP_NORTHEAST_2),
             aws_sdk_s3::types::BucketLocationConstraint::ApNortheast3 => Self::from_static(Self::AP_NORTHEAST_3),
@@ -400,7 +401,10 @@ impl AwsConversion for s3s::dto::BucketLocationConstraint {
             aws_sdk_s3::types::BucketLocationConstraint::ApSoutheast3 => Self::from_static(Self::AP_SOUTHEAST_3),
             aws_sdk_s3::types::BucketLocationConstraint::ApSoutheast4 => Self::from_static(Self::AP_SOUTHEAST_4),
             aws_sdk_s3::types::BucketLocationConstraint::ApSoutheast5 => Self::from_static(Self::AP_SOUTHEAST_5),
+            aws_sdk_s3::types::BucketLocationConstraint::ApSoutheast6 => Self::from_static(Self::AP_SOUTHEAST_6),
+            aws_sdk_s3::types::BucketLocationConstraint::ApSoutheast7 => Self::from_static(Self::AP_SOUTHEAST_7),
             aws_sdk_s3::types::BucketLocationConstraint::CaCentral1 => Self::from_static(Self::CA_CENTRAL_1),
+            aws_sdk_s3::types::BucketLocationConstraint::CaWest1 => Self::from_static(Self::CA_WEST_1),
             aws_sdk_s3::types::BucketLocationConstraint::CnNorth1 => Self::from_static(Self::CN_NORTH_1),
             aws_sdk_s3::types::BucketLocationConstraint::CnNorthwest1 => Self::from_static(Self::CN_NORTHWEST_1),
             aws_sdk_s3::types::BucketLocationConstraint::EuCentral1 => Self::from_static(Self::EU_CENTRAL_1),
@@ -414,6 +418,7 @@ impl AwsConversion for s3s::dto::BucketLocationConstraint {
             aws_sdk_s3::types::BucketLocationConstraint::IlCentral1 => Self::from_static(Self::IL_CENTRAL_1),
             aws_sdk_s3::types::BucketLocationConstraint::MeCentral1 => Self::from_static(Self::ME_CENTRAL_1),
             aws_sdk_s3::types::BucketLocationConstraint::MeSouth1 => Self::from_static(Self::ME_SOUTH_1),
+            aws_sdk_s3::types::BucketLocationConstraint::MxCentral1 => Self::from_static(Self::MX_CENTRAL_1),
             aws_sdk_s3::types::BucketLocationConstraint::SaEast1 => Self::from_static(Self::SA_EAST_1),
             aws_sdk_s3::types::BucketLocationConstraint::UsEast2 => Self::from_static(Self::US_EAST_2),
             aws_sdk_s3::types::BucketLocationConstraint::UsGovEast1 => Self::from_static(Self::US_GOV_EAST_1),
@@ -6200,8 +6205,12 @@ impl AwsConversion for s3s::dto::ObjectStorageClass {
 
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(match x {
+            aws_sdk_s3::types::ObjectStorageClass::AwsBackupLowCostWarm => Self::from_static(Self::AWS_BACKUP_LOW_COST_WARM),
+            aws_sdk_s3::types::ObjectStorageClass::AwsBackupWarm => Self::from_static(Self::AWS_BACKUP_WARM),
             aws_sdk_s3::types::ObjectStorageClass::DeepArchive => Self::from_static(Self::DEEP_ARCHIVE),
             aws_sdk_s3::types::ObjectStorageClass::ExpressOnezone => Self::from_static(Self::EXPRESS_ONEZONE),
+            aws_sdk_s3::types::ObjectStorageClass::FsxOntap => Self::from_static(Self::FSX_ONTAP),
+            aws_sdk_s3::types::ObjectStorageClass::FsxOpenzfs => Self::from_static(Self::FSX_OPENZFS),
             aws_sdk_s3::types::ObjectStorageClass::Glacier => Self::from_static(Self::GLACIER),
             aws_sdk_s3::types::ObjectStorageClass::GlacierIr => Self::from_static(Self::GLACIER_IR),
             aws_sdk_s3::types::ObjectStorageClass::IntelligentTiering => Self::from_static(Self::INTELLIGENT_TIERING),
@@ -8781,8 +8790,12 @@ impl AwsConversion for s3s::dto::StorageClass {
 
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(match x {
+            aws_sdk_s3::types::StorageClass::AwsBackupLowCostWarm => Self::from_static(Self::AWS_BACKUP_LOW_COST_WARM),
+            aws_sdk_s3::types::StorageClass::AwsBackupWarm => Self::from_static(Self::AWS_BACKUP_WARM),
             aws_sdk_s3::types::StorageClass::DeepArchive => Self::from_static(Self::DEEP_ARCHIVE),
             aws_sdk_s3::types::StorageClass::ExpressOnezone => Self::from_static(Self::EXPRESS_ONEZONE),
+            aws_sdk_s3::types::StorageClass::FsxOntap => Self::from_static(Self::FSX_ONTAP),
+            aws_sdk_s3::types::StorageClass::FsxOpenzfs => Self::from_static(Self::FSX_OPENZFS),
             aws_sdk_s3::types::StorageClass::Glacier => Self::from_static(Self::GLACIER),
             aws_sdk_s3::types::StorageClass::GlacierIr => Self::from_static(Self::GLACIER_IR),
             aws_sdk_s3::types::StorageClass::IntelligentTiering => Self::from_static(Self::INTELLIGENT_TIERING),

--- a/crates/s3s-aws/src/proxy/generated.rs
+++ b/crates/s3s-aws/src/proxy/generated.rs
@@ -373,6 +373,7 @@ impl S3 for Proxy {
         debug!(?input);
         let mut b = self.0.delete_bucket_intelligent_tiering_configuration();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         b = b.set_id(Some(try_into_aws(input.id)?));
         let result = b.send().await;
         match result {
@@ -810,6 +811,7 @@ impl S3 for Proxy {
         debug!(?input);
         let mut b = self.0.get_bucket_intelligent_tiering_configuration();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         b = b.set_id(Some(try_into_aws(input.id)?));
         let result = b.send().await;
         match result {
@@ -1482,6 +1484,7 @@ impl S3 for Proxy {
         let mut b = self.0.list_bucket_intelligent_tiering_configurations();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
         b = b.set_continuation_token(try_into_aws(input.continuation_token)?);
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         let result = b.send().await;
         match result {
             Ok(output) => {
@@ -1870,6 +1873,7 @@ impl S3 for Proxy {
         debug!(?input);
         let mut b = self.0.put_bucket_intelligent_tiering_configuration();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         b = b.set_id(Some(try_into_aws(input.id)?));
         b = b.set_intelligent_tiering_configuration(Some(try_into_aws(input.intelligent_tiering_configuration)?));
         let result = b.send().await;

--- a/crates/s3s-aws/src/proxy/generated.rs
+++ b/crates/s3s-aws/src/proxy/generated.rs
@@ -2015,6 +2015,7 @@ impl S3 for Proxy {
         debug!(?input);
         let mut b = self.0.put_bucket_ownership_controls();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_checksum_algorithm(try_into_aws(input.checksum_algorithm)?);
         b = b.set_content_md5(try_into_aws(input.content_md5)?);
         b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         b = b.set_ownership_controls(Some(try_into_aws(input.ownership_controls)?));

--- a/crates/s3s-aws/src/proxy/generated_minio.rs
+++ b/crates/s3s-aws/src/proxy/generated_minio.rs
@@ -373,6 +373,7 @@ impl S3 for Proxy {
         debug!(?input);
         let mut b = self.0.delete_bucket_intelligent_tiering_configuration();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         b = b.set_id(Some(try_into_aws(input.id)?));
         let result = b.send().await;
         match result {
@@ -810,6 +811,7 @@ impl S3 for Proxy {
         debug!(?input);
         let mut b = self.0.get_bucket_intelligent_tiering_configuration();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         b = b.set_id(Some(try_into_aws(input.id)?));
         let result = b.send().await;
         match result {
@@ -1482,6 +1484,7 @@ impl S3 for Proxy {
         let mut b = self.0.list_bucket_intelligent_tiering_configurations();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
         b = b.set_continuation_token(try_into_aws(input.continuation_token)?);
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         let result = b.send().await;
         match result {
             Ok(output) => {
@@ -1870,6 +1873,7 @@ impl S3 for Proxy {
         debug!(?input);
         let mut b = self.0.put_bucket_intelligent_tiering_configuration();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         b = b.set_id(Some(try_into_aws(input.id)?));
         b = b.set_intelligent_tiering_configuration(Some(try_into_aws(input.intelligent_tiering_configuration)?));
         let result = b.send().await;

--- a/crates/s3s-aws/src/proxy/generated_minio.rs
+++ b/crates/s3s-aws/src/proxy/generated_minio.rs
@@ -2015,6 +2015,7 @@ impl S3 for Proxy {
         debug!(?input);
         let mut b = self.0.put_bucket_ownership_controls();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_checksum_algorithm(try_into_aws(input.checksum_algorithm)?);
         b = b.set_content_md5(try_into_aws(input.content_md5)?);
         b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         b = b.set_ownership_controls(Some(try_into_aws(input.ownership_controls)?));

--- a/crates/s3s/src/dto/generated.rs
+++ b/crates/s3s/src/dto/generated.rs
@@ -17352,13 +17352,23 @@ impl fmt::Debug for PutBucketNotificationConfigurationOutput {
 pub struct PutBucketOwnershipControlsInput {
     /// <p>The name of the Amazon S3 bucket whose <code>OwnershipControls</code> you want to set.</p>
     pub bucket: BucketName,
+    /// <p> Indicates the algorithm used to create the checksum for the object when you use the SDK. This
+    /// header will not provide any additional functionality if you don't use the SDK. When you send this
+    /// header, there must be a corresponding <code>x-amz-checksum-<i>algorithm</i>
+    /// </code> header
+    /// sent. Otherwise, Amazon S3 fails the request with the HTTP status code <code>400 Bad Request</code>. For more
+    /// information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in
+    /// the <i>Amazon S3 User Guide</i>.</p>
+    /// <p>If you provide an individual checksum, Amazon S3 ignores any provided <code>ChecksumAlgorithm</code>
+    /// parameter. </p>
+    pub checksum_algorithm: Option<ChecksumAlgorithm>,
     /// <p>The MD5 hash of the <code>OwnershipControls</code> request body. </p>
     /// <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
     pub content_md5: Option<ContentMD5>,
     /// <p>The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code> (access denied).</p>
     pub expected_bucket_owner: Option<AccountId>,
-    /// <p>The <code>OwnershipControls</code> (BucketOwnerEnforced, BucketOwnerPreferred, or
-    /// ObjectWriter) that you want to apply to this Amazon S3 bucket.</p>
+    /// <p>The <code>OwnershipControls</code> (BucketOwnerEnforced, BucketOwnerPreferred, or ObjectWriter) that
+    /// you want to apply to this Amazon S3 bucket.</p>
     pub ownership_controls: OwnershipControls,
 }
 
@@ -17366,6 +17376,9 @@ impl fmt::Debug for PutBucketOwnershipControlsInput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("PutBucketOwnershipControlsInput");
         d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.checksum_algorithm {
+            d.field("checksum_algorithm", val);
+        }
         if let Some(ref val) = self.content_md5 {
             d.field("content_md5", val);
         }
@@ -30977,6 +30990,8 @@ pub mod builders {
     pub struct PutBucketOwnershipControlsInputBuilder {
         bucket: Option<BucketName>,
 
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+
         content_md5: Option<ContentMD5>,
 
         expected_bucket_owner: Option<AccountId>,
@@ -30987,6 +31002,11 @@ pub mod builders {
     impl PutBucketOwnershipControlsInputBuilder {
         pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
             self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_algorithm(&mut self, field: Option<ChecksumAlgorithm>) -> &mut Self {
+            self.checksum_algorithm = field;
             self
         }
 
@@ -31012,6 +31032,12 @@ pub mod builders {
         }
 
         #[must_use]
+        pub fn checksum_algorithm(mut self, field: Option<ChecksumAlgorithm>) -> Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        #[must_use]
         pub fn content_md5(mut self, field: Option<ContentMD5>) -> Self {
             self.content_md5 = field;
             self
@@ -31031,6 +31057,7 @@ pub mod builders {
 
         pub fn build(self) -> Result<PutBucketOwnershipControlsInput, BuildError> {
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_algorithm = self.checksum_algorithm;
             let content_md5 = self.content_md5;
             let expected_bucket_owner = self.expected_bucket_owner;
             let ownership_controls = self
@@ -31038,6 +31065,7 @@ pub mod builders {
                 .ok_or_else(|| BuildError::missing_field("ownership_controls"))?;
             Ok(PutBucketOwnershipControlsInput {
                 bucket,
+                checksum_algorithm,
                 content_md5,
                 expected_bucket_owner,
                 ownership_controls,
@@ -38070,6 +38098,11 @@ impl DtoExt for PutBucketNotificationConfigurationInput {
 }
 impl DtoExt for PutBucketOwnershipControlsInput {
     fn ignore_empty_strings(&mut self) {
+        if let Some(ref val) = self.checksum_algorithm
+            && val.as_str() == ""
+        {
+            self.checksum_algorithm = None;
+        }
         if self.content_md5.as_deref() == Some("") {
             self.content_md5 = None;
         }

--- a/crates/s3s/src/dto/generated.rs
+++ b/crates/s3s/src/dto/generated.rs
@@ -685,6 +685,8 @@ impl BucketLocationConstraint {
 
     pub const AP_EAST_1: &'static str = "ap-east-1";
 
+    pub const AP_EAST_2: &'static str = "ap-east-2";
+
     pub const AP_NORTHEAST_1: &'static str = "ap-northeast-1";
 
     pub const AP_NORTHEAST_2: &'static str = "ap-northeast-2";
@@ -705,7 +707,13 @@ impl BucketLocationConstraint {
 
     pub const AP_SOUTHEAST_5: &'static str = "ap-southeast-5";
 
+    pub const AP_SOUTHEAST_6: &'static str = "ap-southeast-6";
+
+    pub const AP_SOUTHEAST_7: &'static str = "ap-southeast-7";
+
     pub const CA_CENTRAL_1: &'static str = "ca-central-1";
+
+    pub const CA_WEST_1: &'static str = "ca-west-1";
 
     pub const CN_NORTH_1: &'static str = "cn-north-1";
 
@@ -732,6 +740,8 @@ impl BucketLocationConstraint {
     pub const ME_CENTRAL_1: &'static str = "me-central-1";
 
     pub const ME_SOUTH_1: &'static str = "me-south-1";
+
+    pub const MX_CENTRAL_1: &'static str = "mx-central-1";
 
     pub const SA_EAST_1: &'static str = "sa-east-1";
 
@@ -15081,9 +15091,17 @@ pub type ObjectSizeLessThanBytes = i64;
 pub struct ObjectStorageClass(Cow<'static, str>);
 
 impl ObjectStorageClass {
+    pub const AWS_BACKUP_LOW_COST_WARM: &'static str = "AWS_BACKUP_LOW_COST_WARM";
+
+    pub const AWS_BACKUP_WARM: &'static str = "AWS_BACKUP_WARM";
+
     pub const DEEP_ARCHIVE: &'static str = "DEEP_ARCHIVE";
 
     pub const EXPRESS_ONEZONE: &'static str = "EXPRESS_ONEZONE";
+
+    pub const FSX_ONTAP: &'static str = "FSX_ONTAP";
+
+    pub const FSX_OPENZFS: &'static str = "FSX_OPENZFS";
 
     pub const GLACIER: &'static str = "GLACIER";
 
@@ -20953,9 +20971,17 @@ impl fmt::Debug for StatsEvent {
 pub struct StorageClass(Cow<'static, str>);
 
 impl StorageClass {
+    pub const AWS_BACKUP_LOW_COST_WARM: &'static str = "AWS_BACKUP_LOW_COST_WARM";
+
+    pub const AWS_BACKUP_WARM: &'static str = "AWS_BACKUP_WARM";
+
     pub const DEEP_ARCHIVE: &'static str = "DEEP_ARCHIVE";
 
     pub const EXPRESS_ONEZONE: &'static str = "EXPRESS_ONEZONE";
+
+    pub const FSX_ONTAP: &'static str = "FSX_ONTAP";
+
+    pub const FSX_OPENZFS: &'static str = "FSX_OPENZFS";
 
     pub const GLACIER: &'static str = "GLACIER";
 

--- a/crates/s3s/src/dto/generated.rs
+++ b/crates/s3s/src/dto/generated.rs
@@ -11640,6 +11640,8 @@ impl InventoryOptionalField {
 
     pub const LAST_MODIFIED_DATE: &'static str = "LastModifiedDate";
 
+    pub const LIFECYCLE_EXPIRATION_DATE: &'static str = "LifecycleExpirationDate";
+
     pub const OBJECT_ACCESS_CONTROL_LIST: &'static str = "ObjectAccessControlList";
 
     pub const OBJECT_LOCK_LEGAL_HOLD_STATUS: &'static str = "ObjectLockLegalHoldStatus";

--- a/crates/s3s/src/dto/generated.rs
+++ b/crates/s3s/src/dto/generated.rs
@@ -4407,6 +4407,8 @@ impl DeleteBucketInput {
 pub struct DeleteBucketIntelligentTieringConfigurationInput {
     /// <p>The name of the Amazon S3 bucket whose configuration you want to modify or retrieve.</p>
     pub bucket: BucketName,
+    /// <p>The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code> (access denied).</p>
+    pub expected_bucket_owner: Option<AccountId>,
     /// <p>The ID used to identify the S3 Intelligent-Tiering configuration.</p>
     pub id: IntelligentTieringId,
 }
@@ -4415,6 +4417,9 @@ impl fmt::Debug for DeleteBucketIntelligentTieringConfigurationInput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("DeleteBucketIntelligentTieringConfigurationInput");
         d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
         d.field("id", &self.id);
         d.finish_non_exhaustive()
     }
@@ -8142,6 +8147,8 @@ impl fmt::Debug for GetBucketEncryptionOutput {
 pub struct GetBucketIntelligentTieringConfigurationInput {
     /// <p>The name of the Amazon S3 bucket whose configuration you want to modify or retrieve.</p>
     pub bucket: BucketName,
+    /// <p>The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code> (access denied).</p>
+    pub expected_bucket_owner: Option<AccountId>,
     /// <p>The ID used to identify the S3 Intelligent-Tiering configuration.</p>
     pub id: IntelligentTieringId,
 }
@@ -8150,6 +8157,9 @@ impl fmt::Debug for GetBucketIntelligentTieringConfigurationInput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("GetBucketIntelligentTieringConfigurationInput");
         d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
         d.field("id", &self.id);
         d.finish_non_exhaustive()
     }
@@ -12177,9 +12187,11 @@ impl fmt::Debug for ListBucketAnalyticsConfigurationsOutput {
 pub struct ListBucketIntelligentTieringConfigurationsInput {
     /// <p>The name of the Amazon S3 bucket whose configuration you want to modify or retrieve.</p>
     pub bucket: BucketName,
-    /// <p>The <code>ContinuationToken</code> that represents a placeholder from where this request
-    /// should begin.</p>
+    /// <p>The <code>ContinuationToken</code> that represents a placeholder from where this request should
+    /// begin.</p>
     pub continuation_token: Option<Token>,
+    /// <p>The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code> (access denied).</p>
+    pub expected_bucket_owner: Option<AccountId>,
 }
 
 impl fmt::Debug for ListBucketIntelligentTieringConfigurationsInput {
@@ -12188,6 +12200,9 @@ impl fmt::Debug for ListBucketIntelligentTieringConfigurationsInput {
         d.field("bucket", &self.bucket);
         if let Some(ref val) = self.continuation_token {
             d.field("continuation_token", val);
+        }
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
         }
         d.finish_non_exhaustive()
     }
@@ -17017,6 +17032,8 @@ impl fmt::Debug for PutBucketEncryptionOutput {
 pub struct PutBucketIntelligentTieringConfigurationInput {
     /// <p>The name of the Amazon S3 bucket whose configuration you want to modify or retrieve.</p>
     pub bucket: BucketName,
+    /// <p>The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code> (access denied).</p>
+    pub expected_bucket_owner: Option<AccountId>,
     /// <p>The ID used to identify the S3 Intelligent-Tiering configuration.</p>
     pub id: IntelligentTieringId,
     /// <p>Container for S3 Intelligent-Tiering configuration.</p>
@@ -17027,6 +17044,9 @@ impl fmt::Debug for PutBucketIntelligentTieringConfigurationInput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("PutBucketIntelligentTieringConfigurationInput");
         d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
         d.field("id", &self.id);
         d.field("intelligent_tiering_configuration", &self.intelligent_tiering_configuration);
         d.finish_non_exhaustive()
@@ -25071,12 +25091,19 @@ pub mod builders {
     pub struct DeleteBucketIntelligentTieringConfigurationInputBuilder {
         bucket: Option<BucketName>,
 
+        expected_bucket_owner: Option<AccountId>,
+
         id: Option<IntelligentTieringId>,
     }
 
     impl DeleteBucketIntelligentTieringConfigurationInputBuilder {
         pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
             self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
             self
         }
 
@@ -25092,6 +25119,12 @@ pub mod builders {
         }
 
         #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
         pub fn id(mut self, field: IntelligentTieringId) -> Self {
             self.id = Some(field);
             self
@@ -25099,8 +25132,13 @@ pub mod builders {
 
         pub fn build(self) -> Result<DeleteBucketIntelligentTieringConfigurationInput, BuildError> {
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let expected_bucket_owner = self.expected_bucket_owner;
             let id = self.id.ok_or_else(|| BuildError::missing_field("id"))?;
-            Ok(DeleteBucketIntelligentTieringConfigurationInput { bucket, id })
+            Ok(DeleteBucketIntelligentTieringConfigurationInput {
+                bucket,
+                expected_bucket_owner,
+                id,
+            })
         }
     }
 
@@ -26132,12 +26170,19 @@ pub mod builders {
     pub struct GetBucketIntelligentTieringConfigurationInputBuilder {
         bucket: Option<BucketName>,
 
+        expected_bucket_owner: Option<AccountId>,
+
         id: Option<IntelligentTieringId>,
     }
 
     impl GetBucketIntelligentTieringConfigurationInputBuilder {
         pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
             self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
             self
         }
 
@@ -26153,6 +26198,12 @@ pub mod builders {
         }
 
         #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
         pub fn id(mut self, field: IntelligentTieringId) -> Self {
             self.id = Some(field);
             self
@@ -26160,8 +26211,13 @@ pub mod builders {
 
         pub fn build(self) -> Result<GetBucketIntelligentTieringConfigurationInput, BuildError> {
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let expected_bucket_owner = self.expected_bucket_owner;
             let id = self.id.ok_or_else(|| BuildError::missing_field("id"))?;
-            Ok(GetBucketIntelligentTieringConfigurationInput { bucket, id })
+            Ok(GetBucketIntelligentTieringConfigurationInput {
+                bucket,
+                expected_bucket_owner,
+                id,
+            })
         }
     }
 
@@ -28238,6 +28294,8 @@ pub mod builders {
         bucket: Option<BucketName>,
 
         continuation_token: Option<Token>,
+
+        expected_bucket_owner: Option<AccountId>,
     }
 
     impl ListBucketIntelligentTieringConfigurationsInputBuilder {
@@ -28248,6 +28306,11 @@ pub mod builders {
 
         pub fn set_continuation_token(&mut self, field: Option<Token>) -> &mut Self {
             self.continuation_token = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
             self
         }
 
@@ -28263,12 +28326,20 @@ pub mod builders {
             self
         }
 
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
         pub fn build(self) -> Result<ListBucketIntelligentTieringConfigurationsInput, BuildError> {
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
             let continuation_token = self.continuation_token;
+            let expected_bucket_owner = self.expected_bucket_owner;
             Ok(ListBucketIntelligentTieringConfigurationsInput {
                 bucket,
                 continuation_token,
+                expected_bucket_owner,
             })
         }
     }
@@ -30536,6 +30607,8 @@ pub mod builders {
     pub struct PutBucketIntelligentTieringConfigurationInputBuilder {
         bucket: Option<BucketName>,
 
+        expected_bucket_owner: Option<AccountId>,
+
         id: Option<IntelligentTieringId>,
 
         intelligent_tiering_configuration: Option<IntelligentTieringConfiguration>,
@@ -30544,6 +30617,11 @@ pub mod builders {
     impl PutBucketIntelligentTieringConfigurationInputBuilder {
         pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
             self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
             self
         }
 
@@ -30564,6 +30642,12 @@ pub mod builders {
         }
 
         #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
         pub fn id(mut self, field: IntelligentTieringId) -> Self {
             self.id = Some(field);
             self
@@ -30577,12 +30661,14 @@ pub mod builders {
 
         pub fn build(self) -> Result<PutBucketIntelligentTieringConfigurationInput, BuildError> {
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let expected_bucket_owner = self.expected_bucket_owner;
             let id = self.id.ok_or_else(|| BuildError::missing_field("id"))?;
             let intelligent_tiering_configuration = self
                 .intelligent_tiering_configuration
                 .ok_or_else(|| BuildError::missing_field("intelligent_tiering_configuration"))?;
             Ok(PutBucketIntelligentTieringConfigurationInput {
                 bucket,
+                expected_bucket_owner,
                 id,
                 intelligent_tiering_configuration,
             })
@@ -35669,7 +35755,11 @@ impl DtoExt for DeleteBucketInput {
     }
 }
 impl DtoExt for DeleteBucketIntelligentTieringConfigurationInput {
-    fn ignore_empty_strings(&mut self) {}
+    fn ignore_empty_strings(&mut self) {
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+    }
 }
 impl DtoExt for DeleteBucketInventoryConfigurationInput {
     fn ignore_empty_strings(&mut self) {
@@ -36017,7 +36107,11 @@ impl DtoExt for GetBucketEncryptionOutput {
     }
 }
 impl DtoExt for GetBucketIntelligentTieringConfigurationInput {
-    fn ignore_empty_strings(&mut self) {}
+    fn ignore_empty_strings(&mut self) {
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+    }
 }
 impl DtoExt for GetBucketIntelligentTieringConfigurationOutput {
     fn ignore_empty_strings(&mut self) {
@@ -37013,6 +37107,9 @@ impl DtoExt for ListBucketIntelligentTieringConfigurationsInput {
     fn ignore_empty_strings(&mut self) {
         if self.continuation_token.as_deref() == Some("") {
             self.continuation_token = None;
+        }
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
         }
     }
 }
@@ -38024,6 +38121,9 @@ impl DtoExt for PutBucketEncryptionInput {
 }
 impl DtoExt for PutBucketIntelligentTieringConfigurationInput {
     fn ignore_empty_strings(&mut self) {
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
         self.intelligent_tiering_configuration.ignore_empty_strings();
     }
 }

--- a/crates/s3s/src/dto/generated_minio.rs
+++ b/crates/s3s/src/dto/generated_minio.rs
@@ -17505,13 +17505,23 @@ impl fmt::Debug for PutBucketNotificationConfigurationOutput {
 pub struct PutBucketOwnershipControlsInput {
     /// <p>The name of the Amazon S3 bucket whose <code>OwnershipControls</code> you want to set.</p>
     pub bucket: BucketName,
+    /// <p> Indicates the algorithm used to create the checksum for the object when you use the SDK. This
+    /// header will not provide any additional functionality if you don't use the SDK. When you send this
+    /// header, there must be a corresponding <code>x-amz-checksum-<i>algorithm</i>
+    /// </code> header
+    /// sent. Otherwise, Amazon S3 fails the request with the HTTP status code <code>400 Bad Request</code>. For more
+    /// information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in
+    /// the <i>Amazon S3 User Guide</i>.</p>
+    /// <p>If you provide an individual checksum, Amazon S3 ignores any provided <code>ChecksumAlgorithm</code>
+    /// parameter. </p>
+    pub checksum_algorithm: Option<ChecksumAlgorithm>,
     /// <p>The MD5 hash of the <code>OwnershipControls</code> request body. </p>
     /// <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
     pub content_md5: Option<ContentMD5>,
     /// <p>The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code> (access denied).</p>
     pub expected_bucket_owner: Option<AccountId>,
-    /// <p>The <code>OwnershipControls</code> (BucketOwnerEnforced, BucketOwnerPreferred, or
-    /// ObjectWriter) that you want to apply to this Amazon S3 bucket.</p>
+    /// <p>The <code>OwnershipControls</code> (BucketOwnerEnforced, BucketOwnerPreferred, or ObjectWriter) that
+    /// you want to apply to this Amazon S3 bucket.</p>
     pub ownership_controls: OwnershipControls,
 }
 
@@ -17519,6 +17529,9 @@ impl fmt::Debug for PutBucketOwnershipControlsInput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("PutBucketOwnershipControlsInput");
         d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.checksum_algorithm {
+            d.field("checksum_algorithm", val);
+        }
         if let Some(ref val) = self.content_md5 {
             d.field("content_md5", val);
         }
@@ -31234,6 +31247,8 @@ pub mod builders {
     pub struct PutBucketOwnershipControlsInputBuilder {
         bucket: Option<BucketName>,
 
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+
         content_md5: Option<ContentMD5>,
 
         expected_bucket_owner: Option<AccountId>,
@@ -31244,6 +31259,11 @@ pub mod builders {
     impl PutBucketOwnershipControlsInputBuilder {
         pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
             self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_algorithm(&mut self, field: Option<ChecksumAlgorithm>) -> &mut Self {
+            self.checksum_algorithm = field;
             self
         }
 
@@ -31269,6 +31289,12 @@ pub mod builders {
         }
 
         #[must_use]
+        pub fn checksum_algorithm(mut self, field: Option<ChecksumAlgorithm>) -> Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        #[must_use]
         pub fn content_md5(mut self, field: Option<ContentMD5>) -> Self {
             self.content_md5 = field;
             self
@@ -31288,6 +31314,7 @@ pub mod builders {
 
         pub fn build(self) -> Result<PutBucketOwnershipControlsInput, BuildError> {
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_algorithm = self.checksum_algorithm;
             let content_md5 = self.content_md5;
             let expected_bucket_owner = self.expected_bucket_owner;
             let ownership_controls = self
@@ -31295,6 +31322,7 @@ pub mod builders {
                 .ok_or_else(|| BuildError::missing_field("ownership_controls"))?;
             Ok(PutBucketOwnershipControlsInput {
                 bucket,
+                checksum_algorithm,
                 content_md5,
                 expected_bucket_owner,
                 ownership_controls,
@@ -38367,6 +38395,11 @@ impl DtoExt for PutBucketNotificationConfigurationInput {
 }
 impl DtoExt for PutBucketOwnershipControlsInput {
     fn ignore_empty_strings(&mut self) {
+        if let Some(ref val) = self.checksum_algorithm
+            && val.as_str() == ""
+        {
+            self.checksum_algorithm = None;
+        }
         if self.content_md5.as_deref() == Some("") {
             self.content_md5 = None;
         }

--- a/crates/s3s/src/dto/generated_minio.rs
+++ b/crates/s3s/src/dto/generated_minio.rs
@@ -4438,6 +4438,8 @@ impl DeleteBucketInput {
 pub struct DeleteBucketIntelligentTieringConfigurationInput {
     /// <p>The name of the Amazon S3 bucket whose configuration you want to modify or retrieve.</p>
     pub bucket: BucketName,
+    /// <p>The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code> (access denied).</p>
+    pub expected_bucket_owner: Option<AccountId>,
     /// <p>The ID used to identify the S3 Intelligent-Tiering configuration.</p>
     pub id: IntelligentTieringId,
 }
@@ -4446,6 +4448,9 @@ impl fmt::Debug for DeleteBucketIntelligentTieringConfigurationInput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("DeleteBucketIntelligentTieringConfigurationInput");
         d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
         d.field("id", &self.id);
         d.finish_non_exhaustive()
     }
@@ -8247,6 +8252,8 @@ impl fmt::Debug for GetBucketEncryptionOutput {
 pub struct GetBucketIntelligentTieringConfigurationInput {
     /// <p>The name of the Amazon S3 bucket whose configuration you want to modify or retrieve.</p>
     pub bucket: BucketName,
+    /// <p>The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code> (access denied).</p>
+    pub expected_bucket_owner: Option<AccountId>,
     /// <p>The ID used to identify the S3 Intelligent-Tiering configuration.</p>
     pub id: IntelligentTieringId,
 }
@@ -8255,6 +8262,9 @@ impl fmt::Debug for GetBucketIntelligentTieringConfigurationInput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("GetBucketIntelligentTieringConfigurationInput");
         d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
         d.field("id", &self.id);
         d.finish_non_exhaustive()
     }
@@ -12326,9 +12336,11 @@ impl fmt::Debug for ListBucketAnalyticsConfigurationsOutput {
 pub struct ListBucketIntelligentTieringConfigurationsInput {
     /// <p>The name of the Amazon S3 bucket whose configuration you want to modify or retrieve.</p>
     pub bucket: BucketName,
-    /// <p>The <code>ContinuationToken</code> that represents a placeholder from where this request
-    /// should begin.</p>
+    /// <p>The <code>ContinuationToken</code> that represents a placeholder from where this request should
+    /// begin.</p>
     pub continuation_token: Option<Token>,
+    /// <p>The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code> (access denied).</p>
+    pub expected_bucket_owner: Option<AccountId>,
 }
 
 impl fmt::Debug for ListBucketIntelligentTieringConfigurationsInput {
@@ -12337,6 +12349,9 @@ impl fmt::Debug for ListBucketIntelligentTieringConfigurationsInput {
         d.field("bucket", &self.bucket);
         if let Some(ref val) = self.continuation_token {
             d.field("continuation_token", val);
+        }
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
         }
         d.finish_non_exhaustive()
     }
@@ -17170,6 +17185,8 @@ impl fmt::Debug for PutBucketEncryptionOutput {
 pub struct PutBucketIntelligentTieringConfigurationInput {
     /// <p>The name of the Amazon S3 bucket whose configuration you want to modify or retrieve.</p>
     pub bucket: BucketName,
+    /// <p>The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code> (access denied).</p>
+    pub expected_bucket_owner: Option<AccountId>,
     /// <p>The ID used to identify the S3 Intelligent-Tiering configuration.</p>
     pub id: IntelligentTieringId,
     /// <p>Container for S3 Intelligent-Tiering configuration.</p>
@@ -17180,6 +17197,9 @@ impl fmt::Debug for PutBucketIntelligentTieringConfigurationInput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("PutBucketIntelligentTieringConfigurationInput");
         d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
         d.field("id", &self.id);
         d.field("intelligent_tiering_configuration", &self.intelligent_tiering_configuration);
         d.finish_non_exhaustive()
@@ -25313,12 +25333,19 @@ pub mod builders {
     pub struct DeleteBucketIntelligentTieringConfigurationInputBuilder {
         bucket: Option<BucketName>,
 
+        expected_bucket_owner: Option<AccountId>,
+
         id: Option<IntelligentTieringId>,
     }
 
     impl DeleteBucketIntelligentTieringConfigurationInputBuilder {
         pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
             self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
             self
         }
 
@@ -25334,6 +25361,12 @@ pub mod builders {
         }
 
         #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
         pub fn id(mut self, field: IntelligentTieringId) -> Self {
             self.id = Some(field);
             self
@@ -25341,8 +25374,13 @@ pub mod builders {
 
         pub fn build(self) -> Result<DeleteBucketIntelligentTieringConfigurationInput, BuildError> {
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let expected_bucket_owner = self.expected_bucket_owner;
             let id = self.id.ok_or_else(|| BuildError::missing_field("id"))?;
-            Ok(DeleteBucketIntelligentTieringConfigurationInput { bucket, id })
+            Ok(DeleteBucketIntelligentTieringConfigurationInput {
+                bucket,
+                expected_bucket_owner,
+                id,
+            })
         }
     }
 
@@ -26374,12 +26412,19 @@ pub mod builders {
     pub struct GetBucketIntelligentTieringConfigurationInputBuilder {
         bucket: Option<BucketName>,
 
+        expected_bucket_owner: Option<AccountId>,
+
         id: Option<IntelligentTieringId>,
     }
 
     impl GetBucketIntelligentTieringConfigurationInputBuilder {
         pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
             self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
             self
         }
 
@@ -26395,6 +26440,12 @@ pub mod builders {
         }
 
         #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
         pub fn id(mut self, field: IntelligentTieringId) -> Self {
             self.id = Some(field);
             self
@@ -26402,8 +26453,13 @@ pub mod builders {
 
         pub fn build(self) -> Result<GetBucketIntelligentTieringConfigurationInput, BuildError> {
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let expected_bucket_owner = self.expected_bucket_owner;
             let id = self.id.ok_or_else(|| BuildError::missing_field("id"))?;
-            Ok(GetBucketIntelligentTieringConfigurationInput { bucket, id })
+            Ok(GetBucketIntelligentTieringConfigurationInput {
+                bucket,
+                expected_bucket_owner,
+                id,
+            })
         }
     }
 
@@ -28480,6 +28536,8 @@ pub mod builders {
         bucket: Option<BucketName>,
 
         continuation_token: Option<Token>,
+
+        expected_bucket_owner: Option<AccountId>,
     }
 
     impl ListBucketIntelligentTieringConfigurationsInputBuilder {
@@ -28490,6 +28548,11 @@ pub mod builders {
 
         pub fn set_continuation_token(&mut self, field: Option<Token>) -> &mut Self {
             self.continuation_token = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
             self
         }
 
@@ -28505,12 +28568,20 @@ pub mod builders {
             self
         }
 
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
         pub fn build(self) -> Result<ListBucketIntelligentTieringConfigurationsInput, BuildError> {
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
             let continuation_token = self.continuation_token;
+            let expected_bucket_owner = self.expected_bucket_owner;
             Ok(ListBucketIntelligentTieringConfigurationsInput {
                 bucket,
                 continuation_token,
+                expected_bucket_owner,
             })
         }
     }
@@ -30793,6 +30864,8 @@ pub mod builders {
     pub struct PutBucketIntelligentTieringConfigurationInputBuilder {
         bucket: Option<BucketName>,
 
+        expected_bucket_owner: Option<AccountId>,
+
         id: Option<IntelligentTieringId>,
 
         intelligent_tiering_configuration: Option<IntelligentTieringConfiguration>,
@@ -30801,6 +30874,11 @@ pub mod builders {
     impl PutBucketIntelligentTieringConfigurationInputBuilder {
         pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
             self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
             self
         }
 
@@ -30821,6 +30899,12 @@ pub mod builders {
         }
 
         #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
         pub fn id(mut self, field: IntelligentTieringId) -> Self {
             self.id = Some(field);
             self
@@ -30834,12 +30918,14 @@ pub mod builders {
 
         pub fn build(self) -> Result<PutBucketIntelligentTieringConfigurationInput, BuildError> {
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let expected_bucket_owner = self.expected_bucket_owner;
             let id = self.id.ok_or_else(|| BuildError::missing_field("id"))?;
             let intelligent_tiering_configuration = self
                 .intelligent_tiering_configuration
                 .ok_or_else(|| BuildError::missing_field("intelligent_tiering_configuration"))?;
             Ok(PutBucketIntelligentTieringConfigurationInput {
                 bucket,
+                expected_bucket_owner,
                 id,
                 intelligent_tiering_configuration,
             })
@@ -35950,7 +36036,11 @@ impl DtoExt for DeleteBucketInput {
     }
 }
 impl DtoExt for DeleteBucketIntelligentTieringConfigurationInput {
-    fn ignore_empty_strings(&mut self) {}
+    fn ignore_empty_strings(&mut self) {
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+    }
 }
 impl DtoExt for DeleteBucketInventoryConfigurationInput {
     fn ignore_empty_strings(&mut self) {
@@ -36308,7 +36398,11 @@ impl DtoExt for GetBucketEncryptionOutput {
     }
 }
 impl DtoExt for GetBucketIntelligentTieringConfigurationInput {
-    fn ignore_empty_strings(&mut self) {}
+    fn ignore_empty_strings(&mut self) {
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+    }
 }
 impl DtoExt for GetBucketIntelligentTieringConfigurationOutput {
     fn ignore_empty_strings(&mut self) {
@@ -37307,6 +37401,9 @@ impl DtoExt for ListBucketIntelligentTieringConfigurationsInput {
     fn ignore_empty_strings(&mut self) {
         if self.continuation_token.as_deref() == Some("") {
             self.continuation_token = None;
+        }
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
         }
     }
 }
@@ -38321,6 +38418,9 @@ impl DtoExt for PutBucketEncryptionInput {
 }
 impl DtoExt for PutBucketIntelligentTieringConfigurationInput {
     fn ignore_empty_strings(&mut self) {
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
         self.intelligent_tiering_configuration.ignore_empty_strings();
     }
 }

--- a/crates/s3s/src/dto/generated_minio.rs
+++ b/crates/s3s/src/dto/generated_minio.rs
@@ -11745,6 +11745,8 @@ impl InventoryOptionalField {
 
     pub const LAST_MODIFIED_DATE: &'static str = "LastModifiedDate";
 
+    pub const LIFECYCLE_EXPIRATION_DATE: &'static str = "LifecycleExpirationDate";
+
     pub const OBJECT_ACCESS_CONTROL_LIST: &'static str = "ObjectAccessControlList";
 
     pub const OBJECT_LOCK_LEGAL_HOLD_STATUS: &'static str = "ObjectLockLegalHoldStatus";

--- a/crates/s3s/src/dto/generated_minio.rs
+++ b/crates/s3s/src/dto/generated_minio.rs
@@ -689,6 +689,8 @@ impl BucketLocationConstraint {
 
     pub const AP_EAST_1: &'static str = "ap-east-1";
 
+    pub const AP_EAST_2: &'static str = "ap-east-2";
+
     pub const AP_NORTHEAST_1: &'static str = "ap-northeast-1";
 
     pub const AP_NORTHEAST_2: &'static str = "ap-northeast-2";
@@ -709,7 +711,13 @@ impl BucketLocationConstraint {
 
     pub const AP_SOUTHEAST_5: &'static str = "ap-southeast-5";
 
+    pub const AP_SOUTHEAST_6: &'static str = "ap-southeast-6";
+
+    pub const AP_SOUTHEAST_7: &'static str = "ap-southeast-7";
+
     pub const CA_CENTRAL_1: &'static str = "ca-central-1";
+
+    pub const CA_WEST_1: &'static str = "ca-west-1";
 
     pub const CN_NORTH_1: &'static str = "cn-north-1";
 
@@ -736,6 +744,8 @@ impl BucketLocationConstraint {
     pub const ME_CENTRAL_1: &'static str = "me-central-1";
 
     pub const ME_SOUTH_1: &'static str = "me-south-1";
+
+    pub const MX_CENTRAL_1: &'static str = "mx-central-1";
 
     pub const SA_EAST_1: &'static str = "sa-east-1";
 
@@ -15230,9 +15240,17 @@ pub type ObjectSizeLessThanBytes = i64;
 pub struct ObjectStorageClass(Cow<'static, str>);
 
 impl ObjectStorageClass {
+    pub const AWS_BACKUP_LOW_COST_WARM: &'static str = "AWS_BACKUP_LOW_COST_WARM";
+
+    pub const AWS_BACKUP_WARM: &'static str = "AWS_BACKUP_WARM";
+
     pub const DEEP_ARCHIVE: &'static str = "DEEP_ARCHIVE";
 
     pub const EXPRESS_ONEZONE: &'static str = "EXPRESS_ONEZONE";
+
+    pub const FSX_ONTAP: &'static str = "FSX_ONTAP";
+
+    pub const FSX_OPENZFS: &'static str = "FSX_OPENZFS";
 
     pub const GLACIER: &'static str = "GLACIER";
 
@@ -21142,9 +21160,17 @@ impl fmt::Debug for StatsEvent {
 pub struct StorageClass(Cow<'static, str>);
 
 impl StorageClass {
+    pub const AWS_BACKUP_LOW_COST_WARM: &'static str = "AWS_BACKUP_LOW_COST_WARM";
+
+    pub const AWS_BACKUP_WARM: &'static str = "AWS_BACKUP_WARM";
+
     pub const DEEP_ARCHIVE: &'static str = "DEEP_ARCHIVE";
 
     pub const EXPRESS_ONEZONE: &'static str = "EXPRESS_ONEZONE";
+
+    pub const FSX_ONTAP: &'static str = "FSX_ONTAP";
+
+    pub const FSX_OPENZFS: &'static str = "FSX_OPENZFS";
 
     pub const GLACIER: &'static str = "GLACIER";
 

--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -5087,6 +5087,8 @@ impl PutBucketOwnershipControls {
     pub fn deserialize_http(req: &mut http::Request) -> S3Result<PutBucketOwnershipControlsInput> {
         let bucket = http::unwrap_bucket(req);
 
+        let checksum_algorithm: Option<ChecksumAlgorithm> = http::parse_checksum_algorithm_header(req)?;
+
         let content_md5: Option<ContentMD5> = http::parse_opt_header(req, &CONTENT_MD5)?;
 
         let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
@@ -5095,6 +5097,7 @@ impl PutBucketOwnershipControls {
 
         Ok(PutBucketOwnershipControlsInput {
             bucket,
+            checksum_algorithm,
             content_md5,
             expected_bucket_owner,
             ownership_controls,

--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -1371,9 +1371,15 @@ impl DeleteBucketIntelligentTieringConfiguration {
     pub fn deserialize_http(req: &mut http::Request) -> S3Result<DeleteBucketIntelligentTieringConfigurationInput> {
         let bucket = http::unwrap_bucket(req);
 
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
         let id: IntelligentTieringId = http::parse_query(req, "id")?;
 
-        Ok(DeleteBucketIntelligentTieringConfigurationInput { bucket, id })
+        Ok(DeleteBucketIntelligentTieringConfigurationInput {
+            bucket,
+            expected_bucket_owner,
+            id,
+        })
     }
 
     pub fn serialize_http(_: DeleteBucketIntelligentTieringConfigurationOutput) -> S3Result<http::Response> {
@@ -2284,9 +2290,15 @@ impl GetBucketIntelligentTieringConfiguration {
     pub fn deserialize_http(req: &mut http::Request) -> S3Result<GetBucketIntelligentTieringConfigurationInput> {
         let bucket = http::unwrap_bucket(req);
 
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
         let id: IntelligentTieringId = http::parse_query(req, "id")?;
 
-        Ok(GetBucketIntelligentTieringConfigurationInput { bucket, id })
+        Ok(GetBucketIntelligentTieringConfigurationInput {
+            bucket,
+            expected_bucket_owner,
+            id,
+        })
     }
 
     pub fn serialize_http(x: GetBucketIntelligentTieringConfigurationOutput) -> S3Result<http::Response> {
@@ -3902,9 +3914,12 @@ impl ListBucketIntelligentTieringConfigurations {
 
         let continuation_token: Option<Token> = http::parse_opt_query(req, "continuation-token")?;
 
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
         Ok(ListBucketIntelligentTieringConfigurationsInput {
             bucket,
             continuation_token,
+            expected_bucket_owner,
         })
     }
 
@@ -4776,12 +4791,15 @@ impl PutBucketIntelligentTieringConfiguration {
     pub fn deserialize_http(req: &mut http::Request) -> S3Result<PutBucketIntelligentTieringConfigurationInput> {
         let bucket = http::unwrap_bucket(req);
 
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
         let id: IntelligentTieringId = http::parse_query(req, "id")?;
 
         let intelligent_tiering_configuration: IntelligentTieringConfiguration = http::take_xml_body(req)?;
 
         Ok(PutBucketIntelligentTieringConfigurationInput {
             bucket,
+            expected_bucket_owner,
             id,
             intelligent_tiering_configuration,
         })

--- a/crates/s3s/src/ops/generated_minio.rs
+++ b/crates/s3s/src/ops/generated_minio.rs
@@ -1380,9 +1380,15 @@ impl DeleteBucketIntelligentTieringConfiguration {
     pub fn deserialize_http(req: &mut http::Request) -> S3Result<DeleteBucketIntelligentTieringConfigurationInput> {
         let bucket = http::unwrap_bucket(req);
 
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
         let id: IntelligentTieringId = http::parse_query(req, "id")?;
 
-        Ok(DeleteBucketIntelligentTieringConfigurationInput { bucket, id })
+        Ok(DeleteBucketIntelligentTieringConfigurationInput {
+            bucket,
+            expected_bucket_owner,
+            id,
+        })
     }
 
     pub fn serialize_http(_: DeleteBucketIntelligentTieringConfigurationOutput) -> S3Result<http::Response> {
@@ -2293,9 +2299,15 @@ impl GetBucketIntelligentTieringConfiguration {
     pub fn deserialize_http(req: &mut http::Request) -> S3Result<GetBucketIntelligentTieringConfigurationInput> {
         let bucket = http::unwrap_bucket(req);
 
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
         let id: IntelligentTieringId = http::parse_query(req, "id")?;
 
-        Ok(GetBucketIntelligentTieringConfigurationInput { bucket, id })
+        Ok(GetBucketIntelligentTieringConfigurationInput {
+            bucket,
+            expected_bucket_owner,
+            id,
+        })
     }
 
     pub fn serialize_http(x: GetBucketIntelligentTieringConfigurationOutput) -> S3Result<http::Response> {
@@ -3911,9 +3923,12 @@ impl ListBucketIntelligentTieringConfigurations {
 
         let continuation_token: Option<Token> = http::parse_opt_query(req, "continuation-token")?;
 
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
         Ok(ListBucketIntelligentTieringConfigurationsInput {
             bucket,
             continuation_token,
+            expected_bucket_owner,
         })
     }
 
@@ -4785,12 +4800,15 @@ impl PutBucketIntelligentTieringConfiguration {
     pub fn deserialize_http(req: &mut http::Request) -> S3Result<PutBucketIntelligentTieringConfigurationInput> {
         let bucket = http::unwrap_bucket(req);
 
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
         let id: IntelligentTieringId = http::parse_query(req, "id")?;
 
         let intelligent_tiering_configuration: IntelligentTieringConfiguration = http::take_xml_body(req)?;
 
         Ok(PutBucketIntelligentTieringConfigurationInput {
             bucket,
+            expected_bucket_owner,
             id,
             intelligent_tiering_configuration,
         })

--- a/crates/s3s/src/ops/generated_minio.rs
+++ b/crates/s3s/src/ops/generated_minio.rs
@@ -5096,6 +5096,8 @@ impl PutBucketOwnershipControls {
     pub fn deserialize_http(req: &mut http::Request) -> S3Result<PutBucketOwnershipControlsInput> {
         let bucket = http::unwrap_bucket(req);
 
+        let checksum_algorithm: Option<ChecksumAlgorithm> = http::parse_checksum_algorithm_header(req)?;
+
         let content_md5: Option<ContentMD5> = http::parse_opt_header(req, &CONTENT_MD5)?;
 
         let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
@@ -5104,6 +5106,7 @@ impl PutBucketOwnershipControls {
 
         Ok(PutBucketOwnershipControlsInput {
             bucket,
+            checksum_algorithm,
             content_md5,
             expected_bucket_owner,
             ownership_controls,

--- a/crates/s3s/src/s3_trait.rs
+++ b/crates/s3s/src/s3_trait.rs
@@ -3868,28 +3868,56 @@ pub trait S3: Send + Sync + 'static {
         Err(s3_error!(NotImplemented, "ListBucketInventoryConfigurations is not implemented yet"))
     }
 
+    /// <p>Lists the metrics configurations for the bucket. The metrics configurations are only for the request
+    /// metrics of the bucket and do not provide information on daily storage metrics. You can have up to 1,000
+    /// configurations per bucket.</p>
     /// <note>
-    /// <p>This operation is not supported for directory buckets.</p>
+    /// <p>
+    /// <b>Directory buckets </b> - For directory buckets, you must make requests for this API operation to the Regional endpoint. These endpoints support path-style requests in the format <code>https://s3express-control.<i>region-code</i>.amazonaws.com/<i>bucket-name</i>
+    /// </code>. Virtual-hosted-style requests aren't supported.
+    /// For more information about endpoints in Availability Zones, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/endpoint-directory-buckets-AZ.html">Regional and Zonal endpoints for directory buckets in Availability Zones</a> in the
+    /// <i>Amazon S3 User Guide</i>. For more information about endpoints in Local Zones, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-lzs-for-directory-buckets.html">Concepts for directory buckets in Local Zones</a> in the
+    /// <i>Amazon S3 User Guide</i>.</p>
     /// </note>
-    /// <p>Lists the metrics configurations for the bucket. The metrics configurations are only for
-    /// the request metrics of the bucket and do not provide information on daily storage metrics.
-    /// You can have up to 1,000 configurations per bucket.</p>
-    /// <p>This action supports list pagination and does not return more than 100 configurations at
-    /// a time. Always check the <code>IsTruncated</code> element in the response. If there are no
-    /// more configurations to list, <code>IsTruncated</code> is set to false. If there are more
-    /// configurations to list, <code>IsTruncated</code> is set to true, and there is a value in
-    /// <code>NextContinuationToken</code>. You use the <code>NextContinuationToken</code> value
-    /// to continue the pagination of the list by passing the value in
-    /// <code>continuation-token</code> in the request to <code>GET</code> the next page.</p>
+    /// <p>This action supports list pagination and does not return more than 100 configurations at a time.
+    /// Always check the <code>IsTruncated</code> element in the response. If there are no more configurations
+    /// to list, <code>IsTruncated</code> is set to false. If there are more configurations to list,
+    /// <code>IsTruncated</code> is set to true, and there is a value in <code>NextContinuationToken</code>.
+    /// You use the <code>NextContinuationToken</code> value to continue the pagination of the list by passing
+    /// the value in <code>continuation-token</code> in the request to <code>GET</code> the next page.</p>
+    /// <dl>
+    /// <dt>Permissions</dt>
+    /// <dd>
     /// <p>To use this operation, you must have permissions to perform the
-    /// <code>s3:GetMetricsConfiguration</code> action. The bucket owner has this permission by
-    /// default. The bucket owner can grant this permission to others. For more information about
-    /// permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing
-    /// Access Permissions to Your Amazon S3 Resources</a>.</p>
-    /// <p>For more information about metrics configurations and CloudWatch request metrics, see
-    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon CloudWatch</a>.</p>
-    /// <p>The following operations are related to
-    /// <code>ListBucketMetricsConfigurations</code>:</p>
+    /// <code>s3:GetMetricsConfiguration</code> action. The bucket owner has this permission by default. The
+    /// bucket owner can grant this permission to others. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+    /// Resources</a>.</p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <b>General purpose bucket permissions</b> - The
+    /// <code>s3:GetMetricsConfiguration</code> permission is required in a policy. For more information
+    /// about general purpose buckets permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies and User
+    /// Policies</a> in the <i>Amazon S3 User Guide</i>.</p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <b>Directory bucket permissions</b> - To grant access to
+    /// this API operation, you must have the <code>s3express:GetMetricsConfiguration</code> permission in
+    /// an IAM identity-based policy instead of a bucket policy. Cross-account access to this API operation isn't supported. This operation can only be performed by the Amazon Web Services account that owns the resource.
+    /// For more information about directory bucket policies and permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-security-iam.html">Amazon Web Services Identity and Access Management (IAM) for S3 Express One Zone</a> in the <i>Amazon S3 User Guide</i>.</p>
+    /// </li>
+    /// </ul>
+    /// </dd>
+    /// <dt>HTTP Host header syntax</dt>
+    /// <dd>
+    /// <p>
+    /// <b>Directory buckets </b> - The HTTP Host header syntax is <code>s3express-control.<i>region-code</i>.amazonaws.com</code>.</p>
+    /// </dd>
+    /// </dl>
+    /// <p>For more information about metrics configurations and CloudWatch request metrics, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with
+    /// Amazon CloudWatch</a>.</p>
+    /// <p>The following operations are related to <code>ListBucketMetricsConfigurations</code>:</p>
     /// <ul>
     /// <li>
     /// <p>
@@ -3907,6 +3935,9 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
+    /// <important>
+    /// <p>You must URL encode any signed header values that contain spaces. For example, if your header value is <code>my  file.txt</code>, containing two spaces after <code>my</code>, you must URL encode this value to <code>my%20%20file.txt</code>.</p>
+    /// </important>
     async fn list_bucket_metrics_configurations(
         &self,
         _req: S3Request<ListBucketMetricsConfigurationsInput>,

--- a/crates/s3s/src/s3_trait.rs
+++ b/crates/s3s/src/s3_trait.rs
@@ -5487,12 +5487,10 @@ pub trait S3: Send + Sync + 'static {
     /// <note>
     /// <p>This operation is not supported for directory buckets.</p>
     /// </note>
-    /// <p>Creates or modifies <code>OwnershipControls</code> for an Amazon S3 bucket. To use this
-    /// operation, you must have the <code>s3:PutBucketOwnershipControls</code> permission. For
-    /// more information about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/user-guide/using-with-s3-actions.html">Specifying permissions in a
-    /// policy</a>. </p>
-    /// <p>For information about Amazon S3 Object Ownership, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/user-guide/about-object-ownership.html">Using object
-    /// ownership</a>. </p>
+    /// <p>Creates or modifies <code>OwnershipControls</code> for an Amazon S3 bucket. To use this operation, you
+    /// must have the <code>s3:PutBucketOwnershipControls</code> permission. For more information about Amazon S3
+    /// permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/user-guide/using-with-s3-actions.html">Specifying permissions in a policy</a>. </p>
+    /// <p>For information about Amazon S3 Object Ownership, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/user-guide/about-object-ownership.html">Using object ownership</a>. </p>
     /// <p>The following operations are related to <code>PutBucketOwnershipControls</code>:</p>
     /// <ul>
     /// <li>
@@ -5506,6 +5504,9 @@ pub trait S3: Send + Sync + 'static {
     /// </p>
     /// </li>
     /// </ul>
+    /// <important>
+    /// <p>You must URL encode any signed header values that contain spaces. For example, if your header value is <code>my  file.txt</code>, containing two spaces after <code>my</code>, you must URL encode this value to <code>my%20%20file.txt</code>.</p>
+    /// </important>
     async fn put_bucket_ownership_controls(
         &self,
         _req: S3Request<PutBucketOwnershipControlsInput>,

--- a/crates/s3s/src/xml/generated.rs
+++ b/crates/s3s/src/xml/generated.rs
@@ -5313,6 +5313,7 @@ impl<'xml> DeserializeContent<'xml> for InventoryOptionalField {
             "IntelligentTieringAccessTier" => Ok(Self::from_static(InventoryOptionalField::INTELLIGENT_TIERING_ACCESS_TIER)),
             "IsMultipartUploaded" => Ok(Self::from_static(InventoryOptionalField::IS_MULTIPART_UPLOADED)),
             "LastModifiedDate" => Ok(Self::from_static(InventoryOptionalField::LAST_MODIFIED_DATE)),
+            "LifecycleExpirationDate" => Ok(Self::from_static(InventoryOptionalField::LIFECYCLE_EXPIRATION_DATE)),
             "ObjectAccessControlList" => Ok(Self::from_static(InventoryOptionalField::OBJECT_ACCESS_CONTROL_LIST)),
             "ObjectLockLegalHoldStatus" => Ok(Self::from_static(InventoryOptionalField::OBJECT_LOCK_LEGAL_HOLD_STATUS)),
             "ObjectLockMode" => Ok(Self::from_static(InventoryOptionalField::OBJECT_LOCK_MODE)),

--- a/crates/s3s/src/xml/generated.rs
+++ b/crates/s3s/src/xml/generated.rs
@@ -2040,6 +2040,7 @@ impl<'xml> DeserializeContent<'xml> for BucketLocationConstraint {
             "EU" => Ok(Self::from_static(BucketLocationConstraint::EU)),
             "af-south-1" => Ok(Self::from_static(BucketLocationConstraint::AF_SOUTH_1)),
             "ap-east-1" => Ok(Self::from_static(BucketLocationConstraint::AP_EAST_1)),
+            "ap-east-2" => Ok(Self::from_static(BucketLocationConstraint::AP_EAST_2)),
             "ap-northeast-1" => Ok(Self::from_static(BucketLocationConstraint::AP_NORTHEAST_1)),
             "ap-northeast-2" => Ok(Self::from_static(BucketLocationConstraint::AP_NORTHEAST_2)),
             "ap-northeast-3" => Ok(Self::from_static(BucketLocationConstraint::AP_NORTHEAST_3)),
@@ -2050,7 +2051,10 @@ impl<'xml> DeserializeContent<'xml> for BucketLocationConstraint {
             "ap-southeast-3" => Ok(Self::from_static(BucketLocationConstraint::AP_SOUTHEAST_3)),
             "ap-southeast-4" => Ok(Self::from_static(BucketLocationConstraint::AP_SOUTHEAST_4)),
             "ap-southeast-5" => Ok(Self::from_static(BucketLocationConstraint::AP_SOUTHEAST_5)),
+            "ap-southeast-6" => Ok(Self::from_static(BucketLocationConstraint::AP_SOUTHEAST_6)),
+            "ap-southeast-7" => Ok(Self::from_static(BucketLocationConstraint::AP_SOUTHEAST_7)),
             "ca-central-1" => Ok(Self::from_static(BucketLocationConstraint::CA_CENTRAL_1)),
+            "ca-west-1" => Ok(Self::from_static(BucketLocationConstraint::CA_WEST_1)),
             "cn-north-1" => Ok(Self::from_static(BucketLocationConstraint::CN_NORTH_1)),
             "cn-northwest-1" => Ok(Self::from_static(BucketLocationConstraint::CN_NORTHWEST_1)),
             "eu-central-1" => Ok(Self::from_static(BucketLocationConstraint::EU_CENTRAL_1)),
@@ -2064,6 +2068,7 @@ impl<'xml> DeserializeContent<'xml> for BucketLocationConstraint {
             "il-central-1" => Ok(Self::from_static(BucketLocationConstraint::IL_CENTRAL_1)),
             "me-central-1" => Ok(Self::from_static(BucketLocationConstraint::ME_CENTRAL_1)),
             "me-south-1" => Ok(Self::from_static(BucketLocationConstraint::ME_SOUTH_1)),
+            "mx-central-1" => Ok(Self::from_static(BucketLocationConstraint::MX_CENTRAL_1)),
             "sa-east-1" => Ok(Self::from_static(BucketLocationConstraint::SA_EAST_1)),
             "us-east-2" => Ok(Self::from_static(BucketLocationConstraint::US_EAST_2)),
             "us-gov-east-1" => Ok(Self::from_static(BucketLocationConstraint::US_GOV_EAST_1)),
@@ -7643,8 +7648,12 @@ impl SerializeContent for ObjectStorageClass {
 impl<'xml> DeserializeContent<'xml> for ObjectStorageClass {
     fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
         d.text(|s| match s {
+            "AWS_BACKUP_LOW_COST_WARM" => Ok(Self::from_static(ObjectStorageClass::AWS_BACKUP_LOW_COST_WARM)),
+            "AWS_BACKUP_WARM" => Ok(Self::from_static(ObjectStorageClass::AWS_BACKUP_WARM)),
             "DEEP_ARCHIVE" => Ok(Self::from_static(ObjectStorageClass::DEEP_ARCHIVE)),
             "EXPRESS_ONEZONE" => Ok(Self::from_static(ObjectStorageClass::EXPRESS_ONEZONE)),
+            "FSX_ONTAP" => Ok(Self::from_static(ObjectStorageClass::FSX_ONTAP)),
+            "FSX_OPENZFS" => Ok(Self::from_static(ObjectStorageClass::FSX_OPENZFS)),
             "GLACIER" => Ok(Self::from_static(ObjectStorageClass::GLACIER)),
             "GLACIER_IR" => Ok(Self::from_static(ObjectStorageClass::GLACIER_IR)),
             "INTELLIGENT_TIERING" => Ok(Self::from_static(ObjectStorageClass::INTELLIGENT_TIERING)),
@@ -9948,8 +9957,12 @@ impl SerializeContent for StorageClass {
 impl<'xml> DeserializeContent<'xml> for StorageClass {
     fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
         d.text(|s| match s {
+            "AWS_BACKUP_LOW_COST_WARM" => Ok(Self::from_static(StorageClass::AWS_BACKUP_LOW_COST_WARM)),
+            "AWS_BACKUP_WARM" => Ok(Self::from_static(StorageClass::AWS_BACKUP_WARM)),
             "DEEP_ARCHIVE" => Ok(Self::from_static(StorageClass::DEEP_ARCHIVE)),
             "EXPRESS_ONEZONE" => Ok(Self::from_static(StorageClass::EXPRESS_ONEZONE)),
+            "FSX_ONTAP" => Ok(Self::from_static(StorageClass::FSX_ONTAP)),
+            "FSX_OPENZFS" => Ok(Self::from_static(StorageClass::FSX_OPENZFS)),
             "GLACIER" => Ok(Self::from_static(StorageClass::GLACIER)),
             "GLACIER_IR" => Ok(Self::from_static(StorageClass::GLACIER_IR)),
             "INTELLIGENT_TIERING" => Ok(Self::from_static(StorageClass::INTELLIGENT_TIERING)),

--- a/crates/s3s/src/xml/generated_minio.rs
+++ b/crates/s3s/src/xml/generated_minio.rs
@@ -5426,6 +5426,7 @@ impl<'xml> DeserializeContent<'xml> for InventoryOptionalField {
             "IntelligentTieringAccessTier" => Ok(Self::from_static(InventoryOptionalField::INTELLIGENT_TIERING_ACCESS_TIER)),
             "IsMultipartUploaded" => Ok(Self::from_static(InventoryOptionalField::IS_MULTIPART_UPLOADED)),
             "LastModifiedDate" => Ok(Self::from_static(InventoryOptionalField::LAST_MODIFIED_DATE)),
+            "LifecycleExpirationDate" => Ok(Self::from_static(InventoryOptionalField::LIFECYCLE_EXPIRATION_DATE)),
             "ObjectAccessControlList" => Ok(Self::from_static(InventoryOptionalField::OBJECT_ACCESS_CONTROL_LIST)),
             "ObjectLockLegalHoldStatus" => Ok(Self::from_static(InventoryOptionalField::OBJECT_LOCK_LEGAL_HOLD_STATUS)),
             "ObjectLockMode" => Ok(Self::from_static(InventoryOptionalField::OBJECT_LOCK_MODE)),

--- a/crates/s3s/src/xml/generated_minio.rs
+++ b/crates/s3s/src/xml/generated_minio.rs
@@ -2064,6 +2064,7 @@ impl<'xml> DeserializeContent<'xml> for BucketLocationConstraint {
             "EU" => Ok(Self::from_static(BucketLocationConstraint::EU)),
             "af-south-1" => Ok(Self::from_static(BucketLocationConstraint::AF_SOUTH_1)),
             "ap-east-1" => Ok(Self::from_static(BucketLocationConstraint::AP_EAST_1)),
+            "ap-east-2" => Ok(Self::from_static(BucketLocationConstraint::AP_EAST_2)),
             "ap-northeast-1" => Ok(Self::from_static(BucketLocationConstraint::AP_NORTHEAST_1)),
             "ap-northeast-2" => Ok(Self::from_static(BucketLocationConstraint::AP_NORTHEAST_2)),
             "ap-northeast-3" => Ok(Self::from_static(BucketLocationConstraint::AP_NORTHEAST_3)),
@@ -2074,7 +2075,10 @@ impl<'xml> DeserializeContent<'xml> for BucketLocationConstraint {
             "ap-southeast-3" => Ok(Self::from_static(BucketLocationConstraint::AP_SOUTHEAST_3)),
             "ap-southeast-4" => Ok(Self::from_static(BucketLocationConstraint::AP_SOUTHEAST_4)),
             "ap-southeast-5" => Ok(Self::from_static(BucketLocationConstraint::AP_SOUTHEAST_5)),
+            "ap-southeast-6" => Ok(Self::from_static(BucketLocationConstraint::AP_SOUTHEAST_6)),
+            "ap-southeast-7" => Ok(Self::from_static(BucketLocationConstraint::AP_SOUTHEAST_7)),
             "ca-central-1" => Ok(Self::from_static(BucketLocationConstraint::CA_CENTRAL_1)),
+            "ca-west-1" => Ok(Self::from_static(BucketLocationConstraint::CA_WEST_1)),
             "cn-north-1" => Ok(Self::from_static(BucketLocationConstraint::CN_NORTH_1)),
             "cn-northwest-1" => Ok(Self::from_static(BucketLocationConstraint::CN_NORTHWEST_1)),
             "eu-central-1" => Ok(Self::from_static(BucketLocationConstraint::EU_CENTRAL_1)),
@@ -2088,6 +2092,7 @@ impl<'xml> DeserializeContent<'xml> for BucketLocationConstraint {
             "il-central-1" => Ok(Self::from_static(BucketLocationConstraint::IL_CENTRAL_1)),
             "me-central-1" => Ok(Self::from_static(BucketLocationConstraint::ME_CENTRAL_1)),
             "me-south-1" => Ok(Self::from_static(BucketLocationConstraint::ME_SOUTH_1)),
+            "mx-central-1" => Ok(Self::from_static(BucketLocationConstraint::MX_CENTRAL_1)),
             "sa-east-1" => Ok(Self::from_static(BucketLocationConstraint::SA_EAST_1)),
             "us-east-2" => Ok(Self::from_static(BucketLocationConstraint::US_EAST_2)),
             "us-gov-east-1" => Ok(Self::from_static(BucketLocationConstraint::US_GOV_EAST_1)),
@@ -7781,8 +7786,12 @@ impl SerializeContent for ObjectStorageClass {
 impl<'xml> DeserializeContent<'xml> for ObjectStorageClass {
     fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
         d.text(|s| match s {
+            "AWS_BACKUP_LOW_COST_WARM" => Ok(Self::from_static(ObjectStorageClass::AWS_BACKUP_LOW_COST_WARM)),
+            "AWS_BACKUP_WARM" => Ok(Self::from_static(ObjectStorageClass::AWS_BACKUP_WARM)),
             "DEEP_ARCHIVE" => Ok(Self::from_static(ObjectStorageClass::DEEP_ARCHIVE)),
             "EXPRESS_ONEZONE" => Ok(Self::from_static(ObjectStorageClass::EXPRESS_ONEZONE)),
+            "FSX_ONTAP" => Ok(Self::from_static(ObjectStorageClass::FSX_ONTAP)),
+            "FSX_OPENZFS" => Ok(Self::from_static(ObjectStorageClass::FSX_OPENZFS)),
             "GLACIER" => Ok(Self::from_static(ObjectStorageClass::GLACIER)),
             "GLACIER_IR" => Ok(Self::from_static(ObjectStorageClass::GLACIER_IR)),
             "INTELLIGENT_TIERING" => Ok(Self::from_static(ObjectStorageClass::INTELLIGENT_TIERING)),
@@ -10103,8 +10112,12 @@ impl SerializeContent for StorageClass {
 impl<'xml> DeserializeContent<'xml> for StorageClass {
     fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
         d.text(|s| match s {
+            "AWS_BACKUP_LOW_COST_WARM" => Ok(Self::from_static(StorageClass::AWS_BACKUP_LOW_COST_WARM)),
+            "AWS_BACKUP_WARM" => Ok(Self::from_static(StorageClass::AWS_BACKUP_WARM)),
             "DEEP_ARCHIVE" => Ok(Self::from_static(StorageClass::DEEP_ARCHIVE)),
             "EXPRESS_ONEZONE" => Ok(Self::from_static(StorageClass::EXPRESS_ONEZONE)),
+            "FSX_ONTAP" => Ok(Self::from_static(StorageClass::FSX_ONTAP)),
+            "FSX_OPENZFS" => Ok(Self::from_static(StorageClass::FSX_OPENZFS)),
             "GLACIER" => Ok(Self::from_static(StorageClass::GLACIER)),
             "GLACIER_IR" => Ok(Self::from_static(StorageClass::GLACIER_IR)),
             "INTELLIGENT_TIERING" => Ok(Self::from_static(StorageClass::INTELLIGENT_TIERING)),

--- a/data/s3.json
+++ b/data/s3.json
@@ -267,6 +267,9 @@
                     "target": "com.amazonaws.s3#CreateBucket"
                 },
                 {
+                    "target": "com.amazonaws.s3#CreateBucketMetadataConfiguration"
+                },
+                {
                     "target": "com.amazonaws.s3#CreateBucketMetadataTableConfiguration"
                 },
                 {
@@ -297,6 +300,9 @@
                     "target": "com.amazonaws.s3#DeleteBucketLifecycle"
                 },
                 {
+                    "target": "com.amazonaws.s3#DeleteBucketMetadataConfiguration"
+                },
+                {
                     "target": "com.amazonaws.s3#DeleteBucketMetadataTableConfiguration"
                 },
                 {
@@ -321,6 +327,9 @@
                     "target": "com.amazonaws.s3#DeleteObject"
                 },
                 {
+                    "target": "com.amazonaws.s3#DeleteObjectAnnotation"
+                },
+                {
                     "target": "com.amazonaws.s3#DeleteObjects"
                 },
                 {
@@ -328,6 +337,9 @@
                 },
                 {
                     "target": "com.amazonaws.s3#DeletePublicAccessBlock"
+                },
+                {
+                    "target": "com.amazonaws.s3#GetBucketAbac"
                 },
                 {
                     "target": "com.amazonaws.s3#GetBucketAccelerateConfiguration"
@@ -358,6 +370,9 @@
                 },
                 {
                     "target": "com.amazonaws.s3#GetBucketLogging"
+                },
+                {
+                    "target": "com.amazonaws.s3#GetBucketMetadataConfiguration"
                 },
                 {
                     "target": "com.amazonaws.s3#GetBucketMetadataTableConfiguration"
@@ -397,6 +412,9 @@
                 },
                 {
                     "target": "com.amazonaws.s3#GetObjectAcl"
+                },
+                {
+                    "target": "com.amazonaws.s3#GetObjectAnnotation"
                 },
                 {
                     "target": "com.amazonaws.s3#GetObjectAttributes"
@@ -447,6 +465,9 @@
                     "target": "com.amazonaws.s3#ListMultipartUploads"
                 },
                 {
+                    "target": "com.amazonaws.s3#ListObjectAnnotations"
+                },
+                {
                     "target": "com.amazonaws.s3#ListObjects"
                 },
                 {
@@ -457,6 +478,9 @@
                 },
                 {
                     "target": "com.amazonaws.s3#ListParts"
+                },
+                {
+                    "target": "com.amazonaws.s3#PutBucketAbac"
                 },
                 {
                     "target": "com.amazonaws.s3#PutBucketAccelerateConfiguration"
@@ -519,6 +543,9 @@
                     "target": "com.amazonaws.s3#PutObjectAcl"
                 },
                 {
+                    "target": "com.amazonaws.s3#PutObjectAnnotation"
+                },
+                {
                     "target": "com.amazonaws.s3#PutObjectLegalHold"
                 },
                 {
@@ -534,10 +561,25 @@
                     "target": "com.amazonaws.s3#PutPublicAccessBlock"
                 },
                 {
+                    "target": "com.amazonaws.s3#RenameObject"
+                },
+                {
                     "target": "com.amazonaws.s3#RestoreObject"
                 },
                 {
                     "target": "com.amazonaws.s3#SelectObjectContent"
+                },
+                {
+                    "target": "com.amazonaws.s3#UpdateBucketMetadataAnnotationTableConfiguration"
+                },
+                {
+                    "target": "com.amazonaws.s3#UpdateBucketMetadataInventoryTableConfiguration"
+                },
+                {
+                    "target": "com.amazonaws.s3#UpdateBucketMetadataJournalTableConfiguration"
+                },
+                {
+                    "target": "com.amazonaws.s3#UpdateObjectEncryption"
                 },
                 {
                     "target": "com.amazonaws.s3#UploadPart"
@@ -563,7 +605,7 @@
                 "aws.protocols#restXml": {
                     "noErrorWrapping": true
                 },
-                "smithy.api#documentation": "<p></p>",
+                "smithy.api#documentation": "<note>\n            <p>For information about using the Amazon S3 API—including authentication, signing requests, code examples, and error handling—see the <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/developerguide/Welcome.html\">Amazon S3 Developer Guide</a>.</p>\n         </note>\n         <p>Welcome to the <i>Amazon S3 API Reference</i>. This guide explains the Amazon Simple Storage Service (Amazon S3)\n      application programming interface (API).</p>\n         <p>Welcome to the <i>Amazon S3 API Reference</i>. This guide explains the Amazon Simple Storage Service (Amazon S3)\n      application programming interface (API).</p>\n         <p>You can use any toolkit that supports HTTP to use the REST API. You can even use a browser\n      to fetch objects, as long as they are anonymously readable.</p>\n         <p>The REST API uses the standard HTTP headers and status codes, so that standard browsers and toolkits work as expected. In some areas, we have added functionality to HTTP (for example, we added headers to support access control). In these cases, we have done our best to add the new functionality in a way that matched the style of standard HTTP usage.</p>\n         <p>The current version of the Amazon S3 API is <code>2006-03-01</code>.</p>\n         <p>Amazon S3 supports the REST API.</p>\n         <note>\n            <p>Support for SOAP over HTTP is deprecated, but it is still available over HTTPS.\n        However, new Amazon S3 features will not be supported for SOAP. We recommend that\n        you use either this REST API or the Amazon Web Services SDKs.</p>\n         </note>",
                 "smithy.api#suppress": [
                     "RuleSetAuthSchemes"
                 ],
@@ -593,108 +635,2659 @@
                         "type": "boolean"
                     }
                 },
-                "smithy.rules#endpointRuleSet": {
-                    "version": "1.0",
+                "smithy.rules#endpointBdd": {
+                    "version": "1.1",
                     "parameters": {
                         "Bucket": {
                             "required": false,
                             "documentation": "The S3 bucket used to send the request. This is an optional parameter that will be set automatically for operations that are scoped to an S3 bucket.",
-                            "type": "String"
+                            "type": "string"
                         },
                         "Region": {
                             "builtIn": "AWS::Region",
                             "required": false,
                             "documentation": "The AWS region used to dispatch the request.",
-                            "type": "String"
+                            "type": "string"
                         },
                         "UseFIPS": {
                             "builtIn": "AWS::UseFIPS",
                             "required": true,
                             "default": false,
                             "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
-                            "type": "Boolean"
+                            "type": "boolean"
                         },
                         "UseDualStack": {
                             "builtIn": "AWS::UseDualStack",
                             "required": true,
                             "default": false,
                             "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
-                            "type": "Boolean"
+                            "type": "boolean"
                         },
                         "Endpoint": {
                             "builtIn": "SDK::Endpoint",
                             "required": false,
                             "documentation": "Override the endpoint used to send this request",
-                            "type": "String"
+                            "type": "string"
                         },
                         "ForcePathStyle": {
                             "builtIn": "AWS::S3::ForcePathStyle",
                             "required": true,
                             "default": false,
                             "documentation": "When true, force a path-style endpoint to be used where the bucket name is part of the path.",
-                            "type": "Boolean"
+                            "type": "boolean"
                         },
                         "Accelerate": {
                             "builtIn": "AWS::S3::Accelerate",
                             "required": true,
                             "default": false,
                             "documentation": "When true, use S3 Accelerate. NOTE: Not all regions support S3 accelerate.",
-                            "type": "Boolean"
+                            "type": "boolean"
                         },
                         "UseGlobalEndpoint": {
                             "builtIn": "AWS::S3::UseGlobalEndpoint",
                             "required": true,
                             "default": false,
                             "documentation": "Whether the global endpoint should be used, rather then the regional endpoint for us-east-1.",
-                            "type": "Boolean"
+                            "type": "boolean"
                         },
                         "UseObjectLambdaEndpoint": {
                             "required": false,
                             "documentation": "Internal parameter to use object lambda endpoint for an operation (eg: WriteGetObjectResponse)",
-                            "type": "Boolean"
+                            "type": "boolean"
                         },
                         "Key": {
                             "required": false,
                             "documentation": "The S3 Key used to send the request. This is an optional parameter that will be set automatically for operations that are scoped to an S3 Key.",
-                            "type": "String"
+                            "type": "string"
                         },
                         "Prefix": {
                             "required": false,
                             "documentation": "The S3 Prefix used to send the request. This is an optional parameter that will be set automatically for operations that are scoped to an S3 Prefix.",
-                            "type": "String"
+                            "type": "string"
                         },
                         "CopySource": {
                             "required": false,
                             "documentation": "The Copy Source used for Copy Object request. This is an optional parameter that will be set automatically for operations that are scoped to Copy Source.",
-                            "type": "String"
+                            "type": "string"
                         },
                         "DisableAccessPoints": {
                             "required": false,
                             "documentation": "Internal parameter to disable Access Point Buckets",
-                            "type": "Boolean"
+                            "type": "boolean"
                         },
                         "DisableMultiRegionAccessPoints": {
                             "builtIn": "AWS::S3::DisableMultiRegionAccessPoints",
                             "required": true,
                             "default": false,
                             "documentation": "Whether multi-region access points (MRAP) should be disabled.",
-                            "type": "Boolean"
+                            "type": "boolean"
                         },
                         "UseArnRegion": {
                             "builtIn": "AWS::S3::UseArnRegion",
                             "required": false,
                             "documentation": "When an Access Point ARN is provided and this flag is enabled, the SDK MUST use the ARN's region when constructing the endpoint instead of the client's configured region.",
-                            "type": "Boolean"
+                            "type": "boolean"
                         },
                         "UseS3ExpressControlEndpoint": {
                             "required": false,
                             "documentation": "Internal parameter to indicate whether S3Express operation should use control plane, (ex. CreateBucket)",
-                            "type": "Boolean"
+                            "type": "boolean"
                         },
                         "DisableS3ExpressSessionAuth": {
                             "required": false,
                             "documentation": "Parameter to indicate whether S3Express session auth should be disabled",
-                            "type": "Boolean"
+                            "type": "boolean"
+                        }
+                    },
+                    "conditions": [
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "Accelerate"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseFIPS"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseDualStack"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Endpoint"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "isSet",
+                            "argv": [
+                                {
+                                    "ref": "Bucket"
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "coalesce",
+                                    "argv": [
+                                        {
+                                            "fn": "substring",
+                                            "argv": [
+                                                {
+                                                    "ref": "Bucket"
+                                                },
+                                                0,
+                                                6,
+                                                true
+                                            ]
+                                        },
+                                        ""
+                                    ]
+                                },
+                                "--x-s3"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "coalesce",
+                                    "argv": [
+                                        {
+                                            "fn": "substring",
+                                            "argv": [
+                                                {
+                                                    "ref": "Bucket"
+                                                },
+                                                0,
+                                                7,
+                                                true
+                                            ]
+                                        },
+                                        ""
+                                    ]
+                                },
+                                "--xa-s3"
+                            ]
+                        },
+                        {
+                            "fn": "aws.partition",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                }
+                            ],
+                            "assign": "partitionResult"
+                        },
+                        {
+                            "fn": "substring",
+                            "argv": [
+                                {
+                                    "ref": "Bucket"
+                                },
+                                0,
+                                7,
+                                true
+                            ],
+                            "assign": "accessPointSuffix"
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "accessPointSuffix"
+                                },
+                                "--op-s3"
+                            ]
+                        },
+                        {
+                            "fn": "substring",
+                            "argv": [
+                                {
+                                    "ref": "Bucket"
+                                },
+                                8,
+                                12,
+                                true
+                            ],
+                            "assign": "regionPrefix"
+                        },
+                        {
+                            "fn": "substring",
+                            "argv": [
+                                {
+                                    "ref": "Bucket"
+                                },
+                                32,
+                                49,
+                                true
+                            ],
+                            "assign": "outpostId_ssa_2"
+                        },
+                        {
+                            "fn": "substring",
+                            "argv": [
+                                {
+                                    "ref": "Bucket"
+                                },
+                                49,
+                                50,
+                                true
+                            ],
+                            "assign": "hardwareType"
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "ForcePathStyle"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "partitionResult"
+                                        },
+                                        "name"
+                                    ]
+                                },
+                                "aws-cn"
+                            ]
+                        },
+                        {
+                            "fn": "ite",
+                            "argv": [
+                                {
+                                    "ref": "UseDualStack"
+                                },
+                                ".dualstack",
+                                ""
+                            ],
+                            "assign": "_s3e_ds"
+                        },
+                        {
+                            "fn": "isValidHostLabel",
+                            "argv": [
+                                {
+                                    "ref": "outpostId_ssa_2"
+                                },
+                                false
+                            ]
+                        },
+                        {
+                            "fn": "ite",
+                            "argv": [
+                                {
+                                    "ref": "UseFIPS"
+                                },
+                                "-fips",
+                                ""
+                            ],
+                            "assign": "_s3e_fips"
+                        },
+                        {
+                            "fn": "ite",
+                            "argv": [
+                                {
+                                    "fn": "coalesce",
+                                    "argv": [
+                                        {
+                                            "ref": "DisableS3ExpressSessionAuth"
+                                        },
+                                        false
+                                    ]
+                                },
+                                "sigv4",
+                                "sigv4-s3express"
+                            ],
+                            "assign": "_s3e_auth"
+                        },
+                        {
+                            "fn": "aws.isVirtualHostableS3Bucket",
+                            "argv": [
+                                {
+                                    "ref": "Bucket"
+                                },
+                                false
+                            ]
+                        },
+                        {
+                            "fn": "parseURL",
+                            "argv": [
+                                {
+                                    "ref": "Endpoint"
+                                }
+                            ],
+                            "assign": "url"
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "coalesce",
+                                    "argv": [
+                                        {
+                                            "ref": "UseS3ExpressControlEndpoint"
+                                        },
+                                        false
+                                    ]
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "aws.isVirtualHostableS3Bucket",
+                            "argv": [
+                                {
+                                    "ref": "Bucket"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "url"
+                                        },
+                                        "scheme"
+                                    ]
+                                },
+                                "http"
+                            ]
+                        },
+                        {
+                            "fn": "isValidHostLabel",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                false
+                            ]
+                        },
+                        {
+                            "fn": "aws.parseArn",
+                            "argv": [
+                                {
+                                    "ref": "Bucket"
+                                }
+                            ],
+                            "assign": "bucketArn"
+                        },
+                        {
+                            "fn": "getAttr",
+                            "argv": [
+                                {
+                                    "fn": "split",
+                                    "argv": [
+                                        {
+                                            "ref": "Bucket"
+                                        },
+                                        "--",
+                                        0
+                                    ]
+                                },
+                                "[-2]"
+                            ],
+                            "assign": "s3expressAvailabilityZoneId"
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "coalesce",
+                                    "argv": [
+                                        {
+                                            "fn": "substring",
+                                            "argv": [
+                                                {
+                                                    "ref": "Bucket"
+                                                },
+                                                0,
+                                                4,
+                                                false
+                                            ]
+                                        },
+                                        ""
+                                    ]
+                                },
+                                "arn:"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "coalesce",
+                                    "argv": [
+                                        {
+                                            "fn": "substring",
+                                            "argv": [
+                                                {
+                                                    "ref": "Bucket"
+                                                },
+                                                16,
+                                                18,
+                                                true
+                                            ]
+                                        },
+                                        ""
+                                    ]
+                                },
+                                "--"
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "url"
+                                        },
+                                        "isIp"
+                                    ]
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "coalesce",
+                                    "argv": [
+                                        {
+                                            "fn": "substring",
+                                            "argv": [
+                                                {
+                                                    "ref": "Bucket"
+                                                },
+                                                21,
+                                                23,
+                                                true
+                                            ]
+                                        },
+                                        ""
+                                    ]
+                                },
+                                "--"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "coalesce",
+                                    "argv": [
+                                        {
+                                            "fn": "substring",
+                                            "argv": [
+                                                {
+                                                    "ref": "Bucket"
+                                                },
+                                                27,
+                                                29,
+                                                true
+                                            ]
+                                        },
+                                        ""
+                                    ]
+                                },
+                                "--"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "regionPrefix"
+                                },
+                                "beta"
+                            ]
+                        },
+                        {
+                            "fn": "uriEncode",
+                            "argv": [
+                                {
+                                    "ref": "Bucket"
+                                }
+                            ],
+                            "assign": "uri_encoded_bucket"
+                        },
+                        {
+                            "fn": "isValidHostLabel",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "coalesce",
+                                    "argv": [
+                                        {
+                                            "ref": "UseObjectLambdaEndpoint"
+                                        },
+                                        false
+                                    ]
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "getAttr",
+                            "argv": [
+                                {
+                                    "ref": "bucketArn"
+                                },
+                                "resourceId[0]"
+                            ],
+                            "assign": "arnType"
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "arnType"
+                                },
+                                ""
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "arnType"
+                                },
+                                "accesspoint"
+                            ]
+                        },
+                        {
+                            "fn": "getAttr",
+                            "argv": [
+                                {
+                                    "ref": "bucketArn"
+                                },
+                                "resourceId[1]"
+                            ],
+                            "assign": "accessPointName_ssa_1"
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "accessPointName_ssa_1"
+                                },
+                                ""
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "bucketArn"
+                                        },
+                                        "region"
+                                    ]
+                                },
+                                ""
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "coalesce",
+                                    "argv": [
+                                        {
+                                            "fn": "substring",
+                                            "argv": [
+                                                {
+                                                    "ref": "Bucket"
+                                                },
+                                                14,
+                                                16,
+                                                true
+                                            ]
+                                        },
+                                        ""
+                                    ]
+                                },
+                                "--"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "hardwareType"
+                                },
+                                "e"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "hardwareType"
+                                },
+                                "o"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "aws-global"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "coalesce",
+                                    "argv": [
+                                        {
+                                            "fn": "substring",
+                                            "argv": [
+                                                {
+                                                    "ref": "Bucket"
+                                                },
+                                                19,
+                                                21,
+                                                true
+                                            ]
+                                        },
+                                        ""
+                                    ]
+                                },
+                                "--"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "bucketArn"
+                                        },
+                                        "service"
+                                    ]
+                                },
+                                "s3-object-lambda"
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "coalesce",
+                                    "argv": [
+                                        {
+                                            "ref": "DisableAccessPoints"
+                                        },
+                                        false
+                                    ]
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "bucketArn"
+                                        },
+                                        "service"
+                                    ]
+                                },
+                                "s3-outposts"
+                            ]
+                        },
+                        {
+                            "fn": "aws.partition",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "bucketArn"
+                                        },
+                                        "region"
+                                    ]
+                                }
+                            ],
+                            "assign": "bucketPartition"
+                        },
+                        {
+                            "fn": "isValidHostLabel",
+                            "argv": [
+                                {
+                                    "ref": "accessPointName_ssa_1"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "coalesce",
+                                    "argv": [
+                                        {
+                                            "fn": "substring",
+                                            "argv": [
+                                                {
+                                                    "ref": "Bucket"
+                                                },
+                                                26,
+                                                28,
+                                                true
+                                            ]
+                                        },
+                                        ""
+                                    ]
+                                },
+                                "--"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "coalesce",
+                                    "argv": [
+                                        {
+                                            "fn": "substring",
+                                            "argv": [
+                                                {
+                                                    "ref": "Bucket"
+                                                },
+                                                15,
+                                                17,
+                                                true
+                                            ]
+                                        },
+                                        ""
+                                    ]
+                                },
+                                "--"
+                            ]
+                        },
+                        {
+                            "fn": "getAttr",
+                            "argv": [
+                                {
+                                    "ref": "bucketArn"
+                                },
+                                "resourceId[4]"
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "coalesce",
+                                    "argv": [
+                                        {
+                                            "fn": "substring",
+                                            "argv": [
+                                                {
+                                                    "ref": "Bucket"
+                                                },
+                                                20,
+                                                22,
+                                                true
+                                            ]
+                                        },
+                                        ""
+                                    ]
+                                },
+                                "--"
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "UseGlobalEndpoint"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                "us-east-1"
+                            ]
+                        },
+                        {
+                            "fn": "getAttr",
+                            "argv": [
+                                {
+                                    "ref": "bucketArn"
+                                },
+                                "resourceId[1]"
+                            ],
+                            "assign": "outpostId_ssa_1"
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "fn": "coalesce",
+                                    "argv": [
+                                        {
+                                            "ref": "UseArnRegion"
+                                        },
+                                        true
+                                    ]
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "isValidHostLabel",
+                            "argv": [
+                                {
+                                    "ref": "outpostId_ssa_1"
+                                },
+                                false
+                            ]
+                        },
+                        {
+                            "fn": "getAttr",
+                            "argv": [
+                                {
+                                    "ref": "bucketArn"
+                                },
+                                "resourceId[2]"
+                            ],
+                            "assign": "outpostType"
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "Region"
+                                },
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "bucketArn"
+                                        },
+                                        "region"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "bucketPartition"
+                                        },
+                                        "name"
+                                    ]
+                                },
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "partitionResult"
+                                        },
+                                        "name"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "booleanEquals",
+                            "argv": [
+                                {
+                                    "ref": "DisableMultiRegionAccessPoints"
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "isValidHostLabel",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "bucketArn"
+                                        },
+                                        "region"
+                                    ]
+                                },
+                                true
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "bucketArn"
+                                        },
+                                        "partition"
+                                    ]
+                                },
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "partitionResult"
+                                        },
+                                        "name"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "bucketArn"
+                                        },
+                                        "accountId"
+                                    ]
+                                },
+                                ""
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "bucketArn"
+                                        },
+                                        "service"
+                                    ]
+                                },
+                                "s3"
+                            ]
+                        },
+                        {
+                            "fn": "isValidHostLabel",
+                            "argv": [
+                                {
+                                    "fn": "getAttr",
+                                    "argv": [
+                                        {
+                                            "ref": "bucketArn"
+                                        },
+                                        "accountId"
+                                    ]
+                                },
+                                false
+                            ]
+                        },
+                        {
+                            "fn": "getAttr",
+                            "argv": [
+                                {
+                                    "ref": "bucketArn"
+                                },
+                                "resourceId[3]"
+                            ],
+                            "assign": "accessPointName_ssa_2"
+                        },
+                        {
+                            "fn": "isValidHostLabel",
+                            "argv": [
+                                {
+                                    "ref": "accessPointName_ssa_1"
+                                },
+                                false
+                            ]
+                        },
+                        {
+                            "fn": "stringEquals",
+                            "argv": [
+                                {
+                                    "ref": "outpostType"
+                                },
+                                "accesspoint"
+                            ]
+                        },
+                        {
+                            "fn": "isValidHostLabel",
+                            "argv": [
+                                {
+                                    "ref": "accessPointName_ssa_2"
+                                },
+                                false
+                            ]
+                        }
+                    ],
+                    "results": [
+                        {
+                            "conditions": [],
+                            "error": "Accelerate cannot be used with FIPS",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Cannot set dual-stack in combination with a custom endpoint.",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "A custom endpoint cannot be combined with FIPS",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "A custom endpoint cannot be combined with S3 Accelerate",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Partition does not support FIPS",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "S3Express does not support S3 Accelerate.",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "{url#scheme}://{url#authority}/{uri_encoded_bucket}{url#path}",
+                                "properties": {
+                                    "backend": "S3Express",
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "{_s3e_auth}",
+                                            "signingName": "s3express",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "{url#scheme}://{Bucket}.{url#authority}{url#path}",
+                                "properties": {
+                                    "backend": "S3Express",
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "{_s3e_auth}",
+                                            "signingName": "s3express",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "S3Express bucket name is not a valid virtual hostable name.",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3express-control{_s3e_fips}{_s3e_ds}.{Region}.{partitionResult#dnsSuffix}/{uri_encoded_bucket}",
+                                "properties": {
+                                    "backend": "S3Express",
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3express",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.s3express{_s3e_fips}-{s3expressAvailabilityZoneId}{_s3e_ds}.{Region}.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "backend": "S3Express",
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "{_s3e_auth}",
+                                            "signingName": "s3express",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Unrecognized S3Express bucket name format.",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "{url#scheme}://{url#authority}{url#path}",
+                                "properties": {
+                                    "backend": "S3Express",
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "{_s3e_auth}",
+                                            "signingName": "s3express",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3express-control{_s3e_fips}{_s3e_ds}.{Region}.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "backend": "S3Express",
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3express",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Expected a endpoint to be specified but no endpoint was found",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.ec2.{url#authority}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4a",
+                                            "signingName": "s3-outposts",
+                                            "signingRegionSet": [
+                                                "*"
+                                            ]
+                                        },
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3-outposts",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.ec2.s3-outposts.{Region}.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4a",
+                                            "signingName": "s3-outposts",
+                                            "signingRegionSet": [
+                                                "*"
+                                            ]
+                                        },
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3-outposts",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.op-{outpostId_ssa_2}.{url#authority}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4a",
+                                            "signingName": "s3-outposts",
+                                            "signingRegionSet": [
+                                                "*"
+                                            ]
+                                        },
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3-outposts",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.op-{outpostId_ssa_2}.s3-outposts.{Region}.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4a",
+                                            "signingName": "s3-outposts",
+                                            "signingRegionSet": [
+                                                "*"
+                                            ]
+                                        },
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3-outposts",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Unrecognized hardware type: \"Expected hardware type o or e but got {hardwareType}\"",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Outposts Bucket alias - it must be a valid bucket name.",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid ARN: The outpost Id must only contain a-z, A-Z, 0-9 and `-`.",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Custom endpoint `{Endpoint}` was not a valid URI",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "S3 Accelerate cannot be used in this region",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.s3-fips.dualstack.us-east-1.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.s3-fips.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.s3-fips.us-east-1.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.s3-fips.{Region}.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.s3-accelerate.dualstack.us-east-1.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.s3-accelerate.dualstack.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.s3.dualstack.us-east-1.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.s3.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "{url#scheme}://{url#authority}{url#normalizedPath}{Bucket}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "{url#scheme}://{Bucket}.{url#authority}{url#path}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "{url#scheme}://{url#authority}{url#normalizedPath}{Bucket}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "{url#scheme}://{Bucket}.{url#authority}{url#path}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.s3-accelerate.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.s3-accelerate.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.s3.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.s3.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{Bucket}.s3.{Region}.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid region: region was not a valid DNS name.",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "S3 Object Lambda does not support Dual-stack",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "S3 Object Lambda does not support S3 Accelerate",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Access points are not supported for this operation",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid configuration: region from ARN `{bucketArn#region}` does not match client region `{Region}` and UseArnRegion is `false`",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid ARN: Missing account id",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "{url#scheme}://{accessPointName_ssa_1}-{bucketArn#accountId}.{url#authority}{url#path}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3-object-lambda",
+                                            "signingRegion": "{bucketArn#region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{accessPointName_ssa_1}-{bucketArn#accountId}.s3-object-lambda-fips.{bucketArn#region}.{bucketPartition#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3-object-lambda",
+                                            "signingRegion": "{bucketArn#region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{accessPointName_ssa_1}-{bucketArn#accountId}.s3-object-lambda.{bucketArn#region}.{bucketPartition#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3-object-lambda",
+                                            "signingRegion": "{bucketArn#region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid ARN: The access point name may only contain a-z, A-Z, 0-9 and `-`. Found: `{accessPointName_ssa_1}`",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid ARN: The account id may only contain a-z, A-Z, 0-9 and `-`. Found: `{bucketArn#accountId}`",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid region in ARN: `{bucketArn#region}` (invalid DNS name)",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Client was configured for partition `{partitionResult#name}` but ARN (`{Bucket}`) has `{bucketPartition#name}`",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid ARN: The ARN may only contain a single resource component after `accesspoint`.",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid ARN: bucket ARN is missing a region",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid ARN: Expected a resource of the format `accesspoint:<accesspoint name>` but no name was provided",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid ARN: Object Lambda ARNs only support `accesspoint` arn types, but found: `{arnType}`",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Access Points do not support S3 Accelerate",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{accessPointName_ssa_1}-{bucketArn#accountId}.s3-accesspoint-fips.dualstack.{bucketArn#region}.{bucketPartition#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{bucketArn#region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{accessPointName_ssa_1}-{bucketArn#accountId}.s3-accesspoint-fips.{bucketArn#region}.{bucketPartition#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{bucketArn#region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{accessPointName_ssa_1}-{bucketArn#accountId}.s3-accesspoint.dualstack.{bucketArn#region}.{bucketPartition#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{bucketArn#region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "{url#scheme}://{accessPointName_ssa_1}-{bucketArn#accountId}.{url#authority}{url#path}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{bucketArn#region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{accessPointName_ssa_1}-{bucketArn#accountId}.s3-accesspoint.{bucketArn#region}.{bucketPartition#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{bucketArn#region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid ARN: The ARN was not for the S3 service, found: {bucketArn#service}",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "S3 MRAP does not support dual-stack",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "S3 MRAP does not support FIPS",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "S3 MRAP does not support S3 Accelerate",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid configuration: Multi-Region Access Point ARNs are disabled.",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{accessPointName_ssa_1}.accesspoint.s3-global.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4a",
+                                            "signingName": "s3",
+                                            "signingRegionSet": [
+                                                "*"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Client was configured for partition `{partitionResult#name}` but bucket referred to partition `{bucketArn#partition}`",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Access Point Name",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "S3 Outposts does not support Dual-stack",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "S3 Outposts does not support FIPS",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "S3 Outposts does not support S3 Accelerate",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid Arn: Outpost Access Point ARN contains sub resources",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{accessPointName_ssa_2}-{bucketArn#accountId}.{outpostId_ssa_1}.{url#authority}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4a",
+                                            "signingName": "s3-outposts",
+                                            "signingRegionSet": [
+                                                "*"
+                                            ]
+                                        },
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3-outposts",
+                                            "signingRegion": "{bucketArn#region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://{accessPointName_ssa_2}-{bucketArn#accountId}.{outpostId_ssa_1}.s3-outposts.{bucketArn#region}.{bucketPartition#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4a",
+                                            "signingName": "s3-outposts",
+                                            "signingRegionSet": [
+                                                "*"
+                                            ]
+                                        },
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3-outposts",
+                                            "signingRegion": "{bucketArn#region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid ARN: The access point name may only contain a-z, A-Z, 0-9 and `-`. Found: `{accessPointName_ssa_2}`",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Expected an outpost type `accesspoint`, found {outpostType}",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid ARN: expected an access point name",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid ARN: Expected a 4-component resource",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid ARN: The outpost Id may only contain a-z, A-Z, 0-9 and `-`. Found: `{outpostId_ssa_1}`",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid ARN: The Outpost Id was not set",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid ARN: Unrecognized format: {Bucket} (type: {arnType})",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid ARN: No ARN type specified",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Invalid ARN: `{Bucket}` was not a valid ARN",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Path-style addressing cannot be used with ARN buckets",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3-fips.dualstack.us-east-1.{partitionResult#dnsSuffix}/{uri_encoded_bucket}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3-fips.dualstack.{Region}.{partitionResult#dnsSuffix}/{uri_encoded_bucket}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3-fips.us-east-1.{partitionResult#dnsSuffix}/{uri_encoded_bucket}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3-fips.{Region}.{partitionResult#dnsSuffix}/{uri_encoded_bucket}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3.dualstack.us-east-1.{partitionResult#dnsSuffix}/{uri_encoded_bucket}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3.dualstack.{Region}.{partitionResult#dnsSuffix}/{uri_encoded_bucket}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "{url#scheme}://{url#authority}{url#normalizedPath}{uri_encoded_bucket}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "{url#scheme}://{url#authority}{url#normalizedPath}{uri_encoded_bucket}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3.{partitionResult#dnsSuffix}/{uri_encoded_bucket}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3.{partitionResult#dnsSuffix}/{uri_encoded_bucket}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3.{Region}.{partitionResult#dnsSuffix}/{uri_encoded_bucket}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "Path-style addressing cannot be used with S3 Accelerate",
+                            "type": "error"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "{url#scheme}://{url#authority}{url#path}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3-object-lambda",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3-object-lambda-fips.{Region}.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3-object-lambda",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3-object-lambda.{Region}.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3-object-lambda",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3-fips.dualstack.us-east-1.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3-fips.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3-fips.us-east-1.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3-fips.{Region}.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3.dualstack.us-east-1.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "{url#scheme}://{url#authority}{url#path}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "{url#scheme}://{url#authority}{url#path}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "us-east-1"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "endpoint": {
+                                "url": "https://s3.{Region}.{partitionResult#dnsSuffix}",
+                                "properties": {
+                                    "authSchemes": [
+                                        {
+                                            "disableDoubleEncoding": true,
+                                            "name": "sigv4",
+                                            "signingName": "s3",
+                                            "signingRegion": "{Region}"
+                                        }
+                                    ]
+                                },
+                                "headers": {}
+                            },
+                            "type": "endpoint"
+                        },
+                        {
+                            "conditions": [],
+                            "error": "A region must be set when sending requests to S3.",
+                            "type": "error"
+                        }
+                    ],
+                    "root": 2,
+                    "nodeCount": 553,
+                    "nodes": "/////wAAAAH/////AAAAAAAAAAMF9eFzAAAAAQAAAagAAAAEAAAAAgAAARAAAAAFAAAAAwAAAOkAAAAGAAAABAAAAFUAAAAHAAAABQAAAA8AAAAIAAAACAAAAAkF9eFzAAAAEAAAAAoAAAANAAAAEgAAAAsAAAANAAAAEwAAAAwAAAANAAAAFgX14Q4AAAANAAAAIwAAAA4F9eEqAAAAJAX14WcAAAGzAAAABgAAAQ8AAAAQAAAABwAAAQ4AAAARAAAACAAAABMAAAASAAAADgAAAfUAAABqAAAACQAAABQAAAAYAAAACgAAABUAAAAYAAAACwAAABYAAAAYAAAADAAAABcAAAAYAAAADQAAAiMAAAAYAAAADgAAAE0AAAAZAAAAFAAAAEkAAAAaAAAAGgAAABsAAABOAAAAJQAAABwF9eFWAAAAJgX14VYAAAAdAAAAJwAAAC8AAAAeAAAAMAX14ToAAAAfAAAAMgAAACAF9eFVAAAAMwAAACEAAACIAAAANwX14UwAAAAiAAAAOwAAACMF9eFUAAAAPAAAACcAAAAkAAAAPQAAACUF9eFTAAAAPgAAACYAAACSAAAAPwAAACkF9eEuAAAAPQAAACgF9eFTAAAAPgAAACkAAACWAAAAQAAAACoF9eE2AAAAQgAAACsF9eE1AAAARgAAACwF9eE0AAAARwAAAC0F9eFRAAAASQAAAC4F9eFQAAAASgX14U4F9eFPAAAAKAAAADAF9eE5AAAAKQX14TkAAAAxAAAAKgAAALkAAAAyAAAAMAAAAD4AAAAzAAAAMQX14S0AAAA0AAAAMwAAADUAAAIOAAAAPAAAADgAAAA2AAAAPgX14TcAAAA3AAAAPwAAADkF9eEuAAAAPgX14TcAAAA5AAAAQAAAADoF9eE2AAAAQgAAADsF9eE1AAAARQAAADwF9eFBAAAARgAAAD0F9eE0AAAASAX14UAF9eEzAAAAMQX14S0AAAA/AAAAMwAAAEAAAAIOAAAAPAAAAEMAAABBAAAAPgX14TcAAABCAAAAPwAAAEQF9eEuAAAAPgX14TcAAABEAAAAQAAAAEUF9eE2AAAAQgAAAEYF9eE1AAAARAX14S8AAABHAAAARgAAAEgF9eE0AAAASAX14TIF9eEzAAAAGQAAAEoF9eEqAAAALgX14ScAAABLAAAAOQAAAEwF9eEpAAAAOgX14SgF9eEpAAAAGgX14VgAAABOAAAAHAX14VcAAABPAAAAIgAAAFIAAABQAAAAIwAAAFEAAAIhAAAAJAX14WcF9eFzAAAALgX14WEAAABTAAAAOQAAAFQF9eFjAAAAOgX14WIF9eFjAAAABQAAAGUAAABWAAAACAAAAFcF9eFzAAAAEAAAAFgAAABZAAAAEgAAAFsAAABZAAAAEwAAAFoAAABcAAAAFQAAAGEAAABfAAAAEwAAAF0AAABcAAAAFQAAAGIAAABfAAAAFQAAAGEAAABeAAAAFgX14Q4AAABfAAAAIwAAAGAF9eEqAAAAJAX14WcF9eEqAAAAFgX14Q0AAABiAAAAIwAAAGMF9eEqAAAAJAX14WUAAABkAAAALgX14W4F9eFvAAAABgAAANYAAABmAAAABwAAANAAAABnAAAACAAAAHcAAABoAAAADgAAAHYAAABpAAAAFQAAAGoF9eEXAAAAGgAAAGsAAAH2AAAAJQAAAGwF9eFWAAAAJgX14VYAAABtAAAAJwAAAHAAAABuAAAAMAX14ToAAABvAAAAMgAAAIgF9eFVAAAAKAAAAHEF9eE5AAAAKQX14TkAAAByAAAAKgAAAHMAAAH0AAAAMAX14TgAAAB0AAAANAAAAHUF9eFIAAAAQQX14UUF9eFIAAAAFQAAAfUF9eEXAAAACQAAAHgAAAB8AAAACgAAAHkAAAB8AAAACwAAAHoAAAB8AAAADAAAAHsAAAB8AAAADQAAAMoAAAB8AAAADgAAAMMAAAB9AAAAFAAAAL4AAAB+AAAAFQAAAH8F9eEXAAAAFwAAAIAAAACBAAAAGAAAAL0AAACBAAAAGgAAAIIAAADFAAAAJQAAAIMF9eFWAAAAJgX14VYAAACEAAAAJwAAAJ8AAACFAAAAMAX14ToAAACGAAAAMgAAAIcF9eFVAAAAMwAAAI0AAACIAAAANwX14UwAAACJAAAAOwAAAIoF9eFUAAAAPAX14VMAAACLAAAAPQAAAIwF9eFTAAAAPwX14VMF9eEuAAAANwX14UwAAACOAAAAOwAAAI8F9eFUAAAAPAAAAJQAAACQAAAAPQAAAJEF9eFTAAAAPgAAAJMAAACSAAAAPwAAAJYF9eEuAAAAPwAAAJkF9eEuAAAAPQAAAJUF9eFTAAAAPgAAAJkAAACWAAAAQAAAAJcF9eE2AAAAQgAAAJgF9eE1AAAARgX14VIF9eE0AAAAQAAAAJoF9eE2AAAAQgAAAJsF9eE1AAAARgAAAJwF9eE0AAAARwAAAJ0F9eFRAAAASQAAAJ4F9eFQAAAASgX14U0F9eFPAAAAKAAAAKAF9eE5AAAAKQX14TkAAAChAAAAKgAAALkAAACiAAAAMAAAAK4AAACjAAAAMQX14S0AAACkAAAAMwAAAKUAAAIOAAAAPAAAAKgAAACmAAAAPgX14TcAAACnAAAAPwAAAKkF9eEuAAAAPgX14TcAAACpAAAAQAAAAKoF9eE2AAAAQgAAAKsF9eE1AAAARQAAAKwF9eFBAAAARgAAAK0F9eE0AAAASAX14T8F9eEzAAAAMQX14S0AAACvAAAAMwAAALAAAAIOAAAAPAAAALMAAACxAAAAPgX14TcAAACyAAAAPwAAALQF9eEuAAAAPgX14TcAAAC0AAAAQAAAALUF9eE2AAAAQgAAALYF9eE1AAAARAX14S8AAAC3AAAARgAAALgF9eE0AAAASAX14TAF9eEzAAAAMAX14TgAAAC6AAAANAAAALsF9eFIAAAAQQX14UUAAAC8AAAAQwX14UYF9eFHAAAAGQX14SQF9eEqAAAAFQAAAL8F9eEXAAAAGQAAAMAF9eEqAAAAHgAAAMIAAADBAAAALgX14SIF9eEkAAAALgX14SEF9eEjAAAAFQAAAMQF9eEXAAAAGgX14VgAAADFAAAAHAX14VcAAADGAAAAIgAAAMkAAADHAAAAIwAAAMgAAAIhAAAAJAX14WUF9eFzAAAALgX14V8F9eFgAAAAEQAAAMsF9eEWAAAAFAAAAMwF9eEVAAAAFQAAAM0AAAImAAAAIQAAAM4AAAImAAAALAX14RAAAADPAAAALQX14RIF9eEUAAAACAAAANEAAADXAAAAEAAAANIAAADcAAAAEgAAANMAAADcAAAAEwAAANQAAADgAAAAFAAAANUAAADjAAAAFQAAAOcAAAGRAAAACAAAANoAAADXAAAAEwAAANgF9eEJAAAAFAAAANkAAADjAAAAFQAAAOcF9eEJAAAAEAAAANsAAADcAAAAEgAAAN8AAADcAAAAEwAAAN0AAADgAAAAFAAAAN4AAADjAAAAFQAAAOcF9eEMAAAAEwAAAOIAAADgAAAAFAAAAOEF9eEJAAAAFQX14QkF9eEMAAAAFAAAAOYAAADjAAAAFQAAAOQF9eEJAAAAHgAAAOUF9eEJAAAAIgX14QcF9eEJAAAAFQAAAOcAAAGfAAAAHgAAAOgF9eEIAAAAIgX14QcF9eEIAAAABAX14QIAAADqAAAABQAAAOsAAAHgAAAABgAAAQ8AAADsAAAABwAAAQ4AAADtAAAACAAAAO4AAAHrAAAACQAAAO8AAADzAAAACgAAAPAAAADzAAAACwAAAPEAAADzAAAADAAAAPIAAADzAAAADQAAAiMAAADzAAAADgAAAQoAAAD0AAAAFAAAAQgAAAD1AAAAGgAAAPYAAAELAAAAJQAAAPcF9eFWAAAAJgX14VYAAAD4AAAAJwAAAPkAAAIGAAAAKAAAAPoF9eE5AAAAKQX14TkAAAD7AAAAKgAAAhoAAAD8AAAAMAX14SsAAAD9AAAAMQX14S0AAAD+AAAAMwAAAP8AAAIOAAAAPAAAAQIAAAEAAAAAPgX14TcAAAEBAAAAPwAAAQMF9eEuAAAAPgX14TcAAAEDAAAAQAAAAQQF9eE2AAAAQgAAAQUF9eE1AAAARQAAAQYF9eFBAAAARgAAAQcF9eE0AAAASAX14T4F9eEzAAAAGQAAAQkF9eEqAAAALgX14R8F9eEgAAAAGgX14VgAAAELAAAAHAX14VcAAAEMAAAAIgAAAQ0AAAIgAAAALgX14V0F9eFeAAAACAAAAY0F9eEJAAAACAAAAZcF9eEJAAAAAwAAAVoAAAERAAAABAX14QMAAAESAAAABQAAARwAAAETAAAACAAAARQF9eFzAAAADwX14QUAAAEVAAAAEAAAARYAAAEZAAAAEgAAARcAAAEZAAAAEwAAARgAAAEZAAAAFgX14Q4AAAEZAAAAIwAAARoF9eEqAAAAJAX14WYAAAEbAAAALgX14WoF9eFrAAAABgAAAZUAAAEdAAAABwAAAYsAAAEeAAAACAAAAScAAAEfAAAADgAAAfUAAAEgAAAAGgAAASEAAAH2AAAAJQAAASIF9eFWAAAAJgX14VYAAAEjAAAAJwAAASQAAAEzAAAAKAAAASUF9eE5AAAAKQX14TkAAAEmAAAAKgAAAU8AAAH0AAAACQAAASgAAAEsAAAACgAAASkAAAEsAAAACwAAASoAAAEsAAAADAAAASsAAAEsAAAADQAAAYoAAAEsAAAADgAAAVMAAAEtAAAADwX14QUAAAEuAAAAFAAAAVEAAAEvAAAAGgAAATAAAAFVAAAAJQAAATEF9eFWAAAAJgX14VYAAAEyAAAAJwAAATUAAAEzAAAAMAX14ToAAAE0AAAAMgX14UoF9eFVAAAAKAAAATYF9eE5AAAAKQX14TkAAAE3AAAAKgAAAU8AAAE4AAAAMAAAAUQAAAE5AAAAMQX14S0AAAE6AAAAMwAAATsAAAIOAAAAPAAAAT4AAAE8AAAAPgX14TcAAAE9AAAAPwAAAT8F9eEuAAAAPgX14TcAAAE/AAAAQAAAAUAF9eE2AAAAQgAAAUEF9eE1AAAARQAAAUIF9eFBAAAARgAAAUMF9eE0AAAASAX14T0F9eEzAAAAMQX14S0AAAFFAAAAMwAAAUYAAAIOAAAAPAAAAUkAAAFHAAAAPgX14TcAAAFIAAAAPwAAAUoF9eEuAAAAPgX14TcAAAFKAAAAQAAAAUsF9eE2AAAAQgAAAUwF9eE1AAAARAX14S8AAAFNAAAARgAAAU4F9eE0AAAASAX14TEF9eEzAAAAMAX14TgAAAFQAAAANAX14UMF9eFIAAAAGQAAAVIF9eEqAAAALgX14RsF9eEcAAAADwX14QUAAAFUAAAAGgX14VgAAAFVAAAAHAX14VcAAAFWAAAAIgAAAVkAAAFXAAAAIwAAAVgAAAIhAAAAJAX14WYF9eFzAAAALgX14VsF9eFcAAAABAX14QIAAAFbAAAABQAAAWUAAAFcAAAACAAAAV0F9eFzAAAADwX14QUAAAFeAAAAEAAAAV8AAAFiAAAAEgAAAWAAAAFiAAAAEwAAAWEAAAFiAAAAFgX14Q4AAAFiAAAAIwAAAWMF9eEqAAAAJAX14SsAAAFkAAAALgX14WgF9eFpAAAABgAAAZUAAAFmAAAABwAAAYsAAAFnAAAACAAAAWgAAAHrAAAACQAAAWkAAAFtAAAACgAAAWoAAAFtAAAACwAAAWsAAAFtAAAADAAAAWwAAAFtAAAADQAAAYoAAAFtAAAADgAAAYUAAAFuAAAADwX14QUAAAFvAAAAFAAAAYMAAAFwAAAAGgAAAXEAAAGHAAAAJQAAAXIF9eFWAAAAJgX14VYAAAFzAAAAJwAAAXQAAAIGAAAAKAAAAXUF9eE5AAAAKQX14TkAAAF2AAAAKgAAAhoAAAF3AAAAMAX14SsAAAF4AAAAMQX14S0AAAF5AAAAMwAAAXoAAAIOAAAAPAAAAX0AAAF7AAAAPgX14TcAAAF8AAAAPwAAAX4F9eEuAAAAPgX14TcAAAF+AAAAQAAAAX8F9eE2AAAAQgAAAYAF9eE1AAAARQAAAYEF9eFBAAAARgAAAYIF9eE0AAAASAX14TwF9eEzAAAAGQAAAYQF9eEqAAAALgX14RkF9eEaAAAADwX14QUAAAGGAAAAGgX14VgAAAGHAAAAHAX14VcAAAGIAAAAIgAAAYkAAAIgAAAALgX14VkF9eFaAAAADwX14QUAAAIjAAAACAAAAYwF9eEJAAAADwX14QUAAAGNAAAAEAAAAY4AAAGaAAAAEgAAAY8AAAGaAAAAEwAAAZAAAAGaAAAAFAAAAZEF9eEJAAAAGwAAAZIF9eEMAAAAHQX14QsAAAGTAAAAHwX14QsAAAGUAAAAIAX14QsAAAGmAAAACAAAAZYF9eEJAAAADwX14QUAAAGXAAAAEAAAAZgAAAGaAAAAEgAAAZkAAAGaAAAAEwAAAZsAAAGaAAAAFAX14QwF9eEJAAAAFAAAAZ4AAAGcAAAAFgAAAZ0F9eEJAAAAIgX14QoF9eEJAAAAFgAAAaAAAAGfAAAAGwAAAaMF9eEMAAAAGwAAAaIAAAGhAAAAIgX14QoF9eEMAAAAIgX14QoAAAGjAAAAKwX14QsAAAGkAAAALwX14QsAAAGlAAAANQX14QsAAAGmAAAANgX14QsAAAGnAAAAOAX14QsF9eEMAAAAAgX14QEAAAGpAAAAAwAAAd4AAAGqAAAABAX14QQAAAGrAAAABQAAAbYAAAGsAAAACAAAAa0F9eFzAAAAEAAAAa4AAAGxAAAAEgAAAa8AAAGxAAAAEwAAAbAAAAGxAAAAFgX14Q4AAAGxAAAAIwAAAbIF9eEqAAAAJAX14SwAAAGzAAAALgX14XAAAAG0AAAAOQAAAbUF9eFyAAAAOgX14XEF9eFyAAAABgX14QYAAAG3AAAABwX14QYAAAG4AAAACAAAAcIAAAG5AAAADgAAAfUAAAG6AAAAGgAAAbsAAAH2AAAAJQAAAbwF9eFWAAAAJgX14VYAAAG9AAAAJwAAAb4AAAHRAAAAKAAAAb8F9eE5AAAAKQX14TkAAAHAAAAAKgAAAdcAAAHBAAAAMAX14SwAAAH0AAAACQAAAcMAAAHHAAAACgAAAcQAAAHHAAAACwAAAcUAAAHHAAAADAAAAcYAAAHHAAAADQAAAiMAAAHHAAAADgAAAdkAAAHIAAAADwAAAcwAAAHJAAAAFAAAAcoAAAHNAAAAGQAAAcsF9eEqAAAALgX14SUF9eEmAAAAFAAAAhwAAAHNAAAAGgAAAc4AAAHaAAAAJQAAAc8F9eFWAAAAJgX14VYAAAHQAAAAJwAAAdMAAAHRAAAAMAX14ToAAAHSAAAAMgX14UsF9eFVAAAAKAAAAdQF9eE5AAAAKQX14TkAAAHVAAAAKgAAAdcAAAHWAAAAMAX14SwAAAIMAAAAMAX14SwAAAHYAAAANAX14UQF9eFIAAAAGgX14VgAAAHaAAAAHAX14VcAAAHbAAAAIgX14WQAAAHcAAAAIwAAAd0AAAIhAAAAJAX14SwF9eFzAAAABAX14QIAAAHfAAAABQAAAegAAAHgAAAACAAAAeEF9eFzAAAAEAAAAeIAAAHlAAAAEgAAAeMAAAHlAAAAEwAAAeQAAAHlAAAAFgX14Q4AAAHlAAAAIwAAAeYF9eEqAAAAJAX14SsAAAHnAAAALgX14WwF9eFtAAAABgX14QYAAAHpAAAABwX14QYAAAHqAAAACAAAAfcAAAHrAAAADgAAAfUAAAHsAAAAGgAAAe0AAAH2AAAAJQAAAe4F9eFWAAAAJgX14VYAAAHvAAAAJwAAAfAAAAIGAAAAKAAAAfEF9eE5AAAAKQX14TkAAAHyAAAAKgAAAhoAAAHzAAAAMAX14SsAAAH0AAAAMQX14S0AAAIOAAAAGgX14VgAAAH2AAAAHAX14VcF9eFzAAAACQAAAfgAAAH8AAAACgAAAfkAAAH8AAAACwAAAfoAAAH8AAAADAAAAfsAAAH8AAAADQAAAiMAAAH8AAAADgAAAh0AAAH9AAAADwAAAgEAAAH+AAAAFAAAAf8AAAICAAAAGQAAAgAF9eEqAAAALgX14R0F9eEeAAAAFAAAAhwAAAICAAAAGgAAAgMAAAIeAAAAJQAAAgQF9eFWAAAAJgX14VYAAAIFAAAAJwAAAggAAAIGAAAAMAX14ToAAAIHAAAAMgX14UkF9eFVAAAAKAAAAgkF9eE5AAAAKQX14TkAAAIKAAAAKgAAAhoAAAILAAAAMAX14SsAAAIMAAAAMQX14S0AAAINAAAAMwAAAhEAAAIOAAAAPAX14TcAAAIPAAAAPgX14TcAAAIQAAAAPwX14TcF9eEuAAAAPAAAAhQAAAISAAAAPgX14TcAAAITAAAAPwAAAhUF9eEuAAAAPgX14TcAAAIVAAAAQAAAAhYF9eE2AAAAQgAAAhcF9eE1AAAARQAAAhgF9eFBAAAARgAAAhkF9eE0AAAASAX14TsF9eEzAAAAMAX14SsAAAIbAAAANAX14UIF9eFIAAAAGQX14RgF9eEqAAAAGgX14VgAAAIeAAAAHAX14VcAAAIfAAAAIgX14WQAAAIgAAAAIwAAAiIAAAIhAAAAJAX14SoF9eFzAAAAJAX14SsF9eFzAAAAEQAAAiQF9eEWAAAAFAAAAiUF9eEVAAAAIQAAAigAAAImAAAALAX14REAAAInAAAALQX14RMF9eEUAAAALAX14Q8AAAIpAAAALQX14Q8F9eEU"
+                },
+                "smithy.rules#endpointRuleSet": {
+                    "version": "1.0",
+                    "parameters": {
+                        "Bucket": {
+                            "required": false,
+                            "documentation": "The S3 bucket used to send the request. This is an optional parameter that will be set automatically for operations that are scoped to an S3 bucket.",
+                            "type": "string"
+                        },
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "string"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "boolean"
+                        },
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "string"
+                        },
+                        "ForcePathStyle": {
+                            "builtIn": "AWS::S3::ForcePathStyle",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, force a path-style endpoint to be used where the bucket name is part of the path.",
+                            "type": "boolean"
+                        },
+                        "Accelerate": {
+                            "builtIn": "AWS::S3::Accelerate",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use S3 Accelerate. NOTE: Not all regions support S3 accelerate.",
+                            "type": "boolean"
+                        },
+                        "UseGlobalEndpoint": {
+                            "builtIn": "AWS::S3::UseGlobalEndpoint",
+                            "required": true,
+                            "default": false,
+                            "documentation": "Whether the global endpoint should be used, rather then the regional endpoint for us-east-1.",
+                            "type": "boolean"
+                        },
+                        "UseObjectLambdaEndpoint": {
+                            "required": false,
+                            "documentation": "Internal parameter to use object lambda endpoint for an operation (eg: WriteGetObjectResponse)",
+                            "type": "boolean"
+                        },
+                        "Key": {
+                            "required": false,
+                            "documentation": "The S3 Key used to send the request. This is an optional parameter that will be set automatically for operations that are scoped to an S3 Key.",
+                            "type": "string"
+                        },
+                        "Prefix": {
+                            "required": false,
+                            "documentation": "The S3 Prefix used to send the request. This is an optional parameter that will be set automatically for operations that are scoped to an S3 Prefix.",
+                            "type": "string"
+                        },
+                        "CopySource": {
+                            "required": false,
+                            "documentation": "The Copy Source used for Copy Object request. This is an optional parameter that will be set automatically for operations that are scoped to Copy Source.",
+                            "type": "string"
+                        },
+                        "DisableAccessPoints": {
+                            "required": false,
+                            "documentation": "Internal parameter to disable Access Point Buckets",
+                            "type": "boolean"
+                        },
+                        "DisableMultiRegionAccessPoints": {
+                            "builtIn": "AWS::S3::DisableMultiRegionAccessPoints",
+                            "required": true,
+                            "default": false,
+                            "documentation": "Whether multi-region access points (MRAP) should be disabled.",
+                            "type": "boolean"
+                        },
+                        "UseArnRegion": {
+                            "builtIn": "AWS::S3::UseArnRegion",
+                            "required": false,
+                            "documentation": "When an Access Point ARN is provided and this flag is enabled, the SDK MUST use the ARN's region when constructing the endpoint instead of the client's configured region.",
+                            "type": "boolean"
+                        },
+                        "UseS3ExpressControlEndpoint": {
+                            "required": false,
+                            "documentation": "Internal parameter to indicate whether S3Express operation should use control plane, (ex. CreateBucket)",
+                            "type": "boolean"
+                        },
+                        "DisableS3ExpressSessionAuth": {
+                            "required": false,
+                            "documentation": "Parameter to indicate whether S3Express session auth should be disabled",
+                            "type": "boolean"
                         }
                     },
                     "rules": [
@@ -875,21 +3468,6 @@
                                         }
                                     ],
                                     "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseDualStack"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "error": "S3Express does not support Dual-stack.",
-                                            "type": "error"
-                                        },
                                         {
                                             "conditions": [
                                                 {
@@ -1171,76 +3749,196 @@
                                                 {
                                                     "conditions": [
                                                         {
-                                                            "fn": "uriEncode",
+                                                            "fn": "aws.partition",
                                                             "argv": [
                                                                 {
-                                                                    "ref": "Bucket"
+                                                                    "ref": "Region"
                                                                 }
                                                             ],
-                                                            "assign": "uri_encoded_bucket"
-                                                        },
-                                                        {
-                                                            "fn": "not",
-                                                            "argv": [
-                                                                {
-                                                                    "fn": "isSet",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "Endpoint"
-                                                                        }
-                                                                    ]
-                                                                }
-                                                            ]
+                                                            "assign": "partitionResult"
                                                         }
                                                     ],
                                                     "rules": [
                                                         {
                                                             "conditions": [
                                                                 {
-                                                                    "fn": "booleanEquals",
+                                                                    "fn": "uriEncode",
                                                                     "argv": [
                                                                         {
-                                                                            "ref": "UseFIPS"
-                                                                        },
-                                                                        true
+                                                                            "ref": "Bucket"
+                                                                        }
+                                                                    ],
+                                                                    "assign": "uri_encoded_bucket"
+                                                                },
+                                                                {
+                                                                    "fn": "not",
+                                                                    "argv": [
+                                                                        {
+                                                                            "fn": "isSet",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Endpoint"
+                                                                                }
+                                                                            ]
+                                                                        }
                                                                     ]
                                                                 }
                                                             ],
-                                                            "endpoint": {
-                                                                "url": "https://s3express-control-fips.{Region}.amazonaws.com/{uri_encoded_bucket}",
-                                                                "properties": {
-                                                                    "backend": "S3Express",
-                                                                    "authSchemes": [
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
                                                                         {
-                                                                            "disableDoubleEncoding": true,
-                                                                            "name": "sigv4",
-                                                                            "signingName": "s3express",
-                                                                            "signingRegion": "{Region}"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        },
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://s3express-control.{Region}.amazonaws.com/{uri_encoded_bucket}",
-                                                                "properties": {
-                                                                    "backend": "S3Express",
-                                                                    "authSchemes": [
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        },
                                                                         {
-                                                                            "disableDoubleEncoding": true,
-                                                                            "name": "sigv4",
-                                                                            "signingName": "s3express",
-                                                                            "signingRegion": "{Region}"
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
                                                                         }
-                                                                    ]
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://s3express-control-fips.dualstack.{Region}.{partitionResult#dnsSuffix}/{uri_encoded_bucket}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
                                                                 },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://s3express-control-fips.{Region}.{partitionResult#dnsSuffix}/{uri_encoded_bucket}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://s3express-control.dualstack.{Region}.{partitionResult#dnsSuffix}/{uri_encoded_bucket}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://s3express-control.{Region}.{partitionResult#dnsSuffix}/{uri_encoded_bucket}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
                                                         }
                                                     ],
                                                     "type": "tree"
@@ -1264,24 +3962,1005 @@
                                                 {
                                                     "conditions": [
                                                         {
-                                                            "fn": "isSet",
+                                                            "fn": "aws.partition",
                                                             "argv": [
                                                                 {
-                                                                    "ref": "DisableS3ExpressSessionAuth"
+                                                                    "ref": "Region"
                                                                 }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "DisableS3ExpressSessionAuth"
-                                                                },
-                                                                true
-                                                            ]
+                                                            ],
+                                                            "assign": "partitionResult"
                                                         }
                                                     ],
                                                     "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "isSet",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "DisableS3ExpressSessionAuth"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "DisableS3ExpressSessionAuth"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                6,
+                                                                                14,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneId"
+                                                                        },
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                14,
+                                                                                16,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneDelim"
+                                                                        },
+                                                                        {
+                                                                            "fn": "stringEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "s3expressAvailabilityZoneDelim"
+                                                                                },
+                                                                                "--"
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                6,
+                                                                                15,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneId"
+                                                                        },
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                15,
+                                                                                17,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneDelim"
+                                                                        },
+                                                                        {
+                                                                            "fn": "stringEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "s3expressAvailabilityZoneDelim"
+                                                                                },
+                                                                                "--"
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                6,
+                                                                                19,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneId"
+                                                                        },
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                19,
+                                                                                21,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneDelim"
+                                                                        },
+                                                                        {
+                                                                            "fn": "stringEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "s3expressAvailabilityZoneDelim"
+                                                                                },
+                                                                                "--"
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                6,
+                                                                                20,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneId"
+                                                                        },
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                20,
+                                                                                22,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneDelim"
+                                                                        },
+                                                                        {
+                                                                            "fn": "stringEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "s3expressAvailabilityZoneDelim"
+                                                                                },
+                                                                                "--"
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                6,
+                                                                                26,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneId"
+                                                                        },
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                26,
+                                                                                28,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneDelim"
+                                                                        },
+                                                                        {
+                                                                            "fn": "stringEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "s3expressAvailabilityZoneDelim"
+                                                                                },
+                                                                                "--"
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "Unrecognized S3Express bucket name format.",
+                                                                    "type": "error"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
                                                         {
                                                             "conditions": [
                                                                 {
@@ -1329,16 +5008,25 @@
                                                                                 },
                                                                                 true
                                                                             ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
                                                                         }
                                                                     ],
                                                                     "endpoint": {
-                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
                                                                         "properties": {
                                                                             "backend": "S3Express",
                                                                             "authSchemes": [
                                                                                 {
                                                                                     "disableDoubleEncoding": true,
-                                                                                    "name": "sigv4",
+                                                                                    "name": "sigv4-s3express",
                                                                                     "signingName": "s3express",
                                                                                     "signingRegion": "{Region}"
                                                                                 }
@@ -1349,15 +5037,110 @@
                                                                     "type": "endpoint"
                                                                 },
                                                                 {
-                                                                    "conditions": [],
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
                                                                     "endpoint": {
-                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
                                                                         "properties": {
                                                                             "backend": "S3Express",
                                                                             "authSchemes": [
                                                                                 {
                                                                                     "disableDoubleEncoding": true,
-                                                                                    "name": "sigv4",
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
                                                                                     "signingName": "s3express",
                                                                                     "signingRegion": "{Region}"
                                                                                 }
@@ -1417,16 +5200,25 @@
                                                                                 },
                                                                                 true
                                                                             ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
                                                                         }
                                                                     ],
                                                                     "endpoint": {
-                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
                                                                         "properties": {
                                                                             "backend": "S3Express",
                                                                             "authSchemes": [
                                                                                 {
                                                                                     "disableDoubleEncoding": true,
-                                                                                    "name": "sigv4",
+                                                                                    "name": "sigv4-s3express",
                                                                                     "signingName": "s3express",
                                                                                     "signingRegion": "{Region}"
                                                                                 }
@@ -1437,15 +5229,110 @@
                                                                     "type": "endpoint"
                                                                 },
                                                                 {
-                                                                    "conditions": [],
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
                                                                     "endpoint": {
-                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
                                                                         "properties": {
                                                                             "backend": "S3Express",
                                                                             "authSchemes": [
                                                                                 {
                                                                                     "disableDoubleEncoding": true,
-                                                                                    "name": "sigv4",
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
                                                                                     "signingName": "s3express",
                                                                                     "signingRegion": "{Region}"
                                                                                 }
@@ -1505,16 +5392,25 @@
                                                                                 },
                                                                                 true
                                                                             ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
                                                                         }
                                                                     ],
                                                                     "endpoint": {
-                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
                                                                         "properties": {
                                                                             "backend": "S3Express",
                                                                             "authSchemes": [
                                                                                 {
                                                                                     "disableDoubleEncoding": true,
-                                                                                    "name": "sigv4",
+                                                                                    "name": "sigv4-s3express",
                                                                                     "signingName": "s3express",
                                                                                     "signingRegion": "{Region}"
                                                                                 }
@@ -1525,15 +5421,110 @@
                                                                     "type": "endpoint"
                                                                 },
                                                                 {
-                                                                    "conditions": [],
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
                                                                     "endpoint": {
-                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
                                                                         "properties": {
                                                                             "backend": "S3Express",
                                                                             "authSchemes": [
                                                                                 {
                                                                                     "disableDoubleEncoding": true,
-                                                                                    "name": "sigv4",
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
                                                                                     "signingName": "s3express",
                                                                                     "signingRegion": "{Region}"
                                                                                 }
@@ -1593,16 +5584,25 @@
                                                                                 },
                                                                                 true
                                                                             ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
                                                                         }
                                                                     ],
                                                                     "endpoint": {
-                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
                                                                         "properties": {
                                                                             "backend": "S3Express",
                                                                             "authSchemes": [
                                                                                 {
                                                                                     "disableDoubleEncoding": true,
-                                                                                    "name": "sigv4",
+                                                                                    "name": "sigv4-s3express",
                                                                                     "signingName": "s3express",
                                                                                     "signingRegion": "{Region}"
                                                                                 }
@@ -1613,15 +5613,110 @@
                                                                     "type": "endpoint"
                                                                 },
                                                                 {
-                                                                    "conditions": [],
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
                                                                     "endpoint": {
-                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
                                                                         "properties": {
                                                                             "backend": "S3Express",
                                                                             "authSchemes": [
                                                                                 {
                                                                                     "disableDoubleEncoding": true,
-                                                                                    "name": "sigv4",
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
                                                                                     "signingName": "s3express",
                                                                                     "signingRegion": "{Region}"
                                                                                 }
@@ -1681,16 +5776,25 @@
                                                                                 },
                                                                                 true
                                                                             ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
                                                                         }
                                                                     ],
                                                                     "endpoint": {
-                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
                                                                         "properties": {
                                                                             "backend": "S3Express",
                                                                             "authSchemes": [
                                                                                 {
                                                                                     "disableDoubleEncoding": true,
-                                                                                    "name": "sigv4",
+                                                                                    "name": "sigv4-s3express",
                                                                                     "signingName": "s3express",
                                                                                     "signingRegion": "{Region}"
                                                                                 }
@@ -1701,9 +5805,305 @@
                                                                     "type": "endpoint"
                                                                 },
                                                                 {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "Unrecognized S3Express bucket name format.",
+                                                            "type": "error"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
+                                                }
+                                            ],
+                                            "type": "tree"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "error": "S3Express bucket name is not a valid virtual hostable name.",
+                                            "type": "error"
+                                        }
+                                    ],
+                                    "type": "tree"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "isSet",
+                                            "argv": [
+                                                {
+                                                    "ref": "Bucket"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "fn": "substring",
+                                            "argv": [
+                                                {
+                                                    "ref": "Bucket"
+                                                },
+                                                0,
+                                                7,
+                                                true
+                                            ],
+                                            "assign": "accessPointSuffix"
+                                        },
+                                        {
+                                            "fn": "stringEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "accessPointSuffix"
+                                                },
+                                                "--xa-s3"
+                                            ]
+                                        }
+                                    ],
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "Accelerate"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "S3Express does not support S3 Accelerate.",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "isSet",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "Endpoint"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "fn": "parseURL",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "Endpoint"
+                                                        }
+                                                    ],
+                                                    "assign": "url"
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "isSet",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "DisableS3ExpressSessionAuth"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "DisableS3ExpressSessionAuth"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "url"
+                                                                                },
+                                                                                "isIp"
+                                                                            ]
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "uriEncode",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                }
+                                                                            ],
+                                                                            "assign": "uri_encoded_bucket"
+                                                                        }
+                                                                    ],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "{url#scheme}://{url#authority}/{uri_encoded_bucket}{url#path}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "aws.isVirtualHostableS3Bucket",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Bucket"
+                                                                        },
+                                                                        false
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
                                                                     "conditions": [],
                                                                     "endpoint": {
-                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
+                                                                        "url": "{url#scheme}://{Bucket}.{url#authority}{url#path}",
                                                                         "properties": {
                                                                             "backend": "S3Express",
                                                                             "authSchemes": [
@@ -1724,7 +6124,7 @@
                                                         },
                                                         {
                                                             "conditions": [],
-                                                            "error": "Unrecognized S3Express bucket name format.",
+                                                            "error": "S3Express bucket name is not a valid virtual hostable name.",
                                                             "type": "error"
                                                         }
                                                     ],
@@ -1733,36 +6133,18 @@
                                                 {
                                                     "conditions": [
                                                         {
-                                                            "fn": "substring",
+                                                            "fn": "booleanEquals",
                                                             "argv": [
                                                                 {
-                                                                    "ref": "Bucket"
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "url"
+                                                                        },
+                                                                        "isIp"
+                                                                    ]
                                                                 },
-                                                                6,
-                                                                14,
                                                                 true
-                                                            ],
-                                                            "assign": "s3expressAvailabilityZoneId"
-                                                        },
-                                                        {
-                                                            "fn": "substring",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "Bucket"
-                                                                },
-                                                                14,
-                                                                16,
-                                                                true
-                                                            ],
-                                                            "assign": "s3expressAvailabilityZoneDelim"
-                                                        },
-                                                        {
-                                                            "fn": "stringEquals",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "s3expressAvailabilityZoneDelim"
-                                                                },
-                                                                "--"
                                                             ]
                                                         }
                                                     ],
@@ -1770,50 +6152,37 @@
                                                         {
                                                             "conditions": [
                                                                 {
-                                                                    "fn": "booleanEquals",
+                                                                    "fn": "uriEncode",
                                                                     "argv": [
                                                                         {
-                                                                            "ref": "UseFIPS"
-                                                                        },
-                                                                        true
-                                                                    ]
+                                                                            "ref": "Bucket"
+                                                                        }
+                                                                    ],
+                                                                    "assign": "uri_encoded_bucket"
                                                                 }
                                                             ],
-                                                            "endpoint": {
-                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
-                                                                "properties": {
-                                                                    "backend": "S3Express",
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "disableDoubleEncoding": true,
-                                                                            "name": "sigv4-s3express",
-                                                                            "signingName": "s3express",
-                                                                            "signingRegion": "{Region}"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        },
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
-                                                                "properties": {
-                                                                    "backend": "S3Express",
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "disableDoubleEncoding": true,
-                                                                            "name": "sigv4-s3express",
-                                                                            "signingName": "s3express",
-                                                                            "signingRegion": "{Region}"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "endpoint": {
+                                                                        "url": "{url#scheme}://{url#authority}/{uri_encoded_bucket}{url#path}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
                                                         }
                                                     ],
                                                     "type": "tree"
@@ -1821,337 +6190,20 @@
                                                 {
                                                     "conditions": [
                                                         {
-                                                            "fn": "substring",
+                                                            "fn": "aws.isVirtualHostableS3Bucket",
                                                             "argv": [
                                                                 {
                                                                     "ref": "Bucket"
                                                                 },
-                                                                6,
-                                                                15,
-                                                                true
-                                                            ],
-                                                            "assign": "s3expressAvailabilityZoneId"
-                                                        },
-                                                        {
-                                                            "fn": "substring",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "Bucket"
-                                                                },
-                                                                15,
-                                                                17,
-                                                                true
-                                                            ],
-                                                            "assign": "s3expressAvailabilityZoneDelim"
-                                                        },
-                                                        {
-                                                            "fn": "stringEquals",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "s3expressAvailabilityZoneDelim"
-                                                                },
-                                                                "--"
+                                                                false
                                                             ]
                                                         }
                                                     ],
                                                     "rules": [
                                                         {
-                                                            "conditions": [
-                                                                {
-                                                                    "fn": "booleanEquals",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "UseFIPS"
-                                                                        },
-                                                                        true
-                                                                    ]
-                                                                }
-                                                            ],
-                                                            "endpoint": {
-                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
-                                                                "properties": {
-                                                                    "backend": "S3Express",
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "disableDoubleEncoding": true,
-                                                                            "name": "sigv4-s3express",
-                                                                            "signingName": "s3express",
-                                                                            "signingRegion": "{Region}"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        },
-                                                        {
                                                             "conditions": [],
                                                             "endpoint": {
-                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
-                                                                "properties": {
-                                                                    "backend": "S3Express",
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "disableDoubleEncoding": true,
-                                                                            "name": "sigv4-s3express",
-                                                                            "signingName": "s3express",
-                                                                            "signingRegion": "{Region}"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ],
-                                                    "type": "tree"
-                                                },
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "substring",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "Bucket"
-                                                                },
-                                                                6,
-                                                                19,
-                                                                true
-                                                            ],
-                                                            "assign": "s3expressAvailabilityZoneId"
-                                                        },
-                                                        {
-                                                            "fn": "substring",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "Bucket"
-                                                                },
-                                                                19,
-                                                                21,
-                                                                true
-                                                            ],
-                                                            "assign": "s3expressAvailabilityZoneDelim"
-                                                        },
-                                                        {
-                                                            "fn": "stringEquals",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "s3expressAvailabilityZoneDelim"
-                                                                },
-                                                                "--"
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [
-                                                                {
-                                                                    "fn": "booleanEquals",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "UseFIPS"
-                                                                        },
-                                                                        true
-                                                                    ]
-                                                                }
-                                                            ],
-                                                            "endpoint": {
-                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
-                                                                "properties": {
-                                                                    "backend": "S3Express",
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "disableDoubleEncoding": true,
-                                                                            "name": "sigv4-s3express",
-                                                                            "signingName": "s3express",
-                                                                            "signingRegion": "{Region}"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        },
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
-                                                                "properties": {
-                                                                    "backend": "S3Express",
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "disableDoubleEncoding": true,
-                                                                            "name": "sigv4-s3express",
-                                                                            "signingName": "s3express",
-                                                                            "signingRegion": "{Region}"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ],
-                                                    "type": "tree"
-                                                },
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "substring",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "Bucket"
-                                                                },
-                                                                6,
-                                                                20,
-                                                                true
-                                                            ],
-                                                            "assign": "s3expressAvailabilityZoneId"
-                                                        },
-                                                        {
-                                                            "fn": "substring",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "Bucket"
-                                                                },
-                                                                20,
-                                                                22,
-                                                                true
-                                                            ],
-                                                            "assign": "s3expressAvailabilityZoneDelim"
-                                                        },
-                                                        {
-                                                            "fn": "stringEquals",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "s3expressAvailabilityZoneDelim"
-                                                                },
-                                                                "--"
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [
-                                                                {
-                                                                    "fn": "booleanEquals",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "UseFIPS"
-                                                                        },
-                                                                        true
-                                                                    ]
-                                                                }
-                                                            ],
-                                                            "endpoint": {
-                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
-                                                                "properties": {
-                                                                    "backend": "S3Express",
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "disableDoubleEncoding": true,
-                                                                            "name": "sigv4-s3express",
-                                                                            "signingName": "s3express",
-                                                                            "signingRegion": "{Region}"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        },
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
-                                                                "properties": {
-                                                                    "backend": "S3Express",
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "disableDoubleEncoding": true,
-                                                                            "name": "sigv4-s3express",
-                                                                            "signingName": "s3express",
-                                                                            "signingRegion": "{Region}"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ],
-                                                    "type": "tree"
-                                                },
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "substring",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "Bucket"
-                                                                },
-                                                                6,
-                                                                26,
-                                                                true
-                                                            ],
-                                                            "assign": "s3expressAvailabilityZoneId"
-                                                        },
-                                                        {
-                                                            "fn": "substring",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "Bucket"
-                                                                },
-                                                                26,
-                                                                28,
-                                                                true
-                                                            ],
-                                                            "assign": "s3expressAvailabilityZoneDelim"
-                                                        },
-                                                        {
-                                                            "fn": "stringEquals",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "s3expressAvailabilityZoneDelim"
-                                                                },
-                                                                "--"
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [
-                                                                {
-                                                                    "fn": "booleanEquals",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "UseFIPS"
-                                                                        },
-                                                                        true
-                                                                    ]
-                                                                }
-                                                            ],
-                                                            "endpoint": {
-                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
-                                                                "properties": {
-                                                                    "backend": "S3Express",
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "disableDoubleEncoding": true,
-                                                                            "name": "sigv4-s3express",
-                                                                            "signingName": "s3express",
-                                                                            "signingRegion": "{Region}"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        },
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.amazonaws.com",
+                                                                "url": "{url#scheme}://{Bucket}.{url#authority}{url#path}",
                                                                 "properties": {
                                                                     "backend": "S3Express",
                                                                     "authSchemes": [
@@ -2172,8 +6224,1994 @@
                                                 },
                                                 {
                                                     "conditions": [],
-                                                    "error": "Unrecognized S3Express bucket name format.",
+                                                    "error": "S3Express bucket name is not a valid virtual hostable name.",
                                                     "type": "error"
+                                                }
+                                            ],
+                                            "type": "tree"
+                                        },
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "aws.isVirtualHostableS3Bucket",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "Bucket"
+                                                        },
+                                                        false
+                                                    ]
+                                                }
+                                            ],
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "aws.partition",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "Region"
+                                                                }
+                                                            ],
+                                                            "assign": "partitionResult"
+                                                        }
+                                                    ],
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "isSet",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "DisableS3ExpressSessionAuth"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "DisableS3ExpressSessionAuth"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                7,
+                                                                                15,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneId"
+                                                                        },
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                15,
+                                                                                17,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneDelim"
+                                                                        },
+                                                                        {
+                                                                            "fn": "stringEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "s3expressAvailabilityZoneDelim"
+                                                                                },
+                                                                                "--"
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                7,
+                                                                                16,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneId"
+                                                                        },
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                16,
+                                                                                18,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneDelim"
+                                                                        },
+                                                                        {
+                                                                            "fn": "stringEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "s3expressAvailabilityZoneDelim"
+                                                                                },
+                                                                                "--"
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                7,
+                                                                                20,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneId"
+                                                                        },
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                20,
+                                                                                22,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneDelim"
+                                                                        },
+                                                                        {
+                                                                            "fn": "stringEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "s3expressAvailabilityZoneDelim"
+                                                                                },
+                                                                                "--"
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                7,
+                                                                                21,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneId"
+                                                                        },
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                21,
+                                                                                23,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneDelim"
+                                                                        },
+                                                                        {
+                                                                            "fn": "stringEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "s3expressAvailabilityZoneDelim"
+                                                                                },
+                                                                                "--"
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                7,
+                                                                                27,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneId"
+                                                                        },
+                                                                        {
+                                                                            "fn": "substring",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "Bucket"
+                                                                                },
+                                                                                27,
+                                                                                29,
+                                                                                true
+                                                                            ],
+                                                                            "assign": "s3expressAvailabilityZoneDelim"
+                                                                        },
+                                                                        {
+                                                                            "fn": "stringEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "s3expressAvailabilityZoneDelim"
+                                                                                },
+                                                                                "--"
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        true
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseFIPS"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "booleanEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "UseDualStack"
+                                                                                        },
+                                                                                        false
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                                "properties": {
+                                                                                    "backend": "S3Express",
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3express",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "Unrecognized S3Express bucket name format.",
+                                                                    "type": "error"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "substring",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Bucket"
+                                                                        },
+                                                                        7,
+                                                                        15,
+                                                                        true
+                                                                    ],
+                                                                    "assign": "s3expressAvailabilityZoneId"
+                                                                },
+                                                                {
+                                                                    "fn": "substring",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Bucket"
+                                                                        },
+                                                                        15,
+                                                                        17,
+                                                                        true
+                                                                    ],
+                                                                    "assign": "s3expressAvailabilityZoneDelim"
+                                                                },
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "s3expressAvailabilityZoneDelim"
+                                                                        },
+                                                                        "--"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "substring",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Bucket"
+                                                                        },
+                                                                        7,
+                                                                        16,
+                                                                        true
+                                                                    ],
+                                                                    "assign": "s3expressAvailabilityZoneId"
+                                                                },
+                                                                {
+                                                                    "fn": "substring",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Bucket"
+                                                                        },
+                                                                        16,
+                                                                        18,
+                                                                        true
+                                                                    ],
+                                                                    "assign": "s3expressAvailabilityZoneDelim"
+                                                                },
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "s3expressAvailabilityZoneDelim"
+                                                                        },
+                                                                        "--"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "substring",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Bucket"
+                                                                        },
+                                                                        7,
+                                                                        20,
+                                                                        true
+                                                                    ],
+                                                                    "assign": "s3expressAvailabilityZoneId"
+                                                                },
+                                                                {
+                                                                    "fn": "substring",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Bucket"
+                                                                        },
+                                                                        20,
+                                                                        22,
+                                                                        true
+                                                                    ],
+                                                                    "assign": "s3expressAvailabilityZoneDelim"
+                                                                },
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "s3expressAvailabilityZoneDelim"
+                                                                        },
+                                                                        "--"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "substring",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Bucket"
+                                                                        },
+                                                                        7,
+                                                                        21,
+                                                                        true
+                                                                    ],
+                                                                    "assign": "s3expressAvailabilityZoneId"
+                                                                },
+                                                                {
+                                                                    "fn": "substring",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Bucket"
+                                                                        },
+                                                                        21,
+                                                                        23,
+                                                                        true
+                                                                    ],
+                                                                    "assign": "s3expressAvailabilityZoneDelim"
+                                                                },
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "s3expressAvailabilityZoneDelim"
+                                                                        },
+                                                                        "--"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "substring",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Bucket"
+                                                                        },
+                                                                        7,
+                                                                        27,
+                                                                        true
+                                                                    ],
+                                                                    "assign": "s3expressAvailabilityZoneId"
+                                                                },
+                                                                {
+                                                                    "fn": "substring",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Bucket"
+                                                                        },
+                                                                        27,
+                                                                        29,
+                                                                        true
+                                                                    ],
+                                                                    "assign": "s3expressAvailabilityZoneDelim"
+                                                                },
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "s3expressAvailabilityZoneDelim"
+                                                                        },
+                                                                        "--"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-fips-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                true
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                },
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseFIPS"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "UseDualStack"
+                                                                                },
+                                                                                false
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.s3express-{s3expressAvailabilityZoneId}.{Region}.{partitionResult#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "backend": "S3Express",
+                                                                            "authSchemes": [
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4-s3express",
+                                                                                    "signingName": "s3express",
+                                                                                    "signingRegion": "{Region}"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "Unrecognized S3Express bucket name format.",
+                                                            "type": "error"
+                                                        }
+                                                    ],
+                                                    "type": "tree"
                                                 }
                                             ],
                                             "type": "tree"
@@ -2223,87 +8261,207 @@
                                         {
                                             "conditions": [
                                                 {
-                                                    "fn": "isSet",
+                                                    "fn": "aws.partition",
                                                     "argv": [
                                                         {
-                                                            "ref": "Endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "parseURL",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Endpoint"
+                                                            "ref": "Region"
                                                         }
                                                     ],
-                                                    "assign": "url"
+                                                    "assign": "partitionResult"
                                                 }
                                             ],
-                                            "endpoint": {
-                                                "url": "{url#scheme}://{url#authority}{url#path}",
-                                                "properties": {
-                                                    "backend": "S3Express",
-                                                    "authSchemes": [
-                                                        {
-                                                            "disableDoubleEncoding": true,
-                                                            "name": "sigv4",
-                                                            "signingName": "s3express",
-                                                            "signingRegion": "{Region}"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
+                                            "rules": [
                                                 {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
+                                                    "conditions": [
                                                         {
-                                                            "ref": "UseFIPS"
+                                                            "fn": "isSet",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "Endpoint"
+                                                                }
+                                                            ]
                                                         },
-                                                        true
-                                                    ]
+                                                        {
+                                                            "fn": "parseURL",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "Endpoint"
+                                                                }
+                                                            ],
+                                                            "assign": "url"
+                                                        }
+                                                    ],
+                                                    "endpoint": {
+                                                        "url": "{url#scheme}://{url#authority}{url#path}",
+                                                        "properties": {
+                                                            "backend": "S3Express",
+                                                            "authSchemes": [
+                                                                {
+                                                                    "disableDoubleEncoding": true,
+                                                                    "name": "sigv4",
+                                                                    "signingName": "s3express",
+                                                                    "signingRegion": "{Region}"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "headers": {}
+                                                    },
+                                                    "type": "endpoint"
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "endpoint": {
+                                                        "url": "https://s3express-control-fips.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                        "properties": {
+                                                            "backend": "S3Express",
+                                                            "authSchemes": [
+                                                                {
+                                                                    "disableDoubleEncoding": true,
+                                                                    "name": "sigv4",
+                                                                    "signingName": "s3express",
+                                                                    "signingRegion": "{Region}"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "headers": {}
+                                                    },
+                                                    "type": "endpoint"
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                false
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "endpoint": {
+                                                        "url": "https://s3express-control-fips.{Region}.{partitionResult#dnsSuffix}",
+                                                        "properties": {
+                                                            "backend": "S3Express",
+                                                            "authSchemes": [
+                                                                {
+                                                                    "disableDoubleEncoding": true,
+                                                                    "name": "sigv4",
+                                                                    "signingName": "s3express",
+                                                                    "signingRegion": "{Region}"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "headers": {}
+                                                    },
+                                                    "type": "endpoint"
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "endpoint": {
+                                                        "url": "https://s3express-control.dualstack.{Region}.{partitionResult#dnsSuffix}",
+                                                        "properties": {
+                                                            "backend": "S3Express",
+                                                            "authSchemes": [
+                                                                {
+                                                                    "disableDoubleEncoding": true,
+                                                                    "name": "sigv4",
+                                                                    "signingName": "s3express",
+                                                                    "signingRegion": "{Region}"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "headers": {}
+                                                    },
+                                                    "type": "endpoint"
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                false
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                false
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "endpoint": {
+                                                        "url": "https://s3express-control.{Region}.{partitionResult#dnsSuffix}",
+                                                        "properties": {
+                                                            "backend": "S3Express",
+                                                            "authSchemes": [
+                                                                {
+                                                                    "disableDoubleEncoding": true,
+                                                                    "name": "sigv4",
+                                                                    "signingName": "s3express",
+                                                                    "signingRegion": "{Region}"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "headers": {}
+                                                    },
+                                                    "type": "endpoint"
                                                 }
                                             ],
-                                            "endpoint": {
-                                                "url": "https://s3express-control-fips.{Region}.amazonaws.com",
-                                                "properties": {
-                                                    "backend": "S3Express",
-                                                    "authSchemes": [
-                                                        {
-                                                            "disableDoubleEncoding": true,
-                                                            "name": "sigv4",
-                                                            "signingName": "s3express",
-                                                            "signingRegion": "{Region}"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://s3express-control.{Region}.amazonaws.com",
-                                                "properties": {
-                                                    "backend": "S3Express",
-                                                    "authSchemes": [
-                                                        {
-                                                            "disableDoubleEncoding": true,
-                                                            "name": "sigv4",
-                                                            "signingName": "s3express",
-                                                            "signingRegion": "{Region}"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
+                                            "type": "tree"
                                         }
                                     ],
                                     "type": "tree"
@@ -2402,12 +8560,12 @@
                                                 {
                                                     "conditions": [
                                                         {
-                                                            "fn": "stringEquals",
+                                                            "fn": "aws.isVirtualHostableS3Bucket",
                                                             "argv": [
                                                                 {
-                                                                    "ref": "hardwareType"
+                                                                    "ref": "Bucket"
                                                                 },
-                                                                "e"
+                                                                false
                                                             ]
                                                         }
                                                     ],
@@ -2418,9 +8576,9 @@
                                                                     "fn": "stringEquals",
                                                                     "argv": [
                                                                         {
-                                                                            "ref": "regionPrefix"
+                                                                            "ref": "hardwareType"
                                                                         },
-                                                                        "beta"
+                                                                        "e"
                                                                     ]
                                                                 }
                                                             ],
@@ -2428,8 +8586,37 @@
                                                                 {
                                                                     "conditions": [
                                                                         {
-                                                                            "fn": "not",
+                                                                            "fn": "stringEquals",
                                                                             "argv": [
+                                                                                {
+                                                                                    "ref": "regionPrefix"
+                                                                                },
+                                                                                "beta"
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "not",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "fn": "isSet",
+                                                                                            "argv": [
+                                                                                                {
+                                                                                                    "ref": "Endpoint"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "error": "Expected a endpoint to be specified but no endpoint was found",
+                                                                            "type": "error"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
                                                                                 {
                                                                                     "fn": "isSet",
                                                                                     "argv": [
@@ -2437,35 +8624,169 @@
                                                                                             "ref": "Endpoint"
                                                                                         }
                                                                                     ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "parseURL",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "Endpoint"
+                                                                                        }
+                                                                                    ],
+                                                                                    "assign": "url"
                                                                                 }
-                                                                            ]
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.ec2.{url#authority}",
+                                                                                "properties": {
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4a",
+                                                                                            "signingName": "s3-outposts",
+                                                                                            "signingRegionSet": [
+                                                                                                "*"
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3-outposts",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
                                                                         }
                                                                     ],
-                                                                    "error": "Expected a endpoint to be specified but no endpoint was found",
-                                                                    "type": "error"
+                                                                    "type": "tree"
                                                                 },
                                                                 {
-                                                                    "conditions": [
-                                                                        {
-                                                                            "fn": "isSet",
-                                                                            "argv": [
+                                                                    "conditions": [],
+                                                                    "endpoint": {
+                                                                        "url": "https://{Bucket}.ec2.s3-outposts.{Region}.{regionPartition#dnsSuffix}",
+                                                                        "properties": {
+                                                                            "authSchemes": [
                                                                                 {
-                                                                                    "ref": "Endpoint"
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4a",
+                                                                                    "signingName": "s3-outposts",
+                                                                                    "signingRegionSet": [
+                                                                                        "*"
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "disableDoubleEncoding": true,
+                                                                                    "name": "sigv4",
+                                                                                    "signingName": "s3-outposts",
+                                                                                    "signingRegion": "{Region}"
                                                                                 }
                                                                             ]
                                                                         },
+                                                                        "headers": {}
+                                                                    },
+                                                                    "type": "endpoint"
+                                                                }
+                                                            ],
+                                                            "type": "tree"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
                                                                         {
-                                                                            "fn": "parseURL",
+                                                                            "ref": "hardwareType"
+                                                                        },
+                                                                        "o"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "stringEquals",
                                                                             "argv": [
                                                                                 {
-                                                                                    "ref": "Endpoint"
-                                                                                }
-                                                                            ],
-                                                                            "assign": "url"
+                                                                                    "ref": "regionPrefix"
+                                                                                },
+                                                                                "beta"
+                                                                            ]
                                                                         }
                                                                     ],
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "not",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "fn": "isSet",
+                                                                                            "argv": [
+                                                                                                {
+                                                                                                    "ref": "Endpoint"
+                                                                                                }
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "error": "Expected a endpoint to be specified but no endpoint was found",
+                                                                            "type": "error"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "isSet",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "Endpoint"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "fn": "parseURL",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "Endpoint"
+                                                                                        }
+                                                                                    ],
+                                                                                    "assign": "url"
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://{Bucket}.op-{outpostId}.{url#authority}",
+                                                                                "properties": {
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4a",
+                                                                                            "signingName": "s3-outposts",
+                                                                                            "signingRegionSet": [
+                                                                                                "*"
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "disableDoubleEncoding": true,
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "s3-outposts",
+                                                                                            "signingRegion": "{Region}"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree"
+                                                                },
+                                                                {
+                                                                    "conditions": [],
                                                                     "endpoint": {
-                                                                        "url": "https://{Bucket}.ec2.{url#authority}",
+                                                                        "url": "https://{Bucket}.op-{outpostId}.s3-outposts.{Region}.{regionPartition#dnsSuffix}",
                                                                         "properties": {
                                                                             "authSchemes": [
                                                                                 {
@@ -2493,157 +8814,15 @@
                                                         },
                                                         {
                                                             "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://{Bucket}.ec2.s3-outposts.{Region}.{regionPartition#dnsSuffix}",
-                                                                "properties": {
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "disableDoubleEncoding": true,
-                                                                            "name": "sigv4a",
-                                                                            "signingName": "s3-outposts",
-                                                                            "signingRegionSet": [
-                                                                                "*"
-                                                                            ]
-                                                                        },
-                                                                        {
-                                                                            "disableDoubleEncoding": true,
-                                                                            "name": "sigv4",
-                                                                            "signingName": "s3-outposts",
-                                                                            "signingRegion": "{Region}"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ],
-                                                    "type": "tree"
-                                                },
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "stringEquals",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "hardwareType"
-                                                                },
-                                                                "o"
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [
-                                                                {
-                                                                    "fn": "stringEquals",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "regionPrefix"
-                                                                        },
-                                                                        "beta"
-                                                                    ]
-                                                                }
-                                                            ],
-                                                            "rules": [
-                                                                {
-                                                                    "conditions": [
-                                                                        {
-                                                                            "fn": "not",
-                                                                            "argv": [
-                                                                                {
-                                                                                    "fn": "isSet",
-                                                                                    "argv": [
-                                                                                        {
-                                                                                            "ref": "Endpoint"
-                                                                                        }
-                                                                                    ]
-                                                                                }
-                                                                            ]
-                                                                        }
-                                                                    ],
-                                                                    "error": "Expected a endpoint to be specified but no endpoint was found",
-                                                                    "type": "error"
-                                                                },
-                                                                {
-                                                                    "conditions": [
-                                                                        {
-                                                                            "fn": "isSet",
-                                                                            "argv": [
-                                                                                {
-                                                                                    "ref": "Endpoint"
-                                                                                }
-                                                                            ]
-                                                                        },
-                                                                        {
-                                                                            "fn": "parseURL",
-                                                                            "argv": [
-                                                                                {
-                                                                                    "ref": "Endpoint"
-                                                                                }
-                                                                            ],
-                                                                            "assign": "url"
-                                                                        }
-                                                                    ],
-                                                                    "endpoint": {
-                                                                        "url": "https://{Bucket}.op-{outpostId}.{url#authority}",
-                                                                        "properties": {
-                                                                            "authSchemes": [
-                                                                                {
-                                                                                    "disableDoubleEncoding": true,
-                                                                                    "name": "sigv4a",
-                                                                                    "signingName": "s3-outposts",
-                                                                                    "signingRegionSet": [
-                                                                                        "*"
-                                                                                    ]
-                                                                                },
-                                                                                {
-                                                                                    "disableDoubleEncoding": true,
-                                                                                    "name": "sigv4",
-                                                                                    "signingName": "s3-outposts",
-                                                                                    "signingRegion": "{Region}"
-                                                                                }
-                                                                            ]
-                                                                        },
-                                                                        "headers": {}
-                                                                    },
-                                                                    "type": "endpoint"
-                                                                }
-                                                            ],
-                                                            "type": "tree"
-                                                        },
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://{Bucket}.op-{outpostId}.s3-outposts.{Region}.{regionPartition#dnsSuffix}",
-                                                                "properties": {
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "disableDoubleEncoding": true,
-                                                                            "name": "sigv4a",
-                                                                            "signingName": "s3-outposts",
-                                                                            "signingRegionSet": [
-                                                                                "*"
-                                                                            ]
-                                                                        },
-                                                                        {
-                                                                            "disableDoubleEncoding": true,
-                                                                            "name": "sigv4",
-                                                                            "signingName": "s3-outposts",
-                                                                            "signingRegion": "{Region}"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
+                                                            "error": "Unrecognized hardware type: \"Expected hardware type o or e but got {hardwareType}\"",
+                                                            "type": "error"
                                                         }
                                                     ],
                                                     "type": "tree"
                                                 },
                                                 {
                                                     "conditions": [],
-                                                    "error": "Unrecognized hardware type: \"Expected hardware type o or e but got {hardwareType}\"",
+                                                    "error": "Invalid Outposts Bucket alias - it must be a valid bucket name.",
                                                     "type": "error"
                                                 }
                                             ],
@@ -6651,72 +12830,93 @@
                                                                                                                                                 {
                                                                                                                                                     "conditions": [
                                                                                                                                                         {
-                                                                                                                                                            "fn": "isSet",
+                                                                                                                                                            "fn": "isValidHostLabel",
                                                                                                                                                             "argv": [
                                                                                                                                                                 {
-                                                                                                                                                                    "ref": "Endpoint"
-                                                                                                                                                                }
+                                                                                                                                                                    "ref": "accessPointName"
+                                                                                                                                                                },
+                                                                                                                                                                false
                                                                                                                                                             ]
-                                                                                                                                                        },
-                                                                                                                                                        {
-                                                                                                                                                            "fn": "parseURL",
-                                                                                                                                                            "argv": [
-                                                                                                                                                                {
-                                                                                                                                                                    "ref": "Endpoint"
-                                                                                                                                                                }
-                                                                                                                                                            ],
-                                                                                                                                                            "assign": "url"
                                                                                                                                                         }
                                                                                                                                                     ],
-                                                                                                                                                    "endpoint": {
-                                                                                                                                                        "url": "https://{accessPointName}-{bucketArn#accountId}.{outpostId}.{url#authority}",
-                                                                                                                                                        "properties": {
-                                                                                                                                                            "authSchemes": [
+                                                                                                                                                    "rules": [
+                                                                                                                                                        {
+                                                                                                                                                            "conditions": [
                                                                                                                                                                 {
-                                                                                                                                                                    "disableDoubleEncoding": true,
-                                                                                                                                                                    "name": "sigv4a",
-                                                                                                                                                                    "signingName": "s3-outposts",
-                                                                                                                                                                    "signingRegionSet": [
-                                                                                                                                                                        "*"
+                                                                                                                                                                    "fn": "isSet",
+                                                                                                                                                                    "argv": [
+                                                                                                                                                                        {
+                                                                                                                                                                            "ref": "Endpoint"
+                                                                                                                                                                        }
                                                                                                                                                                     ]
                                                                                                                                                                 },
                                                                                                                                                                 {
-                                                                                                                                                                    "disableDoubleEncoding": true,
-                                                                                                                                                                    "name": "sigv4",
-                                                                                                                                                                    "signingName": "s3-outposts",
-                                                                                                                                                                    "signingRegion": "{bucketArn#region}"
+                                                                                                                                                                    "fn": "parseURL",
+                                                                                                                                                                    "argv": [
+                                                                                                                                                                        {
+                                                                                                                                                                            "ref": "Endpoint"
+                                                                                                                                                                        }
+                                                                                                                                                                    ],
+                                                                                                                                                                    "assign": "url"
                                                                                                                                                                 }
-                                                                                                                                                            ]
+                                                                                                                                                            ],
+                                                                                                                                                            "endpoint": {
+                                                                                                                                                                "url": "https://{accessPointName}-{bucketArn#accountId}.{outpostId}.{url#authority}",
+                                                                                                                                                                "properties": {
+                                                                                                                                                                    "authSchemes": [
+                                                                                                                                                                        {
+                                                                                                                                                                            "disableDoubleEncoding": true,
+                                                                                                                                                                            "name": "sigv4a",
+                                                                                                                                                                            "signingName": "s3-outposts",
+                                                                                                                                                                            "signingRegionSet": [
+                                                                                                                                                                                "*"
+                                                                                                                                                                            ]
+                                                                                                                                                                        },
+                                                                                                                                                                        {
+                                                                                                                                                                            "disableDoubleEncoding": true,
+                                                                                                                                                                            "name": "sigv4",
+                                                                                                                                                                            "signingName": "s3-outposts",
+                                                                                                                                                                            "signingRegion": "{bucketArn#region}"
+                                                                                                                                                                        }
+                                                                                                                                                                    ]
+                                                                                                                                                                },
+                                                                                                                                                                "headers": {}
+                                                                                                                                                            },
+                                                                                                                                                            "type": "endpoint"
                                                                                                                                                         },
-                                                                                                                                                        "headers": {}
-                                                                                                                                                    },
-                                                                                                                                                    "type": "endpoint"
+                                                                                                                                                        {
+                                                                                                                                                            "conditions": [],
+                                                                                                                                                            "endpoint": {
+                                                                                                                                                                "url": "https://{accessPointName}-{bucketArn#accountId}.{outpostId}.s3-outposts.{bucketArn#region}.{bucketPartition#dnsSuffix}",
+                                                                                                                                                                "properties": {
+                                                                                                                                                                    "authSchemes": [
+                                                                                                                                                                        {
+                                                                                                                                                                            "disableDoubleEncoding": true,
+                                                                                                                                                                            "name": "sigv4a",
+                                                                                                                                                                            "signingName": "s3-outposts",
+                                                                                                                                                                            "signingRegionSet": [
+                                                                                                                                                                                "*"
+                                                                                                                                                                            ]
+                                                                                                                                                                        },
+                                                                                                                                                                        {
+                                                                                                                                                                            "disableDoubleEncoding": true,
+                                                                                                                                                                            "name": "sigv4",
+                                                                                                                                                                            "signingName": "s3-outposts",
+                                                                                                                                                                            "signingRegion": "{bucketArn#region}"
+                                                                                                                                                                        }
+                                                                                                                                                                    ]
+                                                                                                                                                                },
+                                                                                                                                                                "headers": {}
+                                                                                                                                                            },
+                                                                                                                                                            "type": "endpoint"
+                                                                                                                                                        }
+                                                                                                                                                    ],
+                                                                                                                                                    "type": "tree"
                                                                                                                                                 },
                                                                                                                                                 {
                                                                                                                                                     "conditions": [],
-                                                                                                                                                    "endpoint": {
-                                                                                                                                                        "url": "https://{accessPointName}-{bucketArn#accountId}.{outpostId}.s3-outposts.{bucketArn#region}.{bucketPartition#dnsSuffix}",
-                                                                                                                                                        "properties": {
-                                                                                                                                                            "authSchemes": [
-                                                                                                                                                                {
-                                                                                                                                                                    "disableDoubleEncoding": true,
-                                                                                                                                                                    "name": "sigv4a",
-                                                                                                                                                                    "signingName": "s3-outposts",
-                                                                                                                                                                    "signingRegionSet": [
-                                                                                                                                                                        "*"
-                                                                                                                                                                    ]
-                                                                                                                                                                },
-                                                                                                                                                                {
-                                                                                                                                                                    "disableDoubleEncoding": true,
-                                                                                                                                                                    "name": "sigv4",
-                                                                                                                                                                    "signingName": "s3-outposts",
-                                                                                                                                                                    "signingRegion": "{bucketArn#region}"
-                                                                                                                                                                }
-                                                                                                                                                            ]
-                                                                                                                                                        },
-                                                                                                                                                        "headers": {}
-                                                                                                                                                    },
-                                                                                                                                                    "type": "endpoint"
+                                                                                                                                                    "error": "Invalid ARN: The access point name may only contain a-z, A-Z, 0-9 and `-`. Found: `{accessPointName}`",
+                                                                                                                                                    "type": "error"
                                                                                                                                                 }
                                                                                                                                             ],
                                                                                                                                             "type": "tree"
@@ -16009,6 +22209,19 @@
                             }
                         },
                         {
+                            "documentation": "validates against access point host label",
+                            "expect": {
+                                "error": "Invalid ARN: The access point name may only contain a-z, A-Z, 0-9 and `-`. Found: `invalid.bucket#`"
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "Bucket": "arn:aws:s3-outposts:us-west-2:123456789012:outpost:op-01234567890123456:accesspoint:invalid.bucket#"
+                            }
+                        },
+                        {
                             "documentation": "object lambda @us-east-1",
                             "expect": {
                                 "endpoint": {
@@ -17121,6 +23334,20 @@
                             }
                         },
                         {
+                            "documentation": "S3 Outposts invalid bucket name",
+                            "expect": {
+                                "error": "Invalid Outposts Bucket alias - it must be a valid bucket name."
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "Bucket": "test-accessp-o0b1de75431d83bebd/8xz5w8ijx1qzlbp3i3kbeta0--op-s3",
+                                "Endpoint": "https://example.amazonaws.com",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false
+                            }
+                        },
+                        {
                             "documentation": "S3 Outposts bucketAlias Invalid hardware type",
                             "expect": {
                                 "error": "Unrecognized hardware type: \"Expected hardware type o or e but got h\""
@@ -17302,6 +23529,123 @@
                             }
                         },
                         {
+                            "documentation": "Data Plane with short zone name china region",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "cn-north-1",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--abcd-ab1--x-s3.s3express-abcd-ab1.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1"
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "mybucket--abcd-ab1--x-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "cn-north-1",
+                                "Bucket": "mybucket--abcd-ab1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with short zone name with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-east-1",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--abcd-ab1--xa-s3.s3express-abcd-ab1.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1"
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "myaccesspoint--abcd-ab1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-east-1",
+                                "Bucket": "myaccesspoint--abcd-ab1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with short zone name with AP china region",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "cn-north-1",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--abcd-ab1--xa-s3.s3express-abcd-ab1.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1"
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "myaccesspoint--abcd-ab1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "cn-north-1",
+                                "Bucket": "myaccesspoint--abcd-ab1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
                             "documentation": "Data Plane with short zone names (13 chars)",
                             "expect": {
                                 "endpoint": {
@@ -17334,6 +23678,45 @@
                             "params": {
                                 "Region": "us-west-2",
                                 "Bucket": "mybucket--test-zone-ab1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with short zone names (13 chars) with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test-zone-ab1--xa-s3.s3express-test-zone-ab1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-west-2"
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "myaccesspoint--test-zone-ab1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test-zone-ab1--xa-s3",
                                 "UseFIPS": false,
                                 "UseDualStack": false,
                                 "Accelerate": false,
@@ -17380,6 +23763,45 @@
                             }
                         },
                         {
+                            "documentation": "Data Plane with medium zone names (14 chars) with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-zone-ab1--xa-s3.s3express-test1-zone-ab1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-west-2"
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "myaccesspoint--test1-zone-ab1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-zone-ab1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
                             "documentation": "Data Plane with long zone names (20 chars)",
                             "expect": {
                                 "endpoint": {
@@ -17412,6 +23834,45 @@
                             "params": {
                                 "Region": "us-west-2",
                                 "Bucket": "mybucket--test1-long1-zone-ab1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with long zone names (20 chars)",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-long1-zone-ab1--xa-s3.s3express-test1-long1-zone-ab1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-west-2"
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "myaccesspoint--test1-long1-zone-ab1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-long1-zone-ab1--xa-s3",
                                 "UseFIPS": false,
                                 "UseDualStack": false,
                                 "Accelerate": false,
@@ -17459,6 +23920,100 @@
                             }
                         },
                         {
+                            "documentation": "Data Plane with short zone fips china region",
+                            "expect": {
+                                "error": "Partition does not support FIPS"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1",
+                                        "AWS::UseFIPS": true
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "mybucket--test-ab1--x-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "cn-north-1",
+                                "Bucket": "mybucket--test-ab1--x-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with short zone fips with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-east-1",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test-ab1--xa-s3.s3express-fips-test-ab1.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "myaccesspoint--test-ab1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-east-1",
+                                "Bucket": "myaccesspoint--test-ab1--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with short zone fips with AP china region",
+                            "expect": {
+                                "error": "Partition does not support FIPS"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1",
+                                        "AWS::UseFIPS": true
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "myaccesspoint--test-ab1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "cn-north-1",
+                                "Bucket": "myaccesspoint--test-ab1--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
                             "documentation": "Data Plane with short zone (13 chars) fips",
                             "expect": {
                                 "endpoint": {
@@ -17492,6 +24047,46 @@
                             "params": {
                                 "Region": "us-west-2",
                                 "Bucket": "mybucket--test-zone-ab1--x-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with short zone (13 chars) fips with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test-zone-ab1--xa-s3.s3express-fips-test-zone-ab1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-west-2",
+                                        "AWS::UseFIPS": true
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "myaccesspoint--test-zone-ab1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test-zone-ab1--xa-s3",
                                 "UseFIPS": true,
                                 "UseDualStack": false,
                                 "Accelerate": false,
@@ -17539,6 +24134,46 @@
                             }
                         },
                         {
+                            "documentation": "Data Plane with medium zone (14 chars) fips with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-zone-ab1--xa-s3.s3express-fips-test1-zone-ab1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-west-2",
+                                        "AWS::UseFIPS": true
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "myaccesspoint--test1-zone-ab1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-zone-ab1--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
                             "documentation": "Data Plane with long zone (20 chars) fips",
                             "expect": {
                                 "endpoint": {
@@ -17579,6 +24214,46 @@
                             }
                         },
                         {
+                            "documentation": "Data Plane with long zone (20 chars) fips with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-long1-zone-ab1--xa-s3.s3express-fips-test1-long1-zone-ab1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-west-2",
+                                        "AWS::UseFIPS": true
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "myaccesspoint--test1-long1-zone-ab1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-long1-zone-ab1--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
                             "documentation": "Data Plane with long AZ",
                             "expect": {
                                 "endpoint": {
@@ -17611,6 +24286,45 @@
                             "params": {
                                 "Region": "us-west-2",
                                 "Bucket": "mybucket--test1-az1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with long AZ with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-az1--xa-s3.s3express-test1-az1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-west-2"
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "myaccesspoint--test1-az1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-az1--xa-s3",
                                 "UseFIPS": false,
                                 "UseDualStack": false,
                                 "Accelerate": false,
@@ -17658,6 +24372,46 @@
                             }
                         },
                         {
+                            "documentation": "Data Plane with long AZ fips with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-az1--xa-s3.s3express-fips-test1-az1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-west-2",
+                                        "AWS::UseFIPS": true
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "myaccesspoint--test1-az1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-az1--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
                             "documentation": "Control plane with short AZ bucket",
                             "expect": {
                                 "endpoint": {
@@ -17688,6 +24442,45 @@
                             ],
                             "params": {
                                 "Region": "us-east-1",
+                                "Bucket": "mybucket--test-ab1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": true,
+                                "DisableS3ExpressSessionAuth": false
+                            }
+                        },
+                        {
+                            "documentation": "Control plane with short AZ bucket china region",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "cn-north-1",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://s3express-control.cn-north-1.amazonaws.com.cn/mybucket--test-ab1--x-s3"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1"
+                                    },
+                                    "operationName": "CreateBucket",
+                                    "operationParams": {
+                                        "Bucket": "mybucket--test-ab1--x-s3"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "cn-north-1",
                                 "Bucket": "mybucket--test-ab1--x-s3",
                                 "UseFIPS": false,
                                 "UseDualStack": false,
@@ -17728,6 +24521,33 @@
                             ],
                             "params": {
                                 "Region": "us-east-1",
+                                "Bucket": "mybucket--test-ab1--x-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": true,
+                                "DisableS3ExpressSessionAuth": false
+                            }
+                        },
+                        {
+                            "documentation": "Control plane with short AZ bucket and fips china region",
+                            "expect": {
+                                "error": "Partition does not support FIPS"
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "cn-north-1",
+                                        "AWS::UseFIPS": true
+                                    },
+                                    "operationName": "CreateBucket",
+                                    "operationParams": {
+                                        "Bucket": "mybucket--test-ab1--x-s3"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "cn-north-1",
                                 "Bucket": "mybucket--test-ab1--x-s3",
                                 "UseFIPS": true,
                                 "UseDualStack": false,
@@ -17835,6 +24655,33 @@
                             }
                         },
                         {
+                            "documentation": "Data Plane sigv4 auth with short AZ with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--usw2-az1--xa-s3.s3express-usw2-az1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--usw2-az1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
                             "documentation": "Data Plane sigv4 auth with short zone (13 chars)",
                             "expect": {
                                 "endpoint": {
@@ -17855,6 +24702,33 @@
                             "params": {
                                 "Region": "us-west-2",
                                 "Bucket": "mybucket--test-zone-ab1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with short zone (13 chars) with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test-zone-ab1--xa-s3.s3express-test-zone-ab1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test-zone-ab1--xa-s3",
                                 "UseFIPS": false,
                                 "UseDualStack": false,
                                 "Accelerate": false,
@@ -17889,6 +24763,33 @@
                             }
                         },
                         {
+                            "documentation": "Data Plane sigv4 auth with short AZ fips with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--usw2-az1--xa-s3.s3express-fips-usw2-az1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--usw2-az1--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
                             "documentation": "Data Plane sigv4 auth with short zone (13 chars) fips",
                             "expect": {
                                 "endpoint": {
@@ -17916,6 +24817,33 @@
                             }
                         },
                         {
+                            "documentation": "Data Plane sigv4 auth with short zone (13 chars) fips with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test-zone-ab1--xa-s3.s3express-fips-test-zone-ab1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test-zone-ab1--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
                             "documentation": "Data Plane sigv4 auth with long AZ",
                             "expect": {
                                 "endpoint": {
@@ -17936,6 +24864,34 @@
                             "params": {
                                 "Region": "us-west-2",
                                 "Bucket": "mybucket--test1-az1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with long AZ with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-az1--xa-s3.s3express-test1-az1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-az1--xa-s3",
                                 "UseFIPS": false,
                                 "UseDualStack": false,
                                 "Accelerate": false,
@@ -17972,6 +24928,34 @@
                             }
                         },
                         {
+                            "documentation": "Data Plane sigv4 auth with medium zone(14 chars) with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-zone-ab1--xa-s3.s3express-test1-zone-ab1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-zone-ab1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
                             "documentation": "Data Plane sigv4 auth with long zone(20 chars)",
                             "expect": {
                                 "endpoint": {
@@ -17992,6 +24976,34 @@
                             "params": {
                                 "Region": "us-west-2",
                                 "Bucket": "mybucket--test1-long1-zone-ab1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with long zone(20 chars) with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-long1-zone-ab1--xa-s3.s3express-test1-long1-zone-ab1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-long1-zone-ab1--xa-s3",
                                 "UseFIPS": false,
                                 "UseDualStack": false,
                                 "Accelerate": false,
@@ -18028,6 +25040,34 @@
                             }
                         },
                         {
+                            "documentation": "Data Plane sigv4 auth with long AZ fips with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-az1--xa-s3.s3express-fips-test1-az1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-az1--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
                             "documentation": "Data Plane sigv4 auth with medium zone (14 chars) fips",
                             "expect": {
                                 "endpoint": {
@@ -18048,6 +25088,34 @@
                             "params": {
                                 "Region": "us-west-2",
                                 "Bucket": "mybucket--test1-zone-ab1--x-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with medium zone (14 chars) fips with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-zone-ab1--xa-s3.s3express-fips-test1-zone-ab1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-zone-ab1--xa-s3",
                                 "UseFIPS": true,
                                 "UseDualStack": false,
                                 "Accelerate": false,
@@ -18084,6 +25152,34 @@
                             }
                         },
                         {
+                            "documentation": "Data Plane sigv4 auth with long zone (20 chars) fips with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-long1-zone-ab1--xa-s3.s3express-fips-test1-long1-zone-ab1.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-long1-zone-ab1--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
                             "documentation": "Control Plane host override",
                             "expect": {
                                 "endpoint": {
@@ -18104,6 +25200,35 @@
                             "params": {
                                 "Region": "us-west-2",
                                 "Bucket": "mybucket--usw2-az1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": true,
+                                "DisableS3ExpressSessionAuth": true,
+                                "Endpoint": "https://custom.com"
+                            }
+                        },
+                        {
+                            "documentation": "Control Plane host override with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--usw2-az1--xa-s3.custom.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--usw2-az1--xa-s3",
                                 "UseFIPS": false,
                                 "UseDualStack": false,
                                 "Accelerate": false,
@@ -18181,6 +25306,46 @@
                             }
                         },
                         {
+                            "documentation": "Data plane host override non virtual session auth with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://10.0.0.1/myaccesspoint--usw2-az1--xa-s3"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-west-2",
+                                        "SDK::Endpoint": "https://10.0.0.1"
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "myaccesspoint--usw2-az1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--usw2-az1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "Endpoint": "https://10.0.0.1"
+                            }
+                        },
+                        {
                             "documentation": "Control Plane host override ip",
                             "expect": {
                                 "endpoint": {
@@ -18201,6 +25366,35 @@
                             "params": {
                                 "Region": "us-west-2",
                                 "Bucket": "mybucket--usw2-az1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": true,
+                                "DisableS3ExpressSessionAuth": true,
+                                "Endpoint": "https://10.0.0.1"
+                            }
+                        },
+                        {
+                            "documentation": "Control Plane host override ip with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://10.0.0.1/myaccesspoint--usw2-az1--xa-s3"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--usw2-az1--xa-s3",
                                 "UseFIPS": false,
                                 "UseDualStack": false,
                                 "Accelerate": false,
@@ -18250,6 +25444,46 @@
                             }
                         },
                         {
+                            "documentation": "Data plane host override with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--usw2-az1--xa-s3.custom.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-west-2",
+                                        "SDK::Endpoint": "https://custom.com"
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "myaccesspoint--usw2-az1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--usw2-az1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "Endpoint": "https://custom.com"
+                            }
+                        },
+                        {
                             "documentation": "bad format error",
                             "expect": {
                                 "error": "Unrecognized S3Express bucket name format."
@@ -18269,6 +25503,32 @@
                             "params": {
                                 "Region": "us-east-1",
                                 "Bucket": "mybucket--usaz1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "bad AP format error",
+                            "expect": {
+                                "error": "Unrecognized S3Express bucket name format."
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1"
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "myaccesspoint--usaz1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-east-1",
+                                "Bucket": "myaccesspoint--usaz1--xa-s3",
                                 "UseFIPS": false,
                                 "UseDualStack": false,
                                 "Accelerate": false,
@@ -18303,30 +25563,30 @@
                             }
                         },
                         {
-                            "documentation": "dual-stack error",
+                            "documentation": "bad AP format error no session auth",
                             "expect": {
-                                "error": "S3Express does not support Dual-stack."
+                                "error": "Unrecognized S3Express bucket name format."
                             },
                             "operationInputs": [
                                 {
                                     "builtInParams": {
-                                        "AWS::Region": "us-east-1",
-                                        "AWS::UseDualStack": true
+                                        "AWS::Region": "us-east-1"
                                     },
                                     "operationName": "GetObject",
                                     "operationParams": {
-                                        "Bucket": "mybucket--test-ab1--x-s3",
+                                        "Bucket": "myaccesspoint--usaz1--xa-s3",
                                         "Key": "key"
                                     }
                                 }
                             ],
                             "params": {
                                 "Region": "us-east-1",
-                                "Bucket": "mybucket--test-ab1--x-s3",
+                                "Bucket": "myaccesspoint--usaz1--xa-s3",
                                 "UseFIPS": false,
-                                "UseDualStack": true,
+                                "UseDualStack": false,
                                 "Accelerate": false,
-                                "UseS3ExpressControlEndpoint": false
+                                "UseS3ExpressControlEndpoint": false,
+                                "DisableS3ExpressSessionAuth": true
                             }
                         },
                         {
@@ -18357,6 +25617,33 @@
                             }
                         },
                         {
+                            "documentation": "accelerate error with AP",
+                            "expect": {
+                                "error": "S3Express does not support S3 Accelerate."
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::S3::Accelerate": true
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "myaccesspoint--test-ab1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-east-1",
+                                "Bucket": "myaccesspoint--test-ab1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": true,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
                             "documentation": "Data plane bucket format error",
                             "expect": {
                                 "error": "S3Express bucket name is not a valid virtual hostable name."
@@ -18376,6 +25663,32 @@
                             "params": {
                                 "Region": "us-east-1",
                                 "Bucket": "my.bucket--test-ab1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data plane AP format error",
+                            "expect": {
+                                "error": "S3Express bucket name is not a valid virtual hostable name."
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1"
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "my.myaccesspoint--test-ab1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-east-1",
+                                "Bucket": "my.myaccesspoint--test-ab1--xa-s3",
                                 "UseFIPS": false,
                                 "UseDualStack": false,
                                 "Accelerate": false,
@@ -18410,6 +25723,33 @@
                             }
                         },
                         {
+                            "documentation": "host override data plane AP error session auth",
+                            "expect": {
+                                "error": "S3Express bucket name is not a valid virtual hostable name."
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-west-2",
+                                        "SDK::Endpoint": "https://custom.com"
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "my.myaccesspoint--usw2-az1--xa-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "my.myaccesspoint--usw2-az1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "Endpoint": "https://custom.com"
+                            }
+                        },
+                        {
                             "documentation": "host override data plane bucket error",
                             "expect": {
                                 "error": "S3Express bucket name is not a valid virtual hostable name."
@@ -18422,6 +25762,1347 @@
                                 "Accelerate": false,
                                 "Endpoint": "https://custom.com",
                                 "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "host override data plane AP error",
+                            "expect": {
+                                "error": "S3Express bucket name is not a valid virtual hostable name."
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "my.myaccesspoint--usw2-az1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "Endpoint": "https://custom.com",
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Control plane without bucket and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-east-1",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://s3express-control.dualstack.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseDualStack": true
+                                    },
+                                    "operationName": "ListDirectoryBuckets"
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": true,
+                                "DisableS3ExpressSessionAuth": false
+                            }
+                        },
+                        {
+                            "documentation": "Control plane without bucket, fips and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-east-1",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://s3express-control-fips.dualstack.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true
+                                    },
+                                    "operationName": "ListDirectoryBuckets"
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": true,
+                                "DisableS3ExpressSessionAuth": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with bucket containing delimiters",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-east-1",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://my--s3--bucket--abcd-ab1--x-s3.s3express-abcd-ab1.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1"
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "my--s3--bucket--abcd-ab1--x-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-east-1",
+                                "Bucket": "my--s3--bucket--abcd-ab1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Control plane with with bucket containing delimiters",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-east-1",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://s3express-control.us-east-1.amazonaws.com/my--s3--bucket--abcd-ab1--x-s3"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "Bucket": "my--s3--bucket--abcd-ab1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": true,
+                                "DisableS3ExpressSessionAuth": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with short AZ and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--usw2-az1--x-s3.s3express-usw2-az1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-west-2",
+                                        "AWS::UseDualStack": true
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "mybucket--usw2-az1--x-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--usw2-az1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with short AZ and FIPS with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--usw2-az1--x-s3.s3express-fips-usw2-az1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-west-2",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true
+                                    },
+                                    "operationName": "GetObject",
+                                    "operationParams": {
+                                        "Bucket": "mybucket--usw2-az1--x-s3",
+                                        "Key": "key"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--usw2-az1--x-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with short AZ and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--usw2-az1--x-s3.s3express-usw2-az1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--usw2-az1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with short AZ and FIPS with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--usw2-az1--x-s3.s3express-fips-usw2-az1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--usw2-az1--x-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with zone and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--usw2-az12--x-s3.s3express-usw2-az12.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--usw2-az12--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with zone and FIPS with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--usw2-az12--x-s3.s3express-fips-usw2-az12.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--usw2-az12--x-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with zone and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--usw2-az12--x-s3.s3express-usw2-az12.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--usw2-az12--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with 9-char zone and FIPS with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--usw2-az12--x-s3.s3express-fips-usw2-az12.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--usw2-az12--x-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with 13-char zone and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--test-zone-ab1--x-s3.s3express-test-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--test-zone-ab1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with 13-char zone and FIPS with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--test-zone-ab1--x-s3.s3express-fips-test-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--test-zone-ab1--x-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with 13-char zone and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--test-zone-ab1--x-s3.s3express-test-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--test-zone-ab1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with 13-char zone and FIPS with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--test-zone-ab1--x-s3.s3express-fips-test-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--test-zone-ab1--x-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with 14-char zone and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--test1-zone-ab1--x-s3.s3express-test1-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--test1-zone-ab1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with 14-char zone and FIPS with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--test1-zone-ab1--x-s3.s3express-fips-test1-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--test1-zone-ab1--x-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with 14-char zone and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--test1-zone-ab1--x-s3.s3express-test1-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--test1-zone-ab1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with 14-char zone and FIPS with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--test1-zone-ab1--x-s3.s3express-fips-test1-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--test1-zone-ab1--x-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with long zone (20 cha) and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--test1-long1-zone-ab1--x-s3.s3express-test1-long1-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--test1-long1-zone-ab1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with long zone (20 char) and FIPS with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--test1-long1-zone-ab1--x-s3.s3express-fips-test1-long1-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--test1-long1-zone-ab1--x-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with long zone (20 char) and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--test1-long1-zone-ab1--x-s3.s3express-test1-long1-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--test1-long1-zone-ab1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with long zone (20 char) and FIPS with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://mybucket--test1-long1-zone-ab1--x-s3.s3express-fips-test1-long1-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "mybucket--test1-long1-zone-ab1--x-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Control plane and FIPS with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-east-1",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://s3express-control-fips.dualstack.us-east-1.amazonaws.com/mybucket--test-ab1--x-s3"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseFIPS": true,
+                                        "AWS::UseDualStack": true
+                                    },
+                                    "operationName": "CreateBucket",
+                                    "operationParams": {
+                                        "Bucket": "mybucket--test-ab1--x-s3"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-east-1",
+                                "Bucket": "mybucket--test-ab1--x-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": true
+                            }
+                        },
+                        {
+                            "documentation": "Data plane with zone and dualstack and AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--usw2-az1--xa-s3.s3express-usw2-az1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--usw2-az1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data plane with zone and FIPS with dualstack and AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--usw2-az1--xa-s3.s3express-fips-usw2-az1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--usw2-az1--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with zone and dualstack and AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--usw2-az1--xa-s3.s3express-usw2-az1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--usw2-az1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane AP sigv4 auth with zone and FIPS with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--usw2-az1--xa-s3.s3express-fips-usw2-az1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--usw2-az1--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with zone (9 char) and AP with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--usw2-az12--xa-s3.s3express-usw2-az12.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--usw2-az12--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with zone (9 char) and FIPS with AP and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--usw2-az12--xa-s3.s3express-fips-usw2-az12.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--usw2-az12--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with (9 char) zone and dualstack with AP",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--usw2-az12--xa-s3.s3express-usw2-az12.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--usw2-az12--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Access Point sigv4 auth with (9 char) zone and FIPS with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--usw2-az12--xa-s3.s3express-fips-usw2-az12.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--usw2-az12--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with zone (13 char) and AP with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test-zone-ab1--xa-s3.s3express-test-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test-zone-ab1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with zone (13 char) and AP with FIPS and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test-zone-ab1--xa-s3.s3express-fips-test-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test-zone-ab1--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with (13 char) zone with AP and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test-zone-ab1--xa-s3.s3express-test-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test-zone-ab1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with (13 char) zone with AP and FIPS and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test-zone-ab1--xa-s3.s3express-fips-test-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test-zone-ab1--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with (14 char) zone and AP with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-zone-ab1--xa-s3.s3express-test1-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-zone-ab1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with (14 char) zone and AP with FIPS and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-zone-ab1--xa-s3.s3express-fips-test1-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-zone-ab1--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane sigv4 auth with (14 char) zone and AP with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-zone-ab1--xa-s3.s3express-test1-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-zone-ab1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with (14 char) zone and AP with FIPS and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-zone-ab1--xa-s3.s3express-fips-test1-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-zone-ab1--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with (20 char) zone and AP with dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-long1-zone-ab1--xa-s3.s3express-test1-long1-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-long1-zone-ab1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data Plane with (20 char) zone and AP with FIPS and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4-s3express",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-long1-zone-ab1--xa-s3.s3express-fips-test1-long1-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-long1-zone-ab1--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": false
+                            }
+                        },
+                        {
+                            "documentation": "Data plane AP with sigv4 and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-long1-zone-ab1--xa-s3.s3express-test1-long1-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-long1-zone-ab1--xa-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Data plane AP sigv4 with fips and dualstack",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-west-2",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://myaccesspoint--test1-long1-zone-ab1--xa-s3.s3express-fips-test1-long1-zone-ab1.dualstack.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "Bucket": "myaccesspoint--test1-long1-zone-ab1--xa-s3",
+                                "UseFIPS": true,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "DisableS3ExpressSessionAuth": true
+                            }
+                        },
+                        {
+                            "documentation": "Control plane with dualstack and bucket",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "s3express",
+                                                "signingRegion": "us-east-1",
+                                                "disableDoubleEncoding": true
+                                            }
+                                        ],
+                                        "backend": "S3Express"
+                                    },
+                                    "url": "https://s3express-control.dualstack.us-east-1.amazonaws.com/mybucket--test-ab1--x-s3"
+                                }
+                            },
+                            "operationInputs": [
+                                {
+                                    "builtInParams": {
+                                        "AWS::Region": "us-east-1",
+                                        "AWS::UseDualStack": true
+                                    },
+                                    "operationName": "CreateBucket",
+                                    "operationParams": {
+                                        "Bucket": "mybucket--test-ab1--x-s3"
+                                    }
+                                }
+                            ],
+                            "params": {
+                                "Region": "us-east-1",
+                                "Bucket": "mybucket--test-ab1--x-s3",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Accelerate": false,
+                                "UseS3ExpressControlEndpoint": true
                             }
                         }
                     ],
@@ -28320,11 +37001,16 @@
                 "target": "com.amazonaws.s3#ListBucketMetricsConfigurationsOutput"
             },
             "traits": {
-                "smithy.api#documentation": "<note>\n            <p>This operation is not supported for directory buckets.</p>\n         </note>\n         <p>Lists the metrics configurations for the bucket. The metrics configurations are only for\n         the request metrics of the bucket and do not provide information on daily storage metrics.\n         You can have up to 1,000 configurations per bucket.</p>\n         <p>This action supports list pagination and does not return more than 100 configurations at\n         a time. Always check the <code>IsTruncated</code> element in the response. If there are no\n         more configurations to list, <code>IsTruncated</code> is set to false. If there are more\n         configurations to list, <code>IsTruncated</code> is set to true, and there is a value in\n            <code>NextContinuationToken</code>. You use the <code>NextContinuationToken</code> value\n         to continue the pagination of the list by passing the value in\n            <code>continuation-token</code> in the request to <code>GET</code> the next page.</p>\n         <p>To use this operation, you must have permissions to perform the\n            <code>s3:GetMetricsConfiguration</code> action. The bucket owner has this permission by\n         default. The bucket owner can grant this permission to others. For more information about\n         permissions, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources\">Permissions Related to Bucket Subresource Operations</a> and <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html\">Managing\n            Access Permissions to Your Amazon S3 Resources</a>.</p>\n         <p>For more information about metrics configurations and CloudWatch request metrics, see\n            <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html\">Monitoring Metrics with Amazon CloudWatch</a>.</p>\n         <p>The following operations are related to\n         <code>ListBucketMetricsConfigurations</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html\">PutBucketMetricsConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetricsConfiguration.html\">GetBucketMetricsConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetricsConfiguration.html\">DeleteBucketMetricsConfiguration</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#documentation": "<p>Lists the metrics configurations for the bucket. The metrics configurations are only for the request\n      metrics of the bucket and do not provide information on daily storage metrics. You can have up to 1,000\n      configurations per bucket.</p>\n         <note>\n            <p>\n               <b>Directory buckets </b> - For directory buckets, you must make requests for this API operation to the Regional endpoint. These endpoints support path-style requests in the format <code>https://s3express-control.<i>region-code</i>.amazonaws.com/<i>bucket-name</i>\n               </code>. Virtual-hosted-style requests aren't supported. \nFor more information about endpoints in Availability Zones, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/endpoint-directory-buckets-AZ.html\">Regional and Zonal endpoints for directory buckets in Availability Zones</a> in the\n    <i>Amazon S3 User Guide</i>. For more information about endpoints in Local Zones, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-lzs-for-directory-buckets.html\">Concepts for directory buckets in Local Zones</a> in the\n    <i>Amazon S3 User Guide</i>.</p>\n         </note>\n         <p>This action supports list pagination and does not return more than 100 configurations at a time.\n      Always check the <code>IsTruncated</code> element in the response. If there are no more configurations\n      to list, <code>IsTruncated</code> is set to false. If there are more configurations to list,\n        <code>IsTruncated</code> is set to true, and there is a value in <code>NextContinuationToken</code>.\n      You use the <code>NextContinuationToken</code> value to continue the pagination of the list by passing\n      the value in <code>continuation-token</code> in the request to <code>GET</code> the next page.</p>\n         <dl>\n            <dt>Permissions</dt>\n            <dd>\n               <p>To use this operation, you must have permissions to perform the\n              <code>s3:GetMetricsConfiguration</code> action. The bucket owner has this permission by default. The\n            bucket owner can grant this permission to others. For more information about permissions, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources\">Permissions Related to Bucket Subresource Operations</a> and <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html\">Managing Access Permissions to Your Amazon S3\n              Resources</a>.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <b>General purpose bucket permissions</b> - The\n                  <code>s3:GetMetricsConfiguration</code> permission is required in a policy. For more information\n                about general purpose buckets permissions, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html\">Using Bucket Policies and User\n                  Policies</a> in the <i>Amazon S3 User Guide</i>.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <b>Directory bucket permissions</b> - To grant access to\n                this API operation, you must have the <code>s3express:GetMetricsConfiguration</code> permission in\n                an IAM identity-based policy instead of a bucket policy. Cross-account access to this API operation isn't supported. This operation can only be performed by the Amazon Web Services account that owns the resource.\n                For more information about directory bucket policies and permissions, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-security-iam.html\">Amazon Web Services Identity and Access Management (IAM) for S3 Express One Zone</a> in the <i>Amazon S3 User Guide</i>.</p>\n                  </li>\n               </ul>\n            </dd>\n            <dt>HTTP Host header syntax</dt>\n            <dd>\n               <p>\n                  <b>Directory buckets </b> - The HTTP Host header syntax is <code>s3express-control.<i>region-code</i>.amazonaws.com</code>.</p>\n            </dd>\n         </dl>\n         <p>For more information about metrics configurations and CloudWatch request metrics, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html\">Monitoring Metrics with\n        Amazon CloudWatch</a>.</p>\n         <p>The following operations are related to <code>ListBucketMetricsConfigurations</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html\">PutBucketMetricsConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetricsConfiguration.html\">GetBucketMetricsConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetricsConfiguration.html\">DeleteBucketMetricsConfiguration</a>\n               </p>\n            </li>\n         </ul>\n         <important>\n            <p>You must URL encode any signed header values that contain spaces. For example, if your header value is <code>my  file.txt</code>, containing two spaces after <code>my</code>, you must URL encode this value to <code>my%20%20file.txt</code>.</p>\n         </important>",
                 "smithy.api#http": {
                     "method": "GET",
                     "uri": "/{Bucket}?metrics&x-id=ListBucketMetricsConfigurations",
                     "code": 200
+                },
+                "smithy.rules#staticContextParams": {
+                    "UseS3ExpressControlEndpoint": {
+                        "value": true
+                    }
                 }
             }
         },

--- a/data/s3.json
+++ b/data/s3.json
@@ -21688,6 +21688,13 @@
                         "smithy.api#httpQuery": "id",
                         "smithy.api#required": {}
                     }
+                },
+                "ExpectedBucketOwner": {
+                    "target": "com.amazonaws.s3#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code> (access denied).</p>",
+                        "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
+                    }
                 }
             },
             "traits": {
@@ -23804,6 +23811,13 @@
                         "smithy.api#documentation": "<p>The ID used to identify the S3 Intelligent-Tiering configuration.</p>",
                         "smithy.api#httpQuery": "id",
                         "smithy.api#required": {}
+                    }
+                },
+                "ExpectedBucketOwner": {
+                    "target": "com.amazonaws.s3#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code> (access denied).</p>",
+                        "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
                     }
                 }
             },
@@ -28191,8 +28205,15 @@
                 "ContinuationToken": {
                     "target": "com.amazonaws.s3#Token",
                     "traits": {
-                        "smithy.api#documentation": "<p>The <code>ContinuationToken</code> that represents a placeholder from where this request\n         should begin.</p>",
+                        "smithy.api#documentation": "<p>The <code>ContinuationToken</code> that represents a placeholder from where this request should\n      begin.</p>",
                         "smithy.api#httpQuery": "continuation-token"
+                    }
+                },
+                "ExpectedBucketOwner": {
+                    "target": "com.amazonaws.s3#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code> (access denied).</p>",
+                        "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
                     }
                 }
             },
@@ -31996,6 +32017,13 @@
                         "smithy.api#documentation": "<p>The ID used to identify the S3 Intelligent-Tiering configuration.</p>",
                         "smithy.api#httpQuery": "id",
                         "smithy.api#required": {}
+                    }
+                },
+                "ExpectedBucketOwner": {
+                    "target": "com.amazonaws.s3#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code> (access denied).</p>",
+                        "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
                     }
                 },
                 "IntelligentTieringConfiguration": {

--- a/data/s3.json
+++ b/data/s3.json
@@ -32451,9 +32451,10 @@
             },
             "traits": {
                 "aws.protocols#httpChecksum": {
+                    "requestAlgorithmMember": "ChecksumAlgorithm",
                     "requestChecksumRequired": true
                 },
-                "smithy.api#documentation": "<note>\n            <p>This operation is not supported for directory buckets.</p>\n         </note>\n         <p>Creates or modifies <code>OwnershipControls</code> for an Amazon S3 bucket. To use this\n         operation, you must have the <code>s3:PutBucketOwnershipControls</code> permission. For\n         more information about Amazon S3 permissions, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/user-guide/using-with-s3-actions.html\">Specifying permissions in a\n            policy</a>. </p>\n         <p>For information about Amazon S3 Object Ownership, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/user-guide/about-object-ownership.html\">Using object\n            ownership</a>. </p>\n         <p>The following operations are related to <code>PutBucketOwnershipControls</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a>GetBucketOwnershipControls</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DeleteBucketOwnershipControls</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#documentation": "<note>\n            <p>This operation is not supported for directory buckets.</p>\n         </note>\n         <p>Creates or modifies <code>OwnershipControls</code> for an Amazon S3 bucket. To use this operation, you\n      must have the <code>s3:PutBucketOwnershipControls</code> permission. For more information about Amazon S3\n      permissions, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/user-guide/using-with-s3-actions.html\">Specifying permissions in a policy</a>. </p>\n         <p>For information about Amazon S3 Object Ownership, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/user-guide/about-object-ownership.html\">Using object ownership</a>. </p>\n         <p>The following operations are related to <code>PutBucketOwnershipControls</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a>GetBucketOwnershipControls</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DeleteBucketOwnershipControls</a>\n               </p>\n            </li>\n         </ul>\n         <important>\n            <p>You must URL encode any signed header values that contain spaces. For example, if your header value is <code>my  file.txt</code>, containing two spaces after <code>my</code>, you must URL encode this value to <code>my%20%20file.txt</code>.</p>\n         </important>",
                 "smithy.api#http": {
                     "method": "PUT",
                     "uri": "/{Bucket}?ownershipControls",
@@ -32497,10 +32498,17 @@
                 "OwnershipControls": {
                     "target": "com.amazonaws.s3#OwnershipControls",
                     "traits": {
-                        "smithy.api#documentation": "<p>The <code>OwnershipControls</code> (BucketOwnerEnforced, BucketOwnerPreferred, or\n         ObjectWriter) that you want to apply to this Amazon S3 bucket.</p>",
+                        "smithy.api#documentation": "<p>The <code>OwnershipControls</code> (BucketOwnerEnforced, BucketOwnerPreferred, or ObjectWriter) that\n      you want to apply to this Amazon S3 bucket.</p>",
                         "smithy.api#httpPayload": {},
                         "smithy.api#required": {},
                         "smithy.api#xmlName": "OwnershipControls"
+                    }
+                },
+                "ChecksumAlgorithm": {
+                    "target": "com.amazonaws.s3#ChecksumAlgorithm",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Indicates the algorithm used to create the checksum for the object when you use the SDK. This\n      header will not provide any additional functionality if you don't use the SDK. When you send this\n      header, there must be a corresponding <code>x-amz-checksum-<i>algorithm</i>\n            </code> header\n      sent. Otherwise, Amazon S3 fails the request with the HTTP status code <code>400 Bad Request</code>. For more\n      information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking object integrity</a> in\n      the <i>Amazon S3 User Guide</i>.</p>\n         <p>If you provide an individual checksum, Amazon S3 ignores any provided <code>ChecksumAlgorithm</code>\n      parameter. </p>",
+                        "smithy.api#httpHeader": "x-amz-sdk-checksum-algorithm"
                     }
                 }
             },

--- a/data/s3.json
+++ b/data/s3.json
@@ -18739,6 +18739,12 @@
                         "smithy.api#enumValue": "ap-east-1"
                     }
                 },
+                "ap_east_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-east-2"
+                    }
+                },
                 "ap_northeast_1": {
                     "target": "smithy.api#Unit",
                     "traits": {
@@ -18799,10 +18805,28 @@
                         "smithy.api#enumValue": "ap-southeast-5"
                     }
                 },
+                "ap_southeast_6": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-6"
+                    }
+                },
+                "ap_southeast_7": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ap-southeast-7"
+                    }
+                },
                 "ca_central_1": {
                     "target": "smithy.api#Unit",
                     "traits": {
                         "smithy.api#enumValue": "ca-central-1"
+                    }
+                },
+                "ca_west_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ca-west-1"
                     }
                 },
                 "cn_north_1": {
@@ -18887,6 +18911,12 @@
                     "target": "smithy.api#Unit",
                     "traits": {
                         "smithy.api#enumValue": "me-south-1"
+                    }
+                },
+                "mx_central_1": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "mx-central-1"
                     }
                 },
                 "sa_east_1": {
@@ -30904,6 +30934,30 @@
                     "traits": {
                         "smithy.api#enumValue": "EXPRESS_ONEZONE"
                     }
+                },
+                "FSX_OPENZFS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FSX_OPENZFS"
+                    }
+                },
+                "FSX_ONTAP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FSX_ONTAP"
+                    }
+                },
+                "AWS_BACKUP_WARM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AWS_BACKUP_WARM"
+                    }
+                },
+                "AWS_BACKUP_LOW_COST_WARM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AWS_BACKUP_LOW_COST_WARM"
+                    }
                 }
             }
         },
@@ -35852,6 +35906,30 @@
                     "target": "smithy.api#Unit",
                     "traits": {
                         "smithy.api#enumValue": "EXPRESS_ONEZONE"
+                    }
+                },
+                "FSX_OPENZFS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FSX_OPENZFS"
+                    }
+                },
+                "FSX_ONTAP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FSX_ONTAP"
+                    }
+                },
+                "AWS_BACKUP_WARM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AWS_BACKUP_WARM"
+                    }
+                },
+                "AWS_BACKUP_LOW_COST_WARM": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AWS_BACKUP_LOW_COST_WARM"
                     }
                 }
             }

--- a/data/s3.json
+++ b/data/s3.json
@@ -27671,6 +27671,12 @@
                     "traits": {
                         "smithy.api#enumValue": "ObjectOwner"
                     }
+                },
+                "LifecycleExpirationDate": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "LifecycleExpirationDate"
+                    }
                 }
             }
         },


### PR DESCRIPTION
## Summary

Refresh `data/s3.json` from awslabs/aws-sdk-rust, advancing the model lock from `2c2a06e` (2025-02-14) toward `db89911` (2026-08-06). This PR covers the additive changes that introduce no new operations:

- aws-sdk-s3 1.138.0 → 1.143.0 (prerequisite: the new enum values in this PR and the new operations of later PRs only exist in newer SDK releases; existing generated code compiles unchanged)
- new bucket regions and FSx/AWS Backup storage classes
- `InventoryOptionalField.LifecycleExpirationDate`
- `ChecksumAlgorithm` on `PutBucketOwnershipControls` (request header plus matching `httpChecksum.requestAlgorithmMember` on the operation)
- `ExpectedBucketOwner` on the four IntelligentTiering configuration requests
- service-level traits: `smithy.rules#endpointBdd` on the service, `smithy.rules#staticContextParams` on `ListBucketMetricsConfigurations`

Every changed model shape is byte-identical to upstream `db89911`. No operations are added or removed; `S3Service` signatures are unchanged (only doc-comment updates).

Related: #676

## Changes

### `Cargo.toml` / `Cargo.lock`

- aws-sdk-s3 `1.138.0` → `1.143.0` (2026-08-20). aws-sdk-sts unchanged.

### `data/s3.json`

- `BucketLocationConstraint` +`ap-east-2`, `ap-southeast-6`, `ap-southeast-7`, `ca-west-1`, `mx-central-1`
- `ObjectStorageClass` / `StorageClass` +`AWS_BACKUP_LOW_COST_WARM`, `AWS_BACKUP_WARM`, `FSX_ONTAP`, `FSX_OPENZFS`
- `InventoryOptionalField` +`LifecycleExpirationDate`
- `PutBucketOwnershipControlsRequest` +`ChecksumAlgorithm` (`x-amz-sdk-checksum-algorithm`); operation gains `requestAlgorithmMember`
- `Put/Get/Delete/ListBucketIntelligentTieringConfigurationRequest` +`ExpectedBucketOwner` (`x-amz-expected-bucket-owner`)
- `AmazonS3` +`endpointBdd`; `ListBucketMetricsConfigurations` +`staticContextParams`

### Generated code (`just codegen`, aws + minio variants)

- dto: new enum constants and request fields
- xml: new enum parse arms
- ops: header deserialization for `ExpectedBucketOwner` / `ChecksumAlgorithm`
- s3s-aws conv/proxy: field wiring and new aws enum variant arms
- `s3_trait.rs`: refreshed doc comments (`list_bucket_metrics_configurations`, `put_bucket_ownership_controls`)

## Verification

- `just codegen` idempotent (second run produces no diff)
- `just lint` clean
- `just test` 915 passed
- changed model shapes verified byte-identical to upstream `db89911` (JSON-level comparison against the aws-sdk-rust raw file)

## Notes

- The `data/crawl.py` s3 lock intentionally stays at `2c2a06e`; running `just crawl` now would overwrite the partial update. The lock is bumped once the whole file is byte-identical to upstream.