### PR TITLE
perf(s3s): cache derived signing key in aws-chunked stream

### DIFF
--- a/crates/s3s/src/http/aws_chunked_stream.rs
+++ b/crates/s3s/src/http/aws_chunked_stream.rs
@@ -191,6 +191,7 @@ impl AwsChunkedStream {
                 let mut prev_bytes = Bytes::new();
                 let mut buf: Vec<u8> = Vec::new();
                 let signing_key = Zeroizing::new(sig_v4::derive_signing_key(&secret_key, &amz_date, &region, &service));
+                drop(secret_key);
                 let mut ctx = SignatureCtx {
                     amz_date,
                     region,

--- a/crates/s3s/src/http/aws_chunked_stream.rs
+++ b/crates/s3s/src/http/aws_chunked_stream.rs
@@ -24,6 +24,7 @@ use futures::pin_mut;
 use futures::stream::{Stream, StreamExt};
 use hyper::body::{Buf, Bytes};
 use memchr::memchr;
+use zeroize::Zeroizing;
 
 /// Maximum size for chunk metadata
 /// Prevents `DoS` via oversized chunk size declarations
@@ -57,7 +58,6 @@ impl Debug for AwsChunkedStream {
 }
 
 /// signature ctx
-#[derive(Debug)]
 struct SignatureCtx {
     /// date
     amz_date: AmzDate,
@@ -68,11 +68,23 @@ struct SignatureCtx {
     //// service
     service: Box<str>,
 
-    /// secret key
-    secret_key: SecretKey,
+    /// derived signing key
+    signing_key: Zeroizing<[u8; 32]>,
 
     /// previous chunk's signature
     prev_signature: Sha256Sum,
+}
+
+impl Debug for SignatureCtx {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SignatureCtx")
+            .field("amz_date", &self.amz_date)
+            .field("region", &self.region)
+            .field("service", &self.service)
+            .field("signing_key", &"[REDACTED]")
+            .field("prev_signature", &self.prev_signature)
+            .finish_non_exhaustive()
+    }
 }
 
 /// [`AwsChunkedStream`]
@@ -149,7 +161,7 @@ fn check_signature(ctx: &SignatureCtx, expected_signature: &[u8], chunk_data: &[
         sig_v4::create_chunk_string_to_sign(&ctx.amz_date, &ctx.region, &ctx.service, prev_signature, chunk_data)
     });
 
-    let signature = sig_v4::calculate_signature_raw(&string_to_sign, &ctx.secret_key, &ctx.amz_date, &ctx.region, &ctx.service);
+    let signature = sig_v4::calculate_signature_with_key(&string_to_sign, &ctx.signing_key);
 
     (expected == signature).then_some(signature)
 }
@@ -178,11 +190,12 @@ impl AwsChunkedStream {
                 pin_mut!(body);
                 let mut prev_bytes = Bytes::new();
                 let mut buf: Vec<u8> = Vec::new();
+                let signing_key = Zeroizing::new(sig_v4::derive_signing_key(&secret_key, &amz_date, &region, &service));
                 let mut ctx = SignatureCtx {
                     amz_date,
                     region,
                     service,
-                    secret_key,
+                    signing_key,
                     prev_signature: seed_signature,
                 };
 
@@ -335,8 +348,7 @@ impl AwsChunkedStream {
             let string_to_sign = hex_bytes32(ctx.prev_signature.as_bytes(), |prev_signature| {
                 create_trailer_string_to_sign(&ctx.amz_date, &ctx.region, &ctx.service, prev_signature, &canonical_trailers)
             });
-            let signature =
-                sig_v4::calculate_signature_raw(&string_to_sign, &ctx.secret_key, &ctx.amz_date, &ctx.region, &ctx.service);
+            let signature = sig_v4::calculate_signature_with_key(&string_to_sign, &ctx.signing_key);
             if provided != signature {
                 return Some(Err(AwsChunkedStreamError::SignatureMismatch));
             }

--- a/crates/s3s/src/http/aws_chunked_stream.rs
+++ b/crates/s3s/src/http/aws_chunked_stream.rs
@@ -623,6 +623,21 @@ fn trim_ascii_whitespace(mut s: &[u8]) -> &[u8] {
 mod tests {
     use super::*;
 
+    #[test]
+    fn signature_ctx_debug_redacts_signing_key() {
+        let ctx = SignatureCtx {
+            amz_date: AmzDate::parse("20130524T000000Z").unwrap(),
+            region: "us-east-1".into(),
+            service: "s3".into(),
+            signing_key: Zeroizing::new([0xAA; 32]),
+            prev_signature: Sha256Sum::from_hex("4f232c4386841ef735655705268965c44a0e4690baa4adea153f7db9fa80a0a9").unwrap(),
+        };
+
+        let text = format!("{ctx:?}");
+        assert!(text.contains("signing_key: \"[REDACTED]\""));
+        assert!(!text.contains("signing_key: ["));
+    }
+
     fn join(bytes: &[&[u8]]) -> Bytes {
         let mut buf = Vec::new();
         for b in bytes {

--- a/crates/s3s/src/sig_v4/methods.rs
+++ b/crates/s3s/src/sig_v4/methods.rs
@@ -8,7 +8,7 @@ use super::AmzDate;
 use crate::auth::SecretKey;
 use crate::auth::signature::Signature;
 use crate::http::OrderedHeaders;
-use crate::utils::crypto::{Sha256Sum, hex, hex_sha256, hex_sha256_chunk, hmac_sha256};
+use crate::utils::crypto::{Sha256Sum, hex_sha256, hex_sha256_chunk, hmac_sha256};
 use crate::utils::stable_sort_by_first;
 
 use hyper::Method;
@@ -430,19 +430,12 @@ pub fn calculate_signature(
     service: &str,
 ) -> Signature {
     let signing_key = derive_signing_key(secret_key, amz_date, region, service);
-    Signature::from_computed(hex(hmac_sha256(signing_key, string_to_sign)))
+    Signature::from_computed(calculate_signature_with_key(string_to_sign, &signing_key).to_hex_string())
 }
 
-/// calculate signature as raw bytes
+/// calculate signature with a derived signing key
 #[must_use]
-pub(crate) fn calculate_signature_raw(
-    string_to_sign: &str,
-    secret_key: &SecretKey,
-    amz_date: &AmzDate,
-    region: &str,
-    service: &str,
-) -> Sha256Sum {
-    let signing_key = derive_signing_key(secret_key, amz_date, region, service);
+pub(crate) fn calculate_signature_with_key(string_to_sign: &str, signing_key: &[u8; 32]) -> Sha256Sum {
     Sha256Sum::from_bytes(hmac_sha256(signing_key, string_to_sign))
 }
 
@@ -836,7 +829,7 @@ mod tests {
     }
 
     #[test]
-    fn calculate_signature_raw_matches_calculate_signature() {
+    fn calculate_signature_with_key_matches_calculate_signature() {
         use crate::utils::crypto::Sha256Sum;
 
         let secret_access_key = SecretKey::from("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
@@ -850,7 +843,8 @@ mod tests {
             create_chunk_string_to_sign(&date, region, service, seed_signature, &[Bytes::from(vec![b'a'; 64 * 1024])]);
 
         let signature = calculate_signature(&string_to_sign, &secret_access_key, &date, region, service);
-        let raw = calculate_signature_raw(&string_to_sign, &secret_access_key, &date, region, service);
+        let signing_key = derive_signing_key(&secret_access_key, &date, region, service);
+        let raw = calculate_signature_with_key(&string_to_sign, &signing_key);
 
         let expected = Sha256Sum::from_hex(signature.as_str()).unwrap();
         assert_eq!(expected, raw);


### PR DESCRIPTION
## Summary

Per chunk of an aws-chunked upload, signature verification currently re-derives the SigV4 signing key (`kDate` → `kRegion` → `kService` → `kSigning`) from the secret key. Those four HMAC-SHA256 steps depend only on the secret, date, region and service, which are constant for the whole request. This PR derives the signing key once when the stream is constructed and caches it in the stream context, so each chunk (and the trailer block) costs a single final HMAC.

Builds on #699, which introduced raw-byte signature comparison and extracted `derive_signing_key`.

## Changes

- `sig_v4/methods.rs`
  - Add `calculate_signature_with_key(string_to_sign, signing_key) -> Sha256Sum`: the final HMAC over a pre-derived key, hex-free.
  - The public `calculate_signature` now reuses it (derivation + final HMAC), keeping its signature unchanged.
  - Remove `calculate_signature_raw`, which no longer has callers in the library.
- `http/aws_chunked_stream.rs`
  - `SignatureCtx` now stores `signing_key: Zeroizing<[u8; 32]>` (zeroized on drop, redacted as `[REDACTED]` in a hand-written `Debug`) instead of the raw `SecretKey`, so secret material leaves the context once the key is derived.
  - `AwsChunkedStream::new` derives the signing key once; chunk and trailer verification call `calculate_signature_with_key`.

## Impact

- No observable behavior change: all AWS documentation chunk/trailer signature vectors and mismatch tests still pass.
- Per chunk: 4 fewer HMAC-SHA256 operations (8 SHA-256 block compressions) and one fewer access to the secret key. With 64 KiB chunks the crypto cost per chunk drops from ~10 to ~2 block compressions beyond the data hash.
- `SecretKey` lifetime shrinks to the stream constructor.
- No public API change: `utils` and `sig_v4` are crate-private modules; the public `calculate_signature` keeps its signature.

## Verification

- `just dev` (fetch → fmt → codegen → lint → test) — passes end-to-end, working tree clean after codegen.
- `cargo fmt --all --check` — clean.
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean.
- `just test` — all green; new equivalence test `calculate_signature_with_key_matches_calculate_signature` pins the cached-key path against the AWS-vector output of `calculate_signature`.
- `just semver-checks` — pending (requires published crates.io baselines).
- E2E — handled by CI; not run locally (per repo policy).
