### PR TITLE
perf(s3s): verify aws-chunked signatures as raw bytes

### DIFF
--- a/crates/s3s/src/http/aws_chunked_stream.rs
+++ b/crates/s3s/src/http/aws_chunked_stream.rs
@@ -12,6 +12,7 @@ use crate::sig_v4::AmzDate;
 use crate::sig_v4::create_trailer_string_to_sign;
 use crate::stream::{ByteStream, DynByteStream, RemainingLength};
 use crate::utils::SyncBoxFuture;
+use crate::utils::crypto::{Sha256Sum, hex_bytes32};
 
 use hyper::HeaderMap;
 use hyper::http::{HeaderName, HeaderValue};
@@ -72,7 +73,7 @@ struct SignatureCtx {
     secret_key: SecretKey,
 
     /// previous chunk's signature
-    prev_signature: Signature,
+    prev_signature: Sha256Sum,
 }
 
 /// [`AwsChunkedStream`]
@@ -142,15 +143,16 @@ fn parse_chunk_meta(mut input: &[u8]) -> nom::IResult<&[u8], ChunkMeta<'_>> {
 }
 
 /// check signature
-fn check_signature(ctx: &SignatureCtx, expected_signature: &[u8], chunk_data: &[Bytes]) -> Option<Signature> {
-    let expected_signature = Signature::from_hex(std::str::from_utf8(expected_signature).ok()?)?;
+fn check_signature(ctx: &SignatureCtx, expected_signature: &[u8], chunk_data: &[Bytes]) -> Option<Sha256Sum> {
+    let expected = Sha256Sum::from_hex(std::str::from_utf8(expected_signature).ok()?)?;
 
-    let string_to_sign =
-        sig_v4::create_chunk_string_to_sign(&ctx.amz_date, &ctx.region, &ctx.service, ctx.prev_signature.as_str(), chunk_data);
+    let string_to_sign = hex_bytes32(ctx.prev_signature.as_bytes(), |prev_signature| {
+        sig_v4::create_chunk_string_to_sign(&ctx.amz_date, &ctx.region, &ctx.service, prev_signature, chunk_data)
+    });
 
-    let chunk_signature = sig_v4::calculate_signature(&string_to_sign, &ctx.secret_key, &ctx.amz_date, &ctx.region, &ctx.service);
+    let signature = sig_v4::calculate_signature_raw(&string_to_sign, &ctx.secret_key, &ctx.amz_date, &ctx.region, &ctx.service);
 
-    Signature::compare(&chunk_signature, &expected_signature).then_some(chunk_signature)
+    (expected == signature).then_some(signature)
 }
 
 impl AwsChunkedStream {
@@ -177,12 +179,15 @@ impl AwsChunkedStream {
                 pin_mut!(body);
                 let mut prev_bytes = Bytes::new();
                 let mut buf: Vec<u8> = Vec::new();
+                let Some(prev_signature) = Sha256Sum::from_hex(seed_signature.as_str()) else {
+                    unreachable!("invariant: Signature holds canonical lowercase hex");
+                };
                 let mut ctx = SignatureCtx {
                     amz_date,
                     region,
                     service,
                     secret_key,
-                    prev_signature: seed_signature,
+                    prev_signature,
                 };
 
                 loop {
@@ -327,20 +332,16 @@ impl AwsChunkedStream {
 
         // Verify the trailer signature if present, or require it when unsigned=false
         if let Some(provided) = provided_signature.as_ref() {
-            let Some(provided) = std::str::from_utf8(provided).ok().and_then(Signature::from_hex) else {
+            let Some(provided) = std::str::from_utf8(provided).ok().and_then(Sha256Sum::from_hex) else {
                 return Some(Err(AwsChunkedStreamError::SignatureMismatch));
             };
 
-            let string_to_sign = create_trailer_string_to_sign(
-                &ctx.amz_date,
-                &ctx.region,
-                &ctx.service,
-                ctx.prev_signature.as_str(),
-                &canonical_trailers,
-            );
-            let trailer_signature =
-                sig_v4::calculate_signature(&string_to_sign, &ctx.secret_key, &ctx.amz_date, &ctx.region, &ctx.service);
-            if !Signature::compare(&trailer_signature, &provided) {
+            let string_to_sign = hex_bytes32(ctx.prev_signature.as_bytes(), |prev_signature| {
+                create_trailer_string_to_sign(&ctx.amz_date, &ctx.region, &ctx.service, prev_signature, &canonical_trailers)
+            });
+            let signature =
+                sig_v4::calculate_signature_raw(&string_to_sign, &ctx.secret_key, &ctx.amz_date, &ctx.region, &ctx.service);
+            if provided != signature {
                 return Some(Err(AwsChunkedStreamError::SignatureMismatch));
             }
         } else if !unsigned {

--- a/crates/s3s/src/http/aws_chunked_stream.rs
+++ b/crates/s3s/src/http/aws_chunked_stream.rs
@@ -4,7 +4,6 @@
 //! aws-chunked stream
 
 use crate::auth::SecretKey;
-use crate::auth::signature::Signature;
 use crate::error::StdError;
 use crate::protocol::TrailingHeaders;
 use crate::sig_v4;
@@ -160,7 +159,7 @@ impl AwsChunkedStream {
     #[allow(clippy::too_many_arguments)]
     pub fn new<S>(
         body: S,
-        seed_signature: Signature,
+        seed_signature: Sha256Sum,
         amz_date: AmzDate,
         region: Box<str>,
         service: Box<str>,
@@ -179,15 +178,12 @@ impl AwsChunkedStream {
                 pin_mut!(body);
                 let mut prev_bytes = Bytes::new();
                 let mut buf: Vec<u8> = Vec::new();
-                let Some(prev_signature) = Sha256Sum::from_hex(seed_signature.as_str()) else {
-                    unreachable!("invariant: Signature holds canonical lowercase hex");
-                };
                 let mut ctx = SignatureCtx {
                     amz_date,
                     region,
                     service,
                     secret_key,
-                    prev_signature,
+                    prev_signature: seed_signature,
                 };
 
                 loop {
@@ -650,7 +646,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            Signature::from_hex(seed_signature).unwrap(),
+            Sha256Sum::from_hex(seed_signature).unwrap(),
             date,
             region.into(),
             service.into(),
@@ -704,7 +700,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            Signature::from_hex(seed_signature).unwrap(),
+            Sha256Sum::from_hex(seed_signature).unwrap(),
             date,
             region.into(),
             service.into(),
@@ -768,7 +764,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            Signature::from_hex(seed_signature).unwrap(),
+            Sha256Sum::from_hex(seed_signature).unwrap(),
             date,
             region.into(),
             service.into(),
@@ -820,7 +816,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            Signature::from_hex(seed_signature).unwrap(),
+            Sha256Sum::from_hex(seed_signature).unwrap(),
             date,
             region.into(),
             service.into(),
@@ -855,7 +851,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            Signature::from_hex(seed_signature).unwrap(),
+            Sha256Sum::from_hex(seed_signature).unwrap(),
             date,
             "us-east-1".into(),
             "s3".into(),
@@ -881,7 +877,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            Signature::from_hex(seed_signature).unwrap(),
+            Sha256Sum::from_hex(seed_signature).unwrap(),
             date,
             "us-east-1".into(),
             "s3".into(),
@@ -910,7 +906,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            Signature::from_hex(seed_signature).unwrap(),
+            Sha256Sum::from_hex(seed_signature).unwrap(),
             date,
             "us-east-1".into(),
             "s3".into(),
@@ -939,7 +935,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            Signature::from_hex(seed_signature).unwrap(),
+            Sha256Sum::from_hex(seed_signature).unwrap(),
             date,
             "us-east-1".into(),
             "s3".into(),
@@ -968,7 +964,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            Signature::from_hex(seed_signature).unwrap(),
+            Sha256Sum::from_hex(seed_signature).unwrap(),
             date,
             "us-east-1".into(),
             "s3".into(),
@@ -1006,7 +1002,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            Signature::from_hex(seed_signature).unwrap(),
+            Sha256Sum::from_hex(seed_signature).unwrap(),
             date,
             "us-east-1".into(),
             "s3".into(),
@@ -1039,7 +1035,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            Signature::from_hex(seed_signature).unwrap(),
+            Sha256Sum::from_hex(seed_signature).unwrap(),
             date,
             "us-east-1".into(),
             "s3".into(),
@@ -1076,7 +1072,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            Signature::from_hex(seed_signature).unwrap(),
+            Sha256Sum::from_hex(seed_signature).unwrap(),
             date,
             "us-east-1".into(),
             "s3".into(),
@@ -1135,7 +1131,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            Signature::from_hex(seed_signature).unwrap(),
+            Sha256Sum::from_hex(seed_signature).unwrap(),
             date,
             region.into(),
             service.into(),
@@ -1177,7 +1173,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            Signature::from_hex(seed_signature).unwrap(),
+            Sha256Sum::from_hex(seed_signature).unwrap(),
             date,
             region.into(),
             service.into(),
@@ -1236,7 +1232,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            Signature::from_hex(seed_signature).unwrap(),
+            Sha256Sum::from_hex(seed_signature).unwrap(),
             date,
             region.into(),
             service.into(),
@@ -1321,7 +1317,7 @@ mod tests {
         let stream = futures::stream::iter(chunk_results);
         let mut chunked_stream = AwsChunkedStream::new(
             stream,
-            Signature::from_hex(seed_signature).unwrap(),
+            Sha256Sum::from_hex(seed_signature).unwrap(),
             date,
             region.into(),
             service.into(),

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -19,6 +19,7 @@ use crate::sig_v4::AmzDate;
 use crate::sig_v4::UploadStream;
 use crate::sig_v4::{AuthorizationV4, CredentialV4, PostSignatureV4, PresignedUrlV4};
 use crate::stream::ByteStream as _;
+use crate::utils::crypto::Sha256Sum;
 use crate::utils::crypto::hex_sha256;
 use crate::utils::is_base64_encoded;
 
@@ -627,9 +628,11 @@ impl SignatureContext<'_> {
                 .ok_or_else(|| s3_error!(MissingContentLength, "missing header: x-amz-decoded-content-length"))?;
 
             let unsigned = matches!(amz_content_sha256, Some(AmzContentSha256::StreamingUnsignedPayloadTrailer));
+            let seed_signature = Sha256Sum::from_hex(signature.as_str())
+                .ok_or_else(|| s3_error!(InternalError, "verified request signature is not canonical hex"))?;
             let stream = AwsChunkedStream::new(
                 mem::take(self.req_body),
-                signature,
+                seed_signature,
                 amz_date,
                 region.into(),
                 service.into(),

--- a/crates/s3s/src/sig_v4/methods.rs
+++ b/crates/s3s/src/sig_v4/methods.rs
@@ -8,7 +8,7 @@ use super::AmzDate;
 use crate::auth::SecretKey;
 use crate::auth::signature::Signature;
 use crate::http::OrderedHeaders;
-use crate::utils::crypto::{hex, hex_sha256, hex_sha256_chunk, hmac_sha256};
+use crate::utils::crypto::{Sha256Sum, hex, hex_sha256, hex_sha256_chunk, hmac_sha256};
 use crate::utils::stable_sort_by_first;
 
 use hyper::Method;
@@ -390,15 +390,11 @@ pub fn create_trailer_string_to_sign(
     ans
 }
 
-/// calculate signature
+/// derive the `SigV4` signing key
+///
+/// `kSigning = HMAC(HMAC(HMAC(HMAC("AWS4" + secret, date), region), service), "aws4_request")`
 #[must_use]
-pub fn calculate_signature(
-    string_to_sign: &str,
-    secret_key: &SecretKey,
-    amz_date: &AmzDate,
-    region: &str,
-    service: &str,
-) -> Signature {
+pub(crate) fn derive_signing_key(secret_key: &SecretKey, amz_date: &AmzDate, region: &str, service: &str) -> [u8; 32] {
     let mut secret = {
         let secret_key = secret_key.expose();
         let mut buf = <SmallVec<[u8; 128]>>::with_capacity(secret_key.len().saturating_add(4));
@@ -421,10 +417,33 @@ pub fn calculate_signature(
     let date_region_service_key = hmac_sha256(date_region_key, service);
 
     // SigningKey
-    let signing_key = hmac_sha256(date_region_service_key, "aws4_request");
+    hmac_sha256(date_region_service_key, "aws4_request")
+}
 
-    // Signature
+/// calculate signature
+#[must_use]
+pub fn calculate_signature(
+    string_to_sign: &str,
+    secret_key: &SecretKey,
+    amz_date: &AmzDate,
+    region: &str,
+    service: &str,
+) -> Signature {
+    let signing_key = derive_signing_key(secret_key, amz_date, region, service);
     Signature::from_computed(hex(hmac_sha256(signing_key, string_to_sign)))
+}
+
+/// calculate signature as raw bytes
+#[must_use]
+pub(crate) fn calculate_signature_raw(
+    string_to_sign: &str,
+    secret_key: &SecretKey,
+    amz_date: &AmzDate,
+    region: &str,
+    service: &str,
+) -> Sha256Sum {
+    let signing_key = derive_signing_key(secret_key, amz_date, region, service);
+    Sha256Sum::from_bytes(hmac_sha256(signing_key, string_to_sign))
 }
 
 fn create_presigned_canonical_request_with_uri_mode(
@@ -814,6 +833,27 @@ mod tests {
             chunk3_signature.as_str(),
             "b6c6ea8a5354eaf15b3cb7646744f4275b71ea724fed81ceb9323e279d449df9"
         );
+    }
+
+    #[test]
+    fn calculate_signature_raw_matches_calculate_signature() {
+        use crate::utils::crypto::Sha256Sum;
+
+        let secret_access_key = SecretKey::from("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+        let timestamp = "20130524T000000Z";
+        let region = "us-east-1";
+        let service = "s3";
+        let date = AmzDate::parse(timestamp).unwrap();
+
+        let seed_signature = "4f232c4386841ef735655705268965c44a0e4690baa4adea153f7db9fa80a0a9";
+        let string_to_sign =
+            create_chunk_string_to_sign(&date, region, service, seed_signature, &[Bytes::from(vec![b'a'; 64 * 1024])]);
+
+        let signature = calculate_signature(&string_to_sign, &secret_access_key, &date, region, service);
+        let raw = calculate_signature_raw(&string_to_sign, &secret_access_key, &date, region, service);
+
+        let expected = Sha256Sum::from_hex(signature.as_str()).unwrap();
+        assert_eq!(expected, raw);
     }
 
     #[test]

--- a/crates/s3s/src/utils/crypto.rs
+++ b/crates/s3s/src/utils/crypto.rs
@@ -7,8 +7,18 @@ use hex_simd::{AsOut, AsciiCase};
 use hyper::body::Bytes;
 
 /// A normalized SHA-256 digest.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// [`PartialEq`] compares in constant time.
+#[derive(Debug, Clone, Copy)]
 pub struct Sha256Sum([u8; 32]);
+
+impl PartialEq for Sha256Sum {
+    fn eq(&self, other: &Self) -> bool {
+        self.ct_equal(other)
+    }
+}
+
+impl Eq for Sha256Sum {}
 
 impl Sha256Sum {
     /// Parses a lowercase hexadecimal SHA-256 digest.
@@ -44,6 +54,21 @@ impl Sha256Sum {
     pub fn to_hex_string(self) -> String {
         hex(self.0)
     }
+
+    /// Returns the raw digest bytes.
+    #[must_use]
+    pub(crate) const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Returns whether the digest equals `other` in constant time.
+    ///
+    /// [`PartialEq`] is implemented in constant time through this method.
+    #[must_use]
+    pub fn ct_equal(&self, other: &Sha256Sum) -> bool {
+        use subtle::ConstantTimeEq;
+        bool::from(self.0.ct_eq(&other.0))
+    }
 }
 
 /// verify sha256 checksum string
@@ -78,7 +103,7 @@ pub fn hex(data: impl AsRef<[u8]>) -> String {
 }
 
 /// `f(hex(src))`
-fn hex_bytes32<R>(src: impl AsRef<[u8]>, f: impl FnOnce(&str) -> R) -> R {
+pub(crate) fn hex_bytes32<R>(src: impl AsRef<[u8]>, f: impl FnOnce(&str) -> R) -> R {
     let buf: &mut [_] = &mut [MaybeUninit::uninit(); 64];
     let ans = hex_simd::encode_as_str(src.as_ref(), buf.as_out(), AsciiCase::Lower);
     f(ans)

--- a/crates/s3s/src/utils/crypto.rs
+++ b/crates/s3s/src/utils/crypto.rs
@@ -103,54 +103,60 @@ pub fn hex(data: impl AsRef<[u8]>) -> String {
 }
 
 /// `f(hex(src))`
-pub(crate) fn hex_bytes32<R>(src: impl AsRef<[u8]>, f: impl FnOnce(&str) -> R) -> R {
+pub(crate) fn hex_bytes32<R>(src: &[u8; 32], f: impl FnOnce(&str) -> R) -> R {
     let buf: &mut [_] = &mut [MaybeUninit::uninit(); 64];
     let ans = hex_simd::encode_as_str(src.as_ref(), buf.as_out(), AsciiCase::Lower);
     f(ans)
 }
 
 #[cfg(not(all(feature = "openssl", not(windows))))]
-fn sha256(data: &[u8]) -> impl AsRef<[u8; 32]> + use<> {
+fn sha256(data: &[u8]) -> [u8; 32] {
     use sha2::{Digest, Sha256};
-    <Sha256 as Digest>::digest(data)
+    <Sha256 as Digest>::digest(data).into()
 }
 
 #[cfg(all(feature = "openssl", not(windows)))]
-fn sha256(data: &[u8]) -> impl AsRef<[u8]> {
+fn sha256(data: &[u8]) -> [u8; 32] {
     use openssl::hash::{Hasher, MessageDigest};
     let mut h = Hasher::new(MessageDigest::sha256()).unwrap();
     h.update(data).unwrap();
-    h.finish().unwrap()
+    let digest = h.finish().unwrap();
+    let mut ans = [0_u8; 32];
+    ans.copy_from_slice(&digest);
+    ans
 }
 
 #[cfg(not(all(feature = "openssl", not(windows))))]
-fn sha256_chunk(chunk: &[Bytes]) -> impl AsRef<[u8; 32]> + use<> {
+fn sha256_chunk(chunk: &[Bytes]) -> [u8; 32] {
     use sha2::{Digest, Sha256};
     let mut h = <Sha256 as Digest>::new();
     for data in chunk {
         h.update(data);
     }
-    h.finalize()
+    h.finalize().into()
 }
 
 #[cfg(all(feature = "openssl", not(windows)))]
-fn sha256_chunk(chunk: &[Bytes]) -> impl AsRef<[u8]> {
+fn sha256_chunk(chunk: &[Bytes]) -> [u8; 32] {
     use openssl::hash::{Hasher, MessageDigest};
     let mut h = Hasher::new(MessageDigest::sha256()).unwrap();
     for data in chunk {
         h.update(data).unwrap();
     }
-    h.finish().unwrap()
+    let digest = h.finish().unwrap();
+    let mut ans = [0_u8; 32];
+    ans.copy_from_slice(&digest);
+    ans
 }
 
 /// `f(hex(sha256(data)))`
 pub fn hex_sha256<R>(data: &[u8], f: impl FnOnce(&str) -> R) -> R {
-    hex_bytes32(sha256(data).as_ref(), f)
+    hex_bytes32(&sha256(data), f)
 }
 
 /// `f(hex(sha256(chunk)))`
 pub fn hex_sha256_chunk<R>(chunk: &[Bytes], f: impl FnOnce(&str) -> R) -> R {
-    hex_bytes32(sha256_chunk(chunk).as_ref(), f)
+    hex_bytes32(&sha256_chunk(chunk), f)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Reduces the per-chunk overhead of SigV4 streaming verification for aws-chunked uploads.

`AwsChunkedStream` currently verifies each aws-chunked chunk signature by hex-encoding the computed HMAC-SHA256, wrapping both sides in `Signature` (64-char hex strings), and comparing the hex forms. This PR keeps verification in raw bytes: the computed signature stays a 32-byte value, the expected signature is decoded once per chunk, and the comparison runs in constant time over raw bytes via `subtle`. The previous signature is kept raw and hex-encoded on demand (into a stack buffer) only when embedding it in the next `string_to_sign`.

This also sets the stage for caching the derived SigV4 signing key: `derive_signing_key` is extracted so the per-chunk path can later reuse a cached key with a small follow-up change.

## Changes

- `sig_v4/methods.rs`
  - Extract `derive_signing_key(secret, date, region, service) -> [u8; 32]` (the `kDate`/`kRegion`/`kService`/`kSigning` chain, unchanged logic).
  - Add `calculate_signature_raw(...) -> Sha256Sum` (final HMAC without hex encoding).
  - Public `calculate_signature` is a thin wrapper and keeps its signature — no public API change.
- `http/aws_chunked_stream.rs`
  - `SignatureCtx.prev_signature` becomes `Sha256Sum` instead of `Signature`/hex; `AwsChunkedStream::new` now takes the seed as a decoded `Sha256Sum`, and the single call site (`ops/signature.rs`) decodes the verified request signature with proper error handling instead of panicking.
  - `check_signature` now returns `Option<Sha256Sum>`; chunk and trailer verification compare raw digests in constant time (`==` / `!=` on `Sha256Sum`).
  - `hex_bytes32` hex-encodes the previous signature into a stack buffer only when building the chunk/trailer `string_to_sign` — no heap allocation per chunk beyond the `string_to_sign` `String` itself.
- `utils/crypto.rs`
  - `Sha256Sum` gains `ct_equal(&self, other: &Sha256Sum) -> bool` (constant-time, backed by `subtle::ConstantTimeEq`).
  - `PartialEq`/`Eq` are hand-implemented on top of `ct_equal`, so plain `==` on `Sha256Sum` is constant-time by construction (guards against accidental non-constant-time comparisons in secret contexts, same discipline as #659).
  - Add `as_bytes` accessor and widen `hex_bytes32` to `pub(crate)`, with its input constrained to `&[u8; 32]` so the 64-byte stack buffer is always exactly sized; the sha2/openssl backends now return `[u8; 32]` concretely instead of `impl AsRef`.

## Impact

- No observable behavior change: same verification semantics, `SignatureMismatch` paths unchanged (covered by existing AWS-doc test vectors and mismatch tests).
- No public API change: `utils` and `sig_v4` are crate-private modules; the only public `calculate_signature` keeps its signature (semver-checks pending confirmation).
- Per chunk: expected-signature decoding no longer allocates (`Sha256Sum::from_hex` decodes into a stack array), the computed signature is no longer hex-encoded for comparison, and the previous-signature chain avoids per-chunk `Box<str>` wrapping.

## Verification

- `just dev` (fetch → fmt → codegen → lint → test) — passes end-to-end, working tree clean after codegen (`just assert_unchanged`).
- `cargo fmt --all --check` — clean.
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean.
- `just test` (= `cargo test --workspace --all-features --all-targets`) — all green: s3s lib 825 passed / 3 ignored (including the AWS documentation vectors for aws-chunked chunk/trailer signatures and the signature-mismatch cases), workspace-wide 0 failed.
- New equivalence test `calculate_signature_raw_matches_calculate_signature` pins that the raw path matches the hex path on the AWS vector.
- `just codegen` + `just assert_unchanged` — idempotent, working tree clean.
- `just semver-checks` — pending (requires published crates.io baselines).
- E2E — handled by CI; not run locally (per repo policy).
