### PR TITLE
feat(data): add RenameObject operation to S3 model

### DIFF
--- a/crates/s3s-aws/src/conv/generated.rs
+++ b/crates/s3s-aws/src/conv/generated.rs
@@ -4188,6 +4188,22 @@ impl AwsConversion for s3s::dto::HeadObjectOutput {
     }
 }
 
+impl AwsConversion for s3s::dto::IdempotencyParameterMismatch {
+    type Target = aws_sdk_s3::types::error::IdempotencyParameterMismatch;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
+    }
+}
+
 impl AwsConversion for s3s::dto::IndexDocument {
     type Target = aws_sdk_s3::types::IndexDocument;
     type Error = S3Error;
@@ -7941,6 +7957,61 @@ impl AwsConversion for s3s::dto::RedirectAllRequestsTo {
         y = y.set_host_name(Some(try_into_aws(x.host_name)?));
         y = y.set_protocol(try_into_aws(x.protocol)?);
         y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::RenameObjectInput {
+    type Target = aws_sdk_s3::operation::rename_object::RenameObjectInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            client_token: try_from_aws(x.client_token)?,
+            destination_if_match: try_from_aws(x.destination_if_match)?,
+            destination_if_modified_since: try_from_aws(x.destination_if_modified_since)?,
+            destination_if_none_match: try_from_aws(x.destination_if_none_match)?,
+            destination_if_unmodified_since: try_from_aws(x.destination_if_unmodified_since)?,
+            key: unwrap_from_aws(x.key, "key")?,
+            rename_source: unwrap_from_aws(x.rename_source, "rename_source")?,
+            source_if_match: try_from_aws(x.source_if_match)?,
+            source_if_modified_since: try_from_aws(x.source_if_modified_since)?,
+            source_if_none_match: try_from_aws(x.source_if_none_match)?,
+            source_if_unmodified_since: try_from_aws(x.source_if_unmodified_since)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_client_token(try_into_aws(x.client_token)?);
+        y = y.set_destination_if_match(try_into_aws(x.destination_if_match)?);
+        y = y.set_destination_if_modified_since(try_into_aws(x.destination_if_modified_since)?);
+        y = y.set_destination_if_none_match(try_into_aws(x.destination_if_none_match)?);
+        y = y.set_destination_if_unmodified_since(try_into_aws(x.destination_if_unmodified_since)?);
+        y = y.set_key(Some(try_into_aws(x.key)?));
+        y = y.set_rename_source(Some(try_into_aws(x.rename_source)?));
+        y = y.set_source_if_match(try_into_aws(x.source_if_match)?);
+        y = y.set_source_if_modified_since(try_into_aws(x.source_if_modified_since)?);
+        y = y.set_source_if_none_match(try_into_aws(x.source_if_none_match)?);
+        y = y.set_source_if_unmodified_since(try_into_aws(x.source_if_unmodified_since)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::RenameObjectOutput {
+    type Target = aws_sdk_s3::operation::rename_object::RenameObjectOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
     }
 }
 

--- a/crates/s3s-aws/src/conv/generated_minio.rs
+++ b/crates/s3s-aws/src/conv/generated_minio.rs
@@ -4192,6 +4192,22 @@ impl AwsConversion for s3s::dto::HeadObjectOutput {
     }
 }
 
+impl AwsConversion for s3s::dto::IdempotencyParameterMismatch {
+    type Target = aws_sdk_s3::types::error::IdempotencyParameterMismatch;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
+    }
+}
+
 impl AwsConversion for s3s::dto::IndexDocument {
     type Target = aws_sdk_s3::types::IndexDocument;
     type Error = S3Error;
@@ -7949,6 +7965,61 @@ impl AwsConversion for s3s::dto::RedirectAllRequestsTo {
         y = y.set_host_name(Some(try_into_aws(x.host_name)?));
         y = y.set_protocol(try_into_aws(x.protocol)?);
         y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::RenameObjectInput {
+    type Target = aws_sdk_s3::operation::rename_object::RenameObjectInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            client_token: try_from_aws(x.client_token)?,
+            destination_if_match: try_from_aws(x.destination_if_match)?,
+            destination_if_modified_since: try_from_aws(x.destination_if_modified_since)?,
+            destination_if_none_match: try_from_aws(x.destination_if_none_match)?,
+            destination_if_unmodified_since: try_from_aws(x.destination_if_unmodified_since)?,
+            key: unwrap_from_aws(x.key, "key")?,
+            rename_source: unwrap_from_aws(x.rename_source, "rename_source")?,
+            source_if_match: try_from_aws(x.source_if_match)?,
+            source_if_modified_since: try_from_aws(x.source_if_modified_since)?,
+            source_if_none_match: try_from_aws(x.source_if_none_match)?,
+            source_if_unmodified_since: try_from_aws(x.source_if_unmodified_since)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_client_token(try_into_aws(x.client_token)?);
+        y = y.set_destination_if_match(try_into_aws(x.destination_if_match)?);
+        y = y.set_destination_if_modified_since(try_into_aws(x.destination_if_modified_since)?);
+        y = y.set_destination_if_none_match(try_into_aws(x.destination_if_none_match)?);
+        y = y.set_destination_if_unmodified_since(try_into_aws(x.destination_if_unmodified_since)?);
+        y = y.set_key(Some(try_into_aws(x.key)?));
+        y = y.set_rename_source(Some(try_into_aws(x.rename_source)?));
+        y = y.set_source_if_match(try_into_aws(x.source_if_match)?);
+        y = y.set_source_if_modified_since(try_into_aws(x.source_if_modified_since)?);
+        y = y.set_source_if_none_match(try_into_aws(x.source_if_none_match)?);
+        y = y.set_source_if_unmodified_since(try_into_aws(x.source_if_unmodified_since)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::RenameObjectOutput {
+    type Target = aws_sdk_s3::operation::rename_object::RenameObjectOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
     }
 }
 

--- a/crates/s3s-aws/src/proxy/generated.rs
+++ b/crates/s3s-aws/src/proxy/generated.rs
@@ -2423,6 +2423,38 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, req))]
+    async fn rename_object(
+        &self,
+        req: S3Request<s3s::dto::RenameObjectInput>,
+    ) -> S3Result<S3Response<s3s::dto::RenameObjectOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.rename_object();
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_client_token(try_into_aws(input.client_token)?);
+        b = b.set_destination_if_match(try_into_aws(input.destination_if_match)?);
+        b = b.set_destination_if_modified_since(try_into_aws(input.destination_if_modified_since)?);
+        b = b.set_destination_if_none_match(try_into_aws(input.destination_if_none_match)?);
+        b = b.set_destination_if_unmodified_since(try_into_aws(input.destination_if_unmodified_since)?);
+        b = b.set_key(Some(try_into_aws(input.key)?));
+        b = b.set_rename_source(Some(try_into_aws(input.rename_source)?));
+        b = b.set_source_if_match(try_into_aws(input.source_if_match)?);
+        b = b.set_source_if_modified_since(try_into_aws(input.source_if_modified_since)?);
+        b = b.set_source_if_none_match(try_into_aws(input.source_if_none_match)?);
+        b = b.set_source_if_unmodified_since(try_into_aws(input.source_if_unmodified_since)?);
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
     async fn restore_object(
         &self,
         req: S3Request<s3s::dto::RestoreObjectInput>,

--- a/crates/s3s-aws/src/proxy/generated_minio.rs
+++ b/crates/s3s-aws/src/proxy/generated_minio.rs
@@ -2423,6 +2423,38 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, req))]
+    async fn rename_object(
+        &self,
+        req: S3Request<s3s::dto::RenameObjectInput>,
+    ) -> S3Result<S3Response<s3s::dto::RenameObjectOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.rename_object();
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_client_token(try_into_aws(input.client_token)?);
+        b = b.set_destination_if_match(try_into_aws(input.destination_if_match)?);
+        b = b.set_destination_if_modified_since(try_into_aws(input.destination_if_modified_since)?);
+        b = b.set_destination_if_none_match(try_into_aws(input.destination_if_none_match)?);
+        b = b.set_destination_if_unmodified_since(try_into_aws(input.destination_if_unmodified_since)?);
+        b = b.set_key(Some(try_into_aws(input.key)?));
+        b = b.set_rename_source(Some(try_into_aws(input.rename_source)?));
+        b = b.set_source_if_match(try_into_aws(input.source_if_match)?);
+        b = b.set_source_if_modified_since(try_into_aws(input.source_if_modified_since)?);
+        b = b.set_source_if_none_match(try_into_aws(input.source_if_none_match)?);
+        b = b.set_source_if_unmodified_since(try_into_aws(input.source_if_unmodified_since)?);
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
     async fn restore_object(
         &self,
         req: S3Request<s3s::dto::RestoreObjectInput>,

--- a/crates/s3s/src/access/generated.rs
+++ b/crates/s3s/src/access/generated.rs
@@ -757,6 +757,13 @@ pub trait S3Access: Send + Sync + 'static {
         Ok(())
     }
 
+    /// Checks whether the RenameObject request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn rename_object(&self, _req: &mut S3Request<RenameObjectInput>) -> S3Result<()> {
+        Ok(())
+    }
+
     /// Checks whether the RestoreObject request has accesses to the resources.
     ///
     /// This method returns `Ok(())` by default.

--- a/crates/s3s/src/access/generated_minio.rs
+++ b/crates/s3s/src/access/generated_minio.rs
@@ -757,6 +757,13 @@ pub trait S3Access: Send + Sync + 'static {
         Ok(())
     }
 
+    /// Checks whether the RenameObject request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn rename_object(&self, _req: &mut S3Request<RenameObjectInput>) -> S3Result<()> {
+        Ok(())
+    }
+
     /// Checks whether the RestoreObject request has accesses to the resources.
     ///
     /// This method returns `Ok(())` by default.

--- a/crates/s3s/src/dto/generated.rs
+++ b/crates/s3s/src/dto/generated.rs
@@ -1380,6 +1380,8 @@ pub type ChecksumXXHASH3 = String;
 
 pub type ChecksumXXHASH64 = String;
 
+pub type ClientToken = String;
+
 pub type Code = String;
 
 pub type Comments = String;
@@ -11040,6 +11042,23 @@ pub type HttpRedirectCode = String;
 
 pub type ID = String;
 
+/// <p>Parameters on this idempotent request are inconsistent with parameters used in previous request(s). </p>
+/// <p>For a list of error codes and more information on Amazon S3 errors, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList">Error codes</a>.</p>
+/// <note>
+/// <p>Idempotency ensures that an API request completes no more than one time. With an idempotent
+/// request, if the original request completes successfully, any subsequent retries complete successfully
+/// without performing any further actions.</p>
+/// </note>
+#[derive(Clone, Default, PartialEq)]
+pub struct IdempotencyParameterMismatch {}
+
+impl fmt::Debug for IdempotencyParameterMismatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("IdempotencyParameterMismatch");
+        d.finish_non_exhaustive()
+    }
+}
+
 pub type IfMatch = ETagCondition;
 
 pub type IfMatchInitiatedTime = Timestamp;
@@ -19298,6 +19317,126 @@ impl fmt::Debug for RedirectAllRequestsTo {
 
 pub type Region = String;
 
+#[derive(Clone, Default, PartialEq)]
+pub struct RenameObjectInput {
+    /// <p>The bucket name of the directory bucket containing the object.</p>
+    /// <p> You must use virtual-hosted-style requests in the format
+    /// <code>Bucket-name.s3express-zone-id.region-code.amazonaws.com</code>. Path-style requests are not
+    /// supported. Directory bucket names must be unique in the chosen Availability Zone. Bucket names must
+    /// follow the format <code>bucket-base-name--zone-id--x-s3 </code> (for example,
+    /// <code>amzn-s3-demo-bucket--usw2-az1--x-s3</code>). For information about bucket naming restrictions, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html">Directory bucket naming rules</a> in the <i>Amazon S3 User Guide</i>.</p>
+    pub bucket: BucketName,
+    /// <p> A unique string with a max of 64 ASCII characters in the ASCII range of 33 - 126.</p>
+    /// <note>
+    /// <p>
+    /// <code>RenameObject</code> supports idempotency using a client token. To make an idempotent API request
+    /// using <code>RenameObject</code>, specify a client token in the request. You should not reuse the same
+    /// client token for other API requests. If you retry a request that completed successfully using the same
+    /// client token and the same parameters, the retry succeeds without performing any further actions. If
+    /// you retry a successful request using the same client token, but one or more of the parameters are
+    /// different, the retry fails and an <code>IdempotentParameterMismatch</code> error is returned. </p>
+    /// </note>
+    pub client_token: Option<ClientToken>,
+    /// <p>Renames the object only if the ETag (entity tag) value provided during the operation matches the
+    /// ETag of the object in S3. The <code>If-Match</code> header field makes the request method conditional on
+    /// ETags. If the ETag values do not match, the operation returns a <code>412 Precondition Failed</code>
+    /// error.</p>
+    /// <p>Expects the ETag value as a string.</p>
+    pub destination_if_match: Option<IfMatch>,
+    /// <p>Renames the object if the destination exists and if it has been modified since the specified
+    /// time.</p>
+    pub destination_if_modified_since: Option<IfModifiedSince>,
+    /// <p> Renames the object only if the destination does not already exist in the specified directory
+    /// bucket. If the object does exist when you send a request with <code>If-None-Match:*</code>, the S3 API
+    /// will return a <code>412 Precondition Failed</code> error, preventing an overwrite. The
+    /// <code>If-None-Match</code> header prevents overwrites of existing data by validating that there's not
+    /// an object with the same key name already in your directory bucket.</p>
+    /// <p> Expects the <code>*</code> character (asterisk).</p>
+    pub destination_if_none_match: Option<IfNoneMatch>,
+    /// <p>Renames the object if it hasn't been modified since the specified time.</p>
+    pub destination_if_unmodified_since: Option<IfUnmodifiedSince>,
+    /// <p>Key name of the object to rename.</p>
+    pub key: ObjectKey,
+    /// <p>Specifies the source for the rename operation. The value must be URL encoded.</p>
+    pub rename_source: RenameSource,
+    /// <p>Renames the object if the source exists and if its entity tag (ETag) matches the specified ETag.
+    /// </p>
+    pub source_if_match: Option<RenameSourceIfMatch>,
+    /// <p>Renames the object if the source exists and if it has been modified since the specified time.</p>
+    pub source_if_modified_since: Option<RenameSourceIfModifiedSince>,
+    /// <p>Renames the object if the source exists and if its entity tag (ETag) is different than the specified
+    /// ETag. If an asterisk (<code>*</code>) character is provided, the operation will fail and return a
+    /// <code>412 Precondition Failed</code> error. </p>
+    pub source_if_none_match: Option<RenameSourceIfNoneMatch>,
+    /// <p>Renames the object if the source exists and hasn't been modified since the specified time.</p>
+    pub source_if_unmodified_since: Option<RenameSourceIfUnmodifiedSince>,
+}
+
+impl fmt::Debug for RenameObjectInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("RenameObjectInput");
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.client_token {
+            d.field("client_token", val);
+        }
+        if let Some(ref val) = self.destination_if_match {
+            d.field("destination_if_match", val);
+        }
+        if let Some(ref val) = self.destination_if_modified_since {
+            d.field("destination_if_modified_since", val);
+        }
+        if let Some(ref val) = self.destination_if_none_match {
+            d.field("destination_if_none_match", val);
+        }
+        if let Some(ref val) = self.destination_if_unmodified_since {
+            d.field("destination_if_unmodified_since", val);
+        }
+        d.field("key", &self.key);
+        d.field("rename_source", &self.rename_source);
+        if let Some(ref val) = self.source_if_match {
+            d.field("source_if_match", val);
+        }
+        if let Some(ref val) = self.source_if_modified_since {
+            d.field("source_if_modified_since", val);
+        }
+        if let Some(ref val) = self.source_if_none_match {
+            d.field("source_if_none_match", val);
+        }
+        if let Some(ref val) = self.source_if_unmodified_since {
+            d.field("source_if_unmodified_since", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl RenameObjectInput {
+    #[must_use]
+    pub fn builder() -> builders::RenameObjectInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct RenameObjectOutput {}
+
+impl fmt::Debug for RenameObjectOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("RenameObjectOutput");
+        d.finish_non_exhaustive()
+    }
+}
+
+pub type RenameSource = String;
+
+pub type RenameSourceIfMatch = String;
+
+pub type RenameSourceIfModifiedSince = Timestamp;
+
+pub type RenameSourceIfNoneMatch = String;
+
+pub type RenameSourceIfUnmodifiedSince = Timestamp;
+
 pub type ReplaceKeyPrefixWith = String;
 
 pub type ReplaceKeyWith = String;
@@ -22792,6 +22931,7 @@ mod tests {
         require_default::<PutObjectRetentionOutput>();
         require_default::<PutObjectTaggingOutput>();
         require_default::<PutPublicAccessBlockOutput>();
+        require_default::<RenameObjectOutput>();
         require_default::<RestoreObjectOutput>();
         require_default::<SelectObjectContentOutput>();
         require_default::<UploadPartOutput>();
@@ -22983,6 +23123,8 @@ mod tests {
         require_clone::<PutObjectTaggingOutput>();
         require_clone::<PutPublicAccessBlockInput>();
         require_clone::<PutPublicAccessBlockOutput>();
+        require_clone::<RenameObjectInput>();
+        require_clone::<RenameObjectOutput>();
         require_clone::<RestoreObjectInput>();
         require_clone::<RestoreObjectOutput>();
         require_clone::<SelectObjectContentInput>();
@@ -33262,6 +33404,197 @@ pub mod builders {
         }
     }
 
+    /// A builder for [`RenameObjectInput`]
+    #[derive(Default)]
+    pub struct RenameObjectInputBuilder {
+        bucket: Option<BucketName>,
+
+        client_token: Option<ClientToken>,
+
+        destination_if_match: Option<IfMatch>,
+
+        destination_if_modified_since: Option<IfModifiedSince>,
+
+        destination_if_none_match: Option<IfNoneMatch>,
+
+        destination_if_unmodified_since: Option<IfUnmodifiedSince>,
+
+        key: Option<ObjectKey>,
+
+        rename_source: Option<RenameSource>,
+
+        source_if_match: Option<RenameSourceIfMatch>,
+
+        source_if_modified_since: Option<RenameSourceIfModifiedSince>,
+
+        source_if_none_match: Option<RenameSourceIfNoneMatch>,
+
+        source_if_unmodified_since: Option<RenameSourceIfUnmodifiedSince>,
+    }
+
+    impl RenameObjectInputBuilder {
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_client_token(&mut self, field: Option<ClientToken>) -> &mut Self {
+            self.client_token = field;
+            self
+        }
+
+        pub fn set_destination_if_match(&mut self, field: Option<IfMatch>) -> &mut Self {
+            self.destination_if_match = field;
+            self
+        }
+
+        pub fn set_destination_if_modified_since(&mut self, field: Option<IfModifiedSince>) -> &mut Self {
+            self.destination_if_modified_since = field;
+            self
+        }
+
+        pub fn set_destination_if_none_match(&mut self, field: Option<IfNoneMatch>) -> &mut Self {
+            self.destination_if_none_match = field;
+            self
+        }
+
+        pub fn set_destination_if_unmodified_since(&mut self, field: Option<IfUnmodifiedSince>) -> &mut Self {
+            self.destination_if_unmodified_since = field;
+            self
+        }
+
+        pub fn set_key(&mut self, field: ObjectKey) -> &mut Self {
+            self.key = Some(field);
+            self
+        }
+
+        pub fn set_rename_source(&mut self, field: RenameSource) -> &mut Self {
+            self.rename_source = Some(field);
+            self
+        }
+
+        pub fn set_source_if_match(&mut self, field: Option<RenameSourceIfMatch>) -> &mut Self {
+            self.source_if_match = field;
+            self
+        }
+
+        pub fn set_source_if_modified_since(&mut self, field: Option<RenameSourceIfModifiedSince>) -> &mut Self {
+            self.source_if_modified_since = field;
+            self
+        }
+
+        pub fn set_source_if_none_match(&mut self, field: Option<RenameSourceIfNoneMatch>) -> &mut Self {
+            self.source_if_none_match = field;
+            self
+        }
+
+        pub fn set_source_if_unmodified_since(&mut self, field: Option<RenameSourceIfUnmodifiedSince>) -> &mut Self {
+            self.source_if_unmodified_since = field;
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn client_token(mut self, field: Option<ClientToken>) -> Self {
+            self.client_token = field;
+            self
+        }
+
+        #[must_use]
+        pub fn destination_if_match(mut self, field: Option<IfMatch>) -> Self {
+            self.destination_if_match = field;
+            self
+        }
+
+        #[must_use]
+        pub fn destination_if_modified_since(mut self, field: Option<IfModifiedSince>) -> Self {
+            self.destination_if_modified_since = field;
+            self
+        }
+
+        #[must_use]
+        pub fn destination_if_none_match(mut self, field: Option<IfNoneMatch>) -> Self {
+            self.destination_if_none_match = field;
+            self
+        }
+
+        #[must_use]
+        pub fn destination_if_unmodified_since(mut self, field: Option<IfUnmodifiedSince>) -> Self {
+            self.destination_if_unmodified_since = field;
+            self
+        }
+
+        #[must_use]
+        pub fn key(mut self, field: ObjectKey) -> Self {
+            self.key = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn rename_source(mut self, field: RenameSource) -> Self {
+            self.rename_source = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn source_if_match(mut self, field: Option<RenameSourceIfMatch>) -> Self {
+            self.source_if_match = field;
+            self
+        }
+
+        #[must_use]
+        pub fn source_if_modified_since(mut self, field: Option<RenameSourceIfModifiedSince>) -> Self {
+            self.source_if_modified_since = field;
+            self
+        }
+
+        #[must_use]
+        pub fn source_if_none_match(mut self, field: Option<RenameSourceIfNoneMatch>) -> Self {
+            self.source_if_none_match = field;
+            self
+        }
+
+        #[must_use]
+        pub fn source_if_unmodified_since(mut self, field: Option<RenameSourceIfUnmodifiedSince>) -> Self {
+            self.source_if_unmodified_since = field;
+            self
+        }
+
+        pub fn build(self) -> Result<RenameObjectInput, BuildError> {
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let client_token = self.client_token;
+            let destination_if_match = self.destination_if_match;
+            let destination_if_modified_since = self.destination_if_modified_since;
+            let destination_if_none_match = self.destination_if_none_match;
+            let destination_if_unmodified_since = self.destination_if_unmodified_since;
+            let key = self.key.ok_or_else(|| BuildError::missing_field("key"))?;
+            let rename_source = self.rename_source.ok_or_else(|| BuildError::missing_field("rename_source"))?;
+            let source_if_match = self.source_if_match;
+            let source_if_modified_since = self.source_if_modified_since;
+            let source_if_none_match = self.source_if_none_match;
+            let source_if_unmodified_since = self.source_if_unmodified_since;
+            Ok(RenameObjectInput {
+                bucket,
+                client_token,
+                destination_if_match,
+                destination_if_modified_since,
+                destination_if_none_match,
+                destination_if_unmodified_since,
+                key,
+                rename_source,
+                source_if_match,
+                source_if_modified_since,
+                source_if_none_match,
+                source_if_unmodified_since,
+            })
+        }
+    }
+
     /// A builder for [`RestoreObjectInput`]
     #[derive(Default)]
     pub struct RestoreObjectInputBuilder {
@@ -38747,6 +39080,19 @@ impl DtoExt for RedirectAllRequestsTo {
             && val.as_str() == ""
         {
             self.protocol = None;
+        }
+    }
+}
+impl DtoExt for RenameObjectInput {
+    fn ignore_empty_strings(&mut self) {
+        if self.client_token.as_deref() == Some("") {
+            self.client_token = None;
+        }
+        if self.source_if_match.as_deref() == Some("") {
+            self.source_if_match = None;
+        }
+        if self.source_if_none_match.as_deref() == Some("") {
+            self.source_if_none_match = None;
         }
     }
 }

--- a/crates/s3s/src/dto/generated_minio.rs
+++ b/crates/s3s/src/dto/generated_minio.rs
@@ -1384,6 +1384,8 @@ pub type ChecksumXXHASH3 = String;
 
 pub type ChecksumXXHASH64 = String;
 
+pub type ClientToken = String;
+
 pub type Code = String;
 
 pub type Comments = String;
@@ -11145,6 +11147,23 @@ pub type HttpRedirectCode = String;
 
 pub type ID = String;
 
+/// <p>Parameters on this idempotent request are inconsistent with parameters used in previous request(s). </p>
+/// <p>For a list of error codes and more information on Amazon S3 errors, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList">Error codes</a>.</p>
+/// <note>
+/// <p>Idempotency ensures that an API request completes no more than one time. With an idempotent
+/// request, if the original request completes successfully, any subsequent retries complete successfully
+/// without performing any further actions.</p>
+/// </note>
+#[derive(Clone, Default, PartialEq)]
+pub struct IdempotencyParameterMismatch {}
+
+impl fmt::Debug for IdempotencyParameterMismatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("IdempotencyParameterMismatch");
+        d.finish_non_exhaustive()
+    }
+}
+
 pub type IfMatch = ETagCondition;
 
 pub type IfMatchInitiatedTime = Timestamp;
@@ -19455,6 +19474,126 @@ impl fmt::Debug for RedirectAllRequestsTo {
 
 pub type Region = String;
 
+#[derive(Clone, Default, PartialEq)]
+pub struct RenameObjectInput {
+    /// <p>The bucket name of the directory bucket containing the object.</p>
+    /// <p> You must use virtual-hosted-style requests in the format
+    /// <code>Bucket-name.s3express-zone-id.region-code.amazonaws.com</code>. Path-style requests are not
+    /// supported. Directory bucket names must be unique in the chosen Availability Zone. Bucket names must
+    /// follow the format <code>bucket-base-name--zone-id--x-s3 </code> (for example,
+    /// <code>amzn-s3-demo-bucket--usw2-az1--x-s3</code>). For information about bucket naming restrictions, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html">Directory bucket naming rules</a> in the <i>Amazon S3 User Guide</i>.</p>
+    pub bucket: BucketName,
+    /// <p> A unique string with a max of 64 ASCII characters in the ASCII range of 33 - 126.</p>
+    /// <note>
+    /// <p>
+    /// <code>RenameObject</code> supports idempotency using a client token. To make an idempotent API request
+    /// using <code>RenameObject</code>, specify a client token in the request. You should not reuse the same
+    /// client token for other API requests. If you retry a request that completed successfully using the same
+    /// client token and the same parameters, the retry succeeds without performing any further actions. If
+    /// you retry a successful request using the same client token, but one or more of the parameters are
+    /// different, the retry fails and an <code>IdempotentParameterMismatch</code> error is returned. </p>
+    /// </note>
+    pub client_token: Option<ClientToken>,
+    /// <p>Renames the object only if the ETag (entity tag) value provided during the operation matches the
+    /// ETag of the object in S3. The <code>If-Match</code> header field makes the request method conditional on
+    /// ETags. If the ETag values do not match, the operation returns a <code>412 Precondition Failed</code>
+    /// error.</p>
+    /// <p>Expects the ETag value as a string.</p>
+    pub destination_if_match: Option<IfMatch>,
+    /// <p>Renames the object if the destination exists and if it has been modified since the specified
+    /// time.</p>
+    pub destination_if_modified_since: Option<IfModifiedSince>,
+    /// <p> Renames the object only if the destination does not already exist in the specified directory
+    /// bucket. If the object does exist when you send a request with <code>If-None-Match:*</code>, the S3 API
+    /// will return a <code>412 Precondition Failed</code> error, preventing an overwrite. The
+    /// <code>If-None-Match</code> header prevents overwrites of existing data by validating that there's not
+    /// an object with the same key name already in your directory bucket.</p>
+    /// <p> Expects the <code>*</code> character (asterisk).</p>
+    pub destination_if_none_match: Option<IfNoneMatch>,
+    /// <p>Renames the object if it hasn't been modified since the specified time.</p>
+    pub destination_if_unmodified_since: Option<IfUnmodifiedSince>,
+    /// <p>Key name of the object to rename.</p>
+    pub key: ObjectKey,
+    /// <p>Specifies the source for the rename operation. The value must be URL encoded.</p>
+    pub rename_source: RenameSource,
+    /// <p>Renames the object if the source exists and if its entity tag (ETag) matches the specified ETag.
+    /// </p>
+    pub source_if_match: Option<RenameSourceIfMatch>,
+    /// <p>Renames the object if the source exists and if it has been modified since the specified time.</p>
+    pub source_if_modified_since: Option<RenameSourceIfModifiedSince>,
+    /// <p>Renames the object if the source exists and if its entity tag (ETag) is different than the specified
+    /// ETag. If an asterisk (<code>*</code>) character is provided, the operation will fail and return a
+    /// <code>412 Precondition Failed</code> error. </p>
+    pub source_if_none_match: Option<RenameSourceIfNoneMatch>,
+    /// <p>Renames the object if the source exists and hasn't been modified since the specified time.</p>
+    pub source_if_unmodified_since: Option<RenameSourceIfUnmodifiedSince>,
+}
+
+impl fmt::Debug for RenameObjectInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("RenameObjectInput");
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.client_token {
+            d.field("client_token", val);
+        }
+        if let Some(ref val) = self.destination_if_match {
+            d.field("destination_if_match", val);
+        }
+        if let Some(ref val) = self.destination_if_modified_since {
+            d.field("destination_if_modified_since", val);
+        }
+        if let Some(ref val) = self.destination_if_none_match {
+            d.field("destination_if_none_match", val);
+        }
+        if let Some(ref val) = self.destination_if_unmodified_since {
+            d.field("destination_if_unmodified_since", val);
+        }
+        d.field("key", &self.key);
+        d.field("rename_source", &self.rename_source);
+        if let Some(ref val) = self.source_if_match {
+            d.field("source_if_match", val);
+        }
+        if let Some(ref val) = self.source_if_modified_since {
+            d.field("source_if_modified_since", val);
+        }
+        if let Some(ref val) = self.source_if_none_match {
+            d.field("source_if_none_match", val);
+        }
+        if let Some(ref val) = self.source_if_unmodified_since {
+            d.field("source_if_unmodified_since", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl RenameObjectInput {
+    #[must_use]
+    pub fn builder() -> builders::RenameObjectInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct RenameObjectOutput {}
+
+impl fmt::Debug for RenameObjectOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("RenameObjectOutput");
+        d.finish_non_exhaustive()
+    }
+}
+
+pub type RenameSource = String;
+
+pub type RenameSourceIfMatch = String;
+
+pub type RenameSourceIfModifiedSince = Timestamp;
+
+pub type RenameSourceIfNoneMatch = String;
+
+pub type RenameSourceIfUnmodifiedSince = Timestamp;
+
 pub type ReplaceKeyPrefixWith = String;
 
 pub type ReplaceKeyWith = String;
@@ -22989,6 +23128,7 @@ mod tests {
         require_default::<PutObjectRetentionOutput>();
         require_default::<PutObjectTaggingOutput>();
         require_default::<PutPublicAccessBlockOutput>();
+        require_default::<RenameObjectOutput>();
         require_default::<RestoreObjectOutput>();
         require_default::<SelectObjectContentOutput>();
         require_default::<UploadPartOutput>();
@@ -23180,6 +23320,8 @@ mod tests {
         require_clone::<PutObjectTaggingOutput>();
         require_clone::<PutPublicAccessBlockInput>();
         require_clone::<PutPublicAccessBlockOutput>();
+        require_clone::<RenameObjectInput>();
+        require_clone::<RenameObjectOutput>();
         require_clone::<RestoreObjectInput>();
         require_clone::<RestoreObjectOutput>();
         require_clone::<SelectObjectContentInput>();
@@ -33534,6 +33676,197 @@ pub mod builders {
         }
     }
 
+    /// A builder for [`RenameObjectInput`]
+    #[derive(Default)]
+    pub struct RenameObjectInputBuilder {
+        bucket: Option<BucketName>,
+
+        client_token: Option<ClientToken>,
+
+        destination_if_match: Option<IfMatch>,
+
+        destination_if_modified_since: Option<IfModifiedSince>,
+
+        destination_if_none_match: Option<IfNoneMatch>,
+
+        destination_if_unmodified_since: Option<IfUnmodifiedSince>,
+
+        key: Option<ObjectKey>,
+
+        rename_source: Option<RenameSource>,
+
+        source_if_match: Option<RenameSourceIfMatch>,
+
+        source_if_modified_since: Option<RenameSourceIfModifiedSince>,
+
+        source_if_none_match: Option<RenameSourceIfNoneMatch>,
+
+        source_if_unmodified_since: Option<RenameSourceIfUnmodifiedSince>,
+    }
+
+    impl RenameObjectInputBuilder {
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_client_token(&mut self, field: Option<ClientToken>) -> &mut Self {
+            self.client_token = field;
+            self
+        }
+
+        pub fn set_destination_if_match(&mut self, field: Option<IfMatch>) -> &mut Self {
+            self.destination_if_match = field;
+            self
+        }
+
+        pub fn set_destination_if_modified_since(&mut self, field: Option<IfModifiedSince>) -> &mut Self {
+            self.destination_if_modified_since = field;
+            self
+        }
+
+        pub fn set_destination_if_none_match(&mut self, field: Option<IfNoneMatch>) -> &mut Self {
+            self.destination_if_none_match = field;
+            self
+        }
+
+        pub fn set_destination_if_unmodified_since(&mut self, field: Option<IfUnmodifiedSince>) -> &mut Self {
+            self.destination_if_unmodified_since = field;
+            self
+        }
+
+        pub fn set_key(&mut self, field: ObjectKey) -> &mut Self {
+            self.key = Some(field);
+            self
+        }
+
+        pub fn set_rename_source(&mut self, field: RenameSource) -> &mut Self {
+            self.rename_source = Some(field);
+            self
+        }
+
+        pub fn set_source_if_match(&mut self, field: Option<RenameSourceIfMatch>) -> &mut Self {
+            self.source_if_match = field;
+            self
+        }
+
+        pub fn set_source_if_modified_since(&mut self, field: Option<RenameSourceIfModifiedSince>) -> &mut Self {
+            self.source_if_modified_since = field;
+            self
+        }
+
+        pub fn set_source_if_none_match(&mut self, field: Option<RenameSourceIfNoneMatch>) -> &mut Self {
+            self.source_if_none_match = field;
+            self
+        }
+
+        pub fn set_source_if_unmodified_since(&mut self, field: Option<RenameSourceIfUnmodifiedSince>) -> &mut Self {
+            self.source_if_unmodified_since = field;
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn client_token(mut self, field: Option<ClientToken>) -> Self {
+            self.client_token = field;
+            self
+        }
+
+        #[must_use]
+        pub fn destination_if_match(mut self, field: Option<IfMatch>) -> Self {
+            self.destination_if_match = field;
+            self
+        }
+
+        #[must_use]
+        pub fn destination_if_modified_since(mut self, field: Option<IfModifiedSince>) -> Self {
+            self.destination_if_modified_since = field;
+            self
+        }
+
+        #[must_use]
+        pub fn destination_if_none_match(mut self, field: Option<IfNoneMatch>) -> Self {
+            self.destination_if_none_match = field;
+            self
+        }
+
+        #[must_use]
+        pub fn destination_if_unmodified_since(mut self, field: Option<IfUnmodifiedSince>) -> Self {
+            self.destination_if_unmodified_since = field;
+            self
+        }
+
+        #[must_use]
+        pub fn key(mut self, field: ObjectKey) -> Self {
+            self.key = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn rename_source(mut self, field: RenameSource) -> Self {
+            self.rename_source = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn source_if_match(mut self, field: Option<RenameSourceIfMatch>) -> Self {
+            self.source_if_match = field;
+            self
+        }
+
+        #[must_use]
+        pub fn source_if_modified_since(mut self, field: Option<RenameSourceIfModifiedSince>) -> Self {
+            self.source_if_modified_since = field;
+            self
+        }
+
+        #[must_use]
+        pub fn source_if_none_match(mut self, field: Option<RenameSourceIfNoneMatch>) -> Self {
+            self.source_if_none_match = field;
+            self
+        }
+
+        #[must_use]
+        pub fn source_if_unmodified_since(mut self, field: Option<RenameSourceIfUnmodifiedSince>) -> Self {
+            self.source_if_unmodified_since = field;
+            self
+        }
+
+        pub fn build(self) -> Result<RenameObjectInput, BuildError> {
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let client_token = self.client_token;
+            let destination_if_match = self.destination_if_match;
+            let destination_if_modified_since = self.destination_if_modified_since;
+            let destination_if_none_match = self.destination_if_none_match;
+            let destination_if_unmodified_since = self.destination_if_unmodified_since;
+            let key = self.key.ok_or_else(|| BuildError::missing_field("key"))?;
+            let rename_source = self.rename_source.ok_or_else(|| BuildError::missing_field("rename_source"))?;
+            let source_if_match = self.source_if_match;
+            let source_if_modified_since = self.source_if_modified_since;
+            let source_if_none_match = self.source_if_none_match;
+            let source_if_unmodified_since = self.source_if_unmodified_since;
+            Ok(RenameObjectInput {
+                bucket,
+                client_token,
+                destination_if_match,
+                destination_if_modified_since,
+                destination_if_none_match,
+                destination_if_unmodified_since,
+                key,
+                rename_source,
+                source_if_match,
+                source_if_modified_since,
+                source_if_none_match,
+                source_if_unmodified_since,
+            })
+        }
+    }
+
     /// A builder for [`RestoreObjectInput`]
     #[derive(Default)]
     pub struct RestoreObjectInputBuilder {
@@ -39047,6 +39380,19 @@ impl DtoExt for RedirectAllRequestsTo {
             && val.as_str() == ""
         {
             self.protocol = None;
+        }
+    }
+}
+impl DtoExt for RenameObjectInput {
+    fn ignore_empty_strings(&mut self) {
+        if self.client_token.as_deref() == Some("") {
+            self.client_token = None;
+        }
+        if self.source_if_match.as_deref() == Some("") {
+            self.source_if_match = None;
+        }
+        if self.source_if_none_match.as_deref() == Some("") {
+            self.source_if_none_match = None;
         }
     }
 }

--- a/crates/s3s/src/header/generated.rs
+++ b/crates/s3s/src/header/generated.rs
@@ -95,6 +95,8 @@ pub const X_AMZ_CHECKSUM_XXHASH3: HeaderName = HeaderName::from_static("x-amz-ch
 
 pub const X_AMZ_CHECKSUM_XXHASH64: HeaderName = HeaderName::from_static("x-amz-checksum-xxhash64");
 
+pub const X_AMZ_CLIENT_TOKEN: HeaderName = HeaderName::from_static("x-amz-client-token");
+
 pub const X_AMZ_CONFIRM_REMOVE_SELF_BUCKET_ACCESS: HeaderName =
     HeaderName::from_static("x-amz-confirm-remove-self-bucket-access");
 
@@ -275,6 +277,17 @@ pub const X_AMZ_OBJECT_SIZE: HeaderName = HeaderName::from_static("x-amz-object-
 pub const X_AMZ_OPTIONAL_OBJECT_ATTRIBUTES: HeaderName = HeaderName::from_static("x-amz-optional-object-attributes");
 
 pub const X_AMZ_PART_NUMBER_MARKER: HeaderName = HeaderName::from_static("x-amz-part-number-marker");
+
+pub const X_AMZ_RENAME_SOURCE: HeaderName = HeaderName::from_static("x-amz-rename-source");
+
+pub const X_AMZ_RENAME_SOURCE_IF_MATCH: HeaderName = HeaderName::from_static("x-amz-rename-source-if-match");
+
+pub const X_AMZ_RENAME_SOURCE_IF_MODIFIED_SINCE: HeaderName = HeaderName::from_static("x-amz-rename-source-if-modified-since");
+
+pub const X_AMZ_RENAME_SOURCE_IF_NONE_MATCH: HeaderName = HeaderName::from_static("x-amz-rename-source-if-none-match");
+
+pub const X_AMZ_RENAME_SOURCE_IF_UNMODIFIED_SINCE: HeaderName =
+    HeaderName::from_static("x-amz-rename-source-if-unmodified-since");
 
 pub const X_AMZ_REPLICATION_STATUS: HeaderName = HeaderName::from_static("x-amz-replication-status");
 

--- a/crates/s3s/src/header/generated_minio.rs
+++ b/crates/s3s/src/header/generated_minio.rs
@@ -95,6 +95,8 @@ pub const X_AMZ_CHECKSUM_XXHASH3: HeaderName = HeaderName::from_static("x-amz-ch
 
 pub const X_AMZ_CHECKSUM_XXHASH64: HeaderName = HeaderName::from_static("x-amz-checksum-xxhash64");
 
+pub const X_AMZ_CLIENT_TOKEN: HeaderName = HeaderName::from_static("x-amz-client-token");
+
 pub const X_AMZ_CONFIRM_REMOVE_SELF_BUCKET_ACCESS: HeaderName =
     HeaderName::from_static("x-amz-confirm-remove-self-bucket-access");
 
@@ -275,6 +277,17 @@ pub const X_AMZ_OBJECT_SIZE: HeaderName = HeaderName::from_static("x-amz-object-
 pub const X_AMZ_OPTIONAL_OBJECT_ATTRIBUTES: HeaderName = HeaderName::from_static("x-amz-optional-object-attributes");
 
 pub const X_AMZ_PART_NUMBER_MARKER: HeaderName = HeaderName::from_static("x-amz-part-number-marker");
+
+pub const X_AMZ_RENAME_SOURCE: HeaderName = HeaderName::from_static("x-amz-rename-source");
+
+pub const X_AMZ_RENAME_SOURCE_IF_MATCH: HeaderName = HeaderName::from_static("x-amz-rename-source-if-match");
+
+pub const X_AMZ_RENAME_SOURCE_IF_MODIFIED_SINCE: HeaderName = HeaderName::from_static("x-amz-rename-source-if-modified-since");
+
+pub const X_AMZ_RENAME_SOURCE_IF_NONE_MATCH: HeaderName = HeaderName::from_static("x-amz-rename-source-if-none-match");
+
+pub const X_AMZ_RENAME_SOURCE_IF_UNMODIFIED_SINCE: HeaderName =
+    HeaderName::from_static("x-amz-rename-source-if-unmodified-since");
 
 pub const X_AMZ_REPLICATION_STATUS: HeaderName = HeaderName::from_static("x-amz-replication-status");
 

--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -97,6 +97,7 @@
 // PutObjectRetention
 // PutObjectTagging
 // PutPublicAccessBlock
+// RenameObject
 // RestoreObject
 // SelectObjectContent
 // UploadPart
@@ -6624,6 +6625,87 @@ impl super::Operation for PutPublicAccessBlock {
     }
 }
 
+pub struct RenameObject;
+
+impl RenameObject {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<RenameObjectInput> {
+        let (bucket, key) = http::unwrap_object(req);
+
+        let client_token: Option<ClientToken> = http::parse_opt_header(req, &X_AMZ_CLIENT_TOKEN)?;
+
+        let destination_if_match: Option<IfMatch> = http::parse_opt_header(req, &IF_MATCH)?;
+
+        let destination_if_modified_since: Option<IfModifiedSince> =
+            http::parse_opt_header_timestamp(req, &IF_MODIFIED_SINCE, TimestampFormat::HttpDate)?;
+
+        let destination_if_none_match: Option<IfNoneMatch> = http::parse_opt_header(req, &IF_NONE_MATCH)?;
+
+        let destination_if_unmodified_since: Option<IfUnmodifiedSince> =
+            http::parse_opt_header_timestamp(req, &IF_UNMODIFIED_SINCE, TimestampFormat::HttpDate)?;
+
+        let rename_source: RenameSource = http::parse_header(req, &X_AMZ_RENAME_SOURCE)?;
+
+        let source_if_match: Option<RenameSourceIfMatch> = http::parse_opt_header(req, &X_AMZ_RENAME_SOURCE_IF_MATCH)?;
+
+        let source_if_modified_since: Option<RenameSourceIfModifiedSince> =
+            http::parse_opt_header_timestamp(req, &X_AMZ_RENAME_SOURCE_IF_MODIFIED_SINCE, TimestampFormat::HttpDate)?;
+
+        let source_if_none_match: Option<RenameSourceIfNoneMatch> =
+            http::parse_opt_header(req, &X_AMZ_RENAME_SOURCE_IF_NONE_MATCH)?;
+
+        let source_if_unmodified_since: Option<RenameSourceIfUnmodifiedSince> =
+            http::parse_opt_header_timestamp(req, &X_AMZ_RENAME_SOURCE_IF_UNMODIFIED_SINCE, TimestampFormat::HttpDate)?;
+
+        Ok(RenameObjectInput {
+            bucket,
+            client_token,
+            destination_if_match,
+            destination_if_modified_since,
+            destination_if_none_match,
+            destination_if_unmodified_since,
+            key,
+            rename_source,
+            source_if_match,
+            source_if_modified_since,
+            source_if_none_match,
+            source_if_unmodified_since,
+        })
+    }
+
+    pub fn serialize_http(_: RenameObjectOutput) -> S3Result<http::Response> {
+        Ok(http::Response::with_status(http::StatusCode::OK))
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for RenameObject {
+    fn name(&self) -> &'static str {
+        "RenameObject"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.rename_object(&mut s3_req).await?;
+        }
+        let result = s3.rename_object(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
 pub struct RestoreObject;
 
 impl RestoreObject {
@@ -7578,6 +7660,9 @@ pub fn resolve_route(
             }
             S3Path::Object { .. } => {
                 if let Some(qs) = qs {
+                    if qs.has("renameObject") {
+                        return Ok(&RenameObject as &'static dyn super::Operation);
+                    }
                     if qs.has("acl") {
                         return Ok(&PutObjectAcl as &'static dyn super::Operation);
                     }

--- a/crates/s3s/src/ops/generated_minio.rs
+++ b/crates/s3s/src/ops/generated_minio.rs
@@ -97,6 +97,7 @@
 // PutObjectRetention
 // PutObjectTagging
 // PutPublicAccessBlock
+// RenameObject
 // RestoreObject
 // SelectObjectContent
 // UploadPart
@@ -6641,6 +6642,87 @@ impl super::Operation for PutPublicAccessBlock {
     }
 }
 
+pub struct RenameObject;
+
+impl RenameObject {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<RenameObjectInput> {
+        let (bucket, key) = http::unwrap_object(req);
+
+        let client_token: Option<ClientToken> = http::parse_opt_header(req, &X_AMZ_CLIENT_TOKEN)?;
+
+        let destination_if_match: Option<IfMatch> = http::parse_opt_header(req, &IF_MATCH)?;
+
+        let destination_if_modified_since: Option<IfModifiedSince> =
+            http::parse_opt_header_timestamp(req, &IF_MODIFIED_SINCE, TimestampFormat::HttpDate)?;
+
+        let destination_if_none_match: Option<IfNoneMatch> = http::parse_opt_header(req, &IF_NONE_MATCH)?;
+
+        let destination_if_unmodified_since: Option<IfUnmodifiedSince> =
+            http::parse_opt_header_timestamp(req, &IF_UNMODIFIED_SINCE, TimestampFormat::HttpDate)?;
+
+        let rename_source: RenameSource = http::parse_header(req, &X_AMZ_RENAME_SOURCE)?;
+
+        let source_if_match: Option<RenameSourceIfMatch> = http::parse_opt_header(req, &X_AMZ_RENAME_SOURCE_IF_MATCH)?;
+
+        let source_if_modified_since: Option<RenameSourceIfModifiedSince> =
+            http::parse_opt_header_timestamp(req, &X_AMZ_RENAME_SOURCE_IF_MODIFIED_SINCE, TimestampFormat::HttpDate)?;
+
+        let source_if_none_match: Option<RenameSourceIfNoneMatch> =
+            http::parse_opt_header(req, &X_AMZ_RENAME_SOURCE_IF_NONE_MATCH)?;
+
+        let source_if_unmodified_since: Option<RenameSourceIfUnmodifiedSince> =
+            http::parse_opt_header_timestamp(req, &X_AMZ_RENAME_SOURCE_IF_UNMODIFIED_SINCE, TimestampFormat::HttpDate)?;
+
+        Ok(RenameObjectInput {
+            bucket,
+            client_token,
+            destination_if_match,
+            destination_if_modified_since,
+            destination_if_none_match,
+            destination_if_unmodified_since,
+            key,
+            rename_source,
+            source_if_match,
+            source_if_modified_since,
+            source_if_none_match,
+            source_if_unmodified_since,
+        })
+    }
+
+    pub fn serialize_http(_: RenameObjectOutput) -> S3Result<http::Response> {
+        Ok(http::Response::with_status(http::StatusCode::OK))
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for RenameObject {
+    fn name(&self) -> &'static str {
+        "RenameObject"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.rename_object(&mut s3_req).await?;
+        }
+        let result = s3.rename_object(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
 pub struct RestoreObject;
 
 impl RestoreObject {
@@ -7595,6 +7677,9 @@ pub fn resolve_route(
             }
             S3Path::Object { .. } => {
                 if let Some(qs) = qs {
+                    if qs.has("renameObject") {
+                        return Ok(&RenameObject as &'static dyn super::Operation);
+                    }
                     if qs.has("acl") {
                         return Ok(&PutObjectAcl as &'static dyn super::Operation);
                     }

--- a/crates/s3s/src/ops/route_fixtures.json
+++ b/crates/s3s/src/ops/route_fixtures.json
@@ -3391,5 +3391,37 @@
   "note": "fallback-empty-qs|null-qs",
   "path": "Object",
   "qs": null
+ },
+ {
+  "expect": "RenameObject",
+  "headers": {},
+  "method": "PUT",
+  "nfb": false,
+  "note": "if:qs.has(\"renameObject\")",
+  "path": "Object",
+  "qs": [
+   [
+    "renameObject",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "RenameObject",
+  "headers": {},
+  "method": "PUT",
+  "nfb": false,
+  "note": "noise:qs.has(\"renameObject\")",
+  "path": "Object",
+  "qs": [
+   [
+    "renameObject",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
  }
 ]

--- a/crates/s3s/src/s3_trait.rs
+++ b/crates/s3s/src/s3_trait.rs
@@ -6507,6 +6507,62 @@ pub trait S3: Send + Sync + 'static {
         Err(s3_error!(NotImplemented, "PutPublicAccessBlock is not implemented yet"))
     }
 
+    /// <p>Renames an existing object in a directory bucket that uses the S3 Express One Zone storage class.
+    /// You can use <code>RenameObject</code> by specifying an existing object’s name as the source and the new
+    /// name of the object as the destination within the same directory bucket.</p>
+    /// <note>
+    /// <p>
+    /// <code>RenameObject</code> is only supported for objects stored in the S3 Express One Zone storage
+    /// class.</p>
+    /// </note>
+    /// <p> To prevent overwriting an object, you can use the <code>If-None-Match</code> conditional
+    /// header.</p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <b>If-None-Match</b> - Renames the object only if an object
+    /// with the specified name does not already exist in the directory bucket. If you don't want to
+    /// overwrite an existing object, you can add the <code>If-None-Match</code> conditional header with the
+    /// value <code>‘*’</code> in the <code>RenameObject</code> request. Amazon S3 then returns a <code>412
+    /// Precondition Failed</code> error if the object with the specified name already exists. For more
+    /// information, see <a href="https://datatracker.ietf.org/doc/rfc7232/">RFC 7232</a>.</p>
+    /// </li>
+    /// </ul>
+    /// <dl>
+    /// <dt>Permissions</dt>
+    /// <dd>
+    /// <p> To grant access to the <code>RenameObject</code> operation on a directory bucket, we
+    /// recommend that you use the <code>CreateSession</code> operation for session-based authorization.
+    /// Specifically, you grant the <code>s3express:CreateSession</code> permission to the directory
+    /// bucket in a bucket policy or an IAM identity-based policy. Then, you make the
+    /// <code>CreateSession</code> API call on the directory bucket to obtain a session token. With the
+    /// session token in your request header, you can make API requests to this operation. After the
+    /// session token expires, you make another <code>CreateSession</code> API call to generate a new
+    /// session token for use. The Amazon Web Services CLI and SDKs will create and manage your session including
+    /// refreshing the session token automatically to avoid service interruptions when a session expires.
+    /// In your bucket policy, you can specify the <code>s3express:SessionMode</code> condition key to
+    /// control who can create a <code>ReadWrite</code> or <code>ReadOnly</code> session. A
+    /// <code>ReadWrite</code> session is required for executing all the Zonal endpoint API operations,
+    /// including <code>RenameObject</code>. For more information about authorization, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateSession.html">
+    /// <code>CreateSession</code>
+    /// </a>. To learn more about Zonal endpoint API operations, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-create-session.html">Authorizing Zonal endpoint API operations with CreateSession</a> in the <i>Amazon S3 User
+    /// Guide</i>. </p>
+    /// </dd>
+    /// <dt>HTTP Host header syntax</dt>
+    /// <dd>
+    /// <p>
+    /// <b>Directory buckets </b> - The HTTP Host header syntax is <code>
+    /// <i>Bucket-name</i>.s3express-<i>zone-id</i>.<i>region-code</i>.amazonaws.com</code>.</p>
+    /// </dd>
+    /// </dl>
+    /// <important>
+    /// <p>You must URL encode any signed header values that contain spaces. For example, if your header value is <code>my  file.txt</code>, containing two spaces after <code>my</code>, you must URL encode this value to <code>my%20%20file.txt</code>.</p>
+    /// </important>
+    async fn rename_object(&self, _req: S3Request<RenameObjectInput>) -> S3Result<S3Response<RenameObjectOutput>> {
+        Err(s3_error!(NotImplemented, "RenameObject is not implemented yet"))
+    }
+
     /// <note>
     /// <p>This operation is not supported for directory buckets.</p>
     /// </note>

--- a/data/s3.json
+++ b/data/s3.json
@@ -28101,6 +28101,9 @@
                 }
             }
         },
+        "com.amazonaws.s3#ClientToken": {
+            "type": "string"
+        },
         "com.amazonaws.s3#Code": {
             "type": "string"
         },
@@ -35842,6 +35845,15 @@
         "com.amazonaws.s3#ID": {
             "type": "string"
         },
+        "com.amazonaws.s3#IdempotencyParameterMismatch": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>Parameters on this idempotent request are inconsistent with parameters used in previous request(s). </p>\n         <p>For a list of error codes and more information on Amazon S3 errors, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList\">Error codes</a>.</p>\n         <note>\n            <p>Idempotency ensures that an API request completes no more than one time. With an idempotent\n        request, if the original request completes successfully, any subsequent retries complete successfully\n        without performing any further actions.</p>\n         </note>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
         "com.amazonaws.s3#IfMatch": {
             "type": "string"
         },
@@ -43271,6 +43283,161 @@
                     "min": 0,
                     "max": 20
                 }
+            }
+        },
+        "com.amazonaws.s3#RenameObject": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.s3#RenameObjectRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.s3#RenameObjectOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.s3#IdempotencyParameterMismatch"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Renames an existing object in a directory bucket that uses the S3 Express One Zone storage class.\n      You can use <code>RenameObject</code> by specifying an existing object’s name as the source and the new\n      name of the object as the destination within the same directory bucket.</p>\n         <note>\n            <p>\n               <code>RenameObject</code> is only supported for objects stored in the S3 Express One Zone storage\n        class.</p>\n         </note>\n         <p> To prevent overwriting an object, you can use the <code>If-None-Match</code> conditional\n      header.</p>\n         <ul>\n            <li>\n               <p>\n                  <b>If-None-Match</b> - Renames the object only if an object\n          with the specified name does not already exist in the directory bucket. If you don't want to\n          overwrite an existing object, you can add the <code>If-None-Match</code> conditional header with the\n          value <code>‘*’</code> in the <code>RenameObject</code> request. Amazon S3 then returns a <code>412\n            Precondition Failed</code> error if the object with the specified name already exists. For more\n          information, see <a href=\"https://datatracker.ietf.org/doc/rfc7232/\">RFC 7232</a>.</p>\n            </li>\n         </ul>\n         <dl>\n            <dt>Permissions</dt>\n            <dd>\n               <p> To grant access to the <code>RenameObject</code> operation on a directory bucket, we\n            recommend that you use the <code>CreateSession</code> operation for session-based authorization.\n            Specifically, you grant the <code>s3express:CreateSession</code> permission to the directory\n            bucket in a bucket policy or an IAM identity-based policy. Then, you make the\n              <code>CreateSession</code> API call on the directory bucket to obtain a session token. With the\n            session token in your request header, you can make API requests to this operation. After the\n            session token expires, you make another <code>CreateSession</code> API call to generate a new\n            session token for use. The Amazon Web Services CLI and SDKs will create and manage your session including\n            refreshing the session token automatically to avoid service interruptions when a session expires.\n            In your bucket policy, you can specify the <code>s3express:SessionMode</code> condition key to\n            control who can create a <code>ReadWrite</code> or <code>ReadOnly</code> session. A\n              <code>ReadWrite</code> session is required for executing all the Zonal endpoint API operations,\n            including <code>RenameObject</code>. For more information about authorization, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateSession.html\">\n                     <code>CreateSession</code>\n                  </a>. To learn more about Zonal endpoint API operations, see\n              <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-create-session.html\">Authorizing Zonal endpoint API operations with CreateSession</a> in the <i>Amazon S3 User\n              Guide</i>. </p>\n            </dd>\n            <dt>HTTP Host header syntax</dt>\n            <dd>\n               <p>\n                  <b>Directory buckets </b> - The HTTP Host header syntax is <code>\n                     <i>Bucket-name</i>.s3express-<i>zone-id</i>.<i>region-code</i>.amazonaws.com</code>.</p>\n            </dd>\n         </dl>\n         <important>\n            <p>You must URL encode any signed header values that contain spaces. For example, if your header value is <code>my  file.txt</code>, containing two spaces after <code>my</code>, you must URL encode this value to <code>my%20%20file.txt</code>.</p>\n         </important>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/{Bucket}/{Key+}?renameObject",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.s3#RenameObjectOutput": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.s3#RenameObjectRequest": {
+            "type": "structure",
+            "members": {
+                "Bucket": {
+                    "target": "com.amazonaws.s3#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The bucket name of the directory bucket containing the object.</p>\n         <p> You must use virtual-hosted-style requests in the format\n        <code>Bucket-name.s3express-zone-id.region-code.amazonaws.com</code>. Path-style requests are not\n      supported. Directory bucket names must be unique in the chosen Availability Zone. Bucket names must\n      follow the format <code>bucket-base-name--zone-id--x-s3 </code> (for example,\n        <code>amzn-s3-demo-bucket--usw2-az1--x-s3</code>). For information about bucket naming restrictions, see\n        <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html\">Directory bucket naming rules</a> in the <i>Amazon S3 User Guide</i>.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Bucket"
+                        }
+                    }
+                },
+                "Key": {
+                    "target": "com.amazonaws.s3#ObjectKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Key name of the object to rename.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Key"
+                        }
+                    }
+                },
+                "RenameSource": {
+                    "target": "com.amazonaws.s3#RenameSource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the source for the rename operation. The value must be URL encoded.</p>",
+                        "smithy.api#httpHeader": "x-amz-rename-source",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DestinationIfMatch": {
+                    "target": "com.amazonaws.s3#IfMatch",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Renames the object only if the ETag (entity tag) value provided during the operation matches the\n      ETag of the object in S3. The <code>If-Match</code> header field makes the request method conditional on\n      ETags. If the ETag values do not match, the operation returns a <code>412 Precondition Failed</code>\n      error.</p>\n         <p>Expects the ETag value as a string.</p>",
+                        "smithy.api#httpHeader": "If-Match"
+                    }
+                },
+                "DestinationIfNoneMatch": {
+                    "target": "com.amazonaws.s3#IfNoneMatch",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Renames the object only if the destination does not already exist in the specified directory\n      bucket. If the object does exist when you send a request with <code>If-None-Match:*</code>, the S3 API\n      will return a <code>412 Precondition Failed</code> error, preventing an overwrite. The\n        <code>If-None-Match</code> header prevents overwrites of existing data by validating that there's not\n      an object with the same key name already in your directory bucket.</p>\n         <p> Expects the <code>*</code> character (asterisk).</p>",
+                        "smithy.api#httpHeader": "If-None-Match"
+                    }
+                },
+                "DestinationIfModifiedSince": {
+                    "target": "com.amazonaws.s3#IfModifiedSince",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Renames the object if the destination exists and if it has been modified since the specified\n      time.</p>",
+                        "smithy.api#httpHeader": "If-Modified-Since"
+                    }
+                },
+                "DestinationIfUnmodifiedSince": {
+                    "target": "com.amazonaws.s3#IfUnmodifiedSince",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Renames the object if it hasn't been modified since the specified time.</p>",
+                        "smithy.api#httpHeader": "If-Unmodified-Since"
+                    }
+                },
+                "SourceIfMatch": {
+                    "target": "com.amazonaws.s3#RenameSourceIfMatch",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Renames the object if the source exists and if its entity tag (ETag) matches the specified ETag.\n    </p>",
+                        "smithy.api#httpHeader": "x-amz-rename-source-if-match"
+                    }
+                },
+                "SourceIfNoneMatch": {
+                    "target": "com.amazonaws.s3#RenameSourceIfNoneMatch",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Renames the object if the source exists and if its entity tag (ETag) is different than the specified\n      ETag. If an asterisk (<code>*</code>) character is provided, the operation will fail and return a\n        <code>412 Precondition Failed</code> error. </p>",
+                        "smithy.api#httpHeader": "x-amz-rename-source-if-none-match"
+                    }
+                },
+                "SourceIfModifiedSince": {
+                    "target": "com.amazonaws.s3#RenameSourceIfModifiedSince",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Renames the object if the source exists and if it has been modified since the specified time.</p>",
+                        "smithy.api#httpHeader": "x-amz-rename-source-if-modified-since"
+                    }
+                },
+                "SourceIfUnmodifiedSince": {
+                    "target": "com.amazonaws.s3#RenameSourceIfUnmodifiedSince",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Renames the object if the source exists and hasn't been modified since the specified time.</p>",
+                        "smithy.api#httpHeader": "x-amz-rename-source-if-unmodified-since"
+                    }
+                },
+                "ClientToken": {
+                    "target": "com.amazonaws.s3#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p> A unique string with a max of 64 ASCII characters in the ASCII range of 33 - 126.</p>\n         <note>\n            <p>\n               <code>RenameObject</code> supports idempotency using a client token. To make an idempotent API request\n        using <code>RenameObject</code>, specify a client token in the request. You should not reuse the same\n        client token for other API requests. If you retry a request that completed successfully using the same\n        client token and the same parameters, the retry succeeds without performing any further actions. If\n        you retry a successful request using the same client token, but one or more of the parameters are\n        different, the retry fails and an <code>IdempotentParameterMismatch</code> error is returned. </p>\n         </note>",
+                        "smithy.api#httpHeader": "x-amz-client-token",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.s3#RenameSource": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^\\/?.+\\/.+$"
+            }
+        },
+        "com.amazonaws.s3#RenameSourceIfMatch": {
+            "type": "string"
+        },
+        "com.amazonaws.s3#RenameSourceIfModifiedSince": {
+            "type": "timestamp",
+            "traits": {
+                "smithy.api#timestampFormat": "http-date"
+            }
+        },
+        "com.amazonaws.s3#RenameSourceIfNoneMatch": {
+            "type": "string"
+        },
+        "com.amazonaws.s3#RenameSourceIfUnmodifiedSince": {
+            "type": "timestamp",
+            "traits": {
+                "smithy.api#timestampFormat": "http-date"
             }
         },
         "com.amazonaws.s3#ReplaceKeyPrefixWith": {


### PR DESCRIPTION
## Summary

Add the `RenameObject` operation to the S3 model, following up on the model refresh merged in #698. This is the first operation of the new batch added to the `S3Service` trait, with a default stub that returns `NotImplemented` like the other operations.

## Changes

### `data/s3.json`

- +1 operation: `RenameObject` (`PUT /{Bucket}/{Key+}?renameObject`)
- +9 shapes: `RenameObjectRequest`, `RenameObjectOutput`, `RenameSource`, `RenameSourceIfMatch`, `RenameSourceIfNoneMatch`, `RenameSourceIfModifiedSince`, `RenameSourceIfUnmodifiedSince`, `ClientToken`, `IdempotencyParameterMismatch`
- The request carries `x-amz-rename-source` (required), four destination condition headers (`If-Match`, `If-None-Match`, `If-Modified-Since`, `If-Unmodified-Since`), four source condition headers (`x-amz-rename-source-*`), and `x-amz-client-token`
- All changed shapes are byte-identical to upstream `db89911`

### Generated code (`just codegen`, aws + minio variants)

- dto: new input/output types and builders
- ops: HTTP deserialization for the new headers, router rule for `?renameObject`
- s3_trait: `rename_object` method with a `NotImplemented` stub
- access: `rename_object` access hook
- s3s-aws conv/proxy: field wiring to `aws_sdk_s3` `RenameObject`

### Route fixtures

- +2 entries for the `?renameObject` router rule

## Verification

- `just codegen` idempotent (second run produces no diff)
- `just lint` clean
- `just test` 922 passed
- changed model shapes verified byte-identical to upstream `db89911`