### PR TITLE
feat(data): add ABAC operations and bucket namespace to S3 model

### DIFF
--- a/crates/s3s-aws/src/conv/generated.rs
+++ b/crates/s3s-aws/src/conv/generated.rs
@@ -5,6 +5,23 @@
 
 use super::*;
 
+impl AwsConversion for s3s::dto::AbacStatus {
+    type Target = aws_sdk_s3::types::AbacStatus;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            status: try_from_aws(x.status)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_status(try_into_aws(x.status)?);
+        Ok(y.build())
+    }
+}
+
 impl AwsConversion for s3s::dto::AbortIncompleteMultipartUpload {
     type Target = aws_sdk_s3::types::AbortIncompleteMultipartUpload;
     type Error = S3Error;
@@ -276,6 +293,23 @@ impl AwsConversion for s3s::dto::Bucket {
     }
 }
 
+impl AwsConversion for s3s::dto::BucketAbacStatus {
+    type Target = aws_sdk_s3::types::BucketAbacStatus;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(match x {
+            aws_sdk_s3::types::BucketAbacStatus::Disabled => Self::from_static(Self::DISABLED),
+            aws_sdk_s3::types::BucketAbacStatus::Enabled => Self::from_static(Self::ENABLED),
+            _ => Self::from(x.as_str().to_owned()),
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        Ok(aws_sdk_s3::types::BucketAbacStatus::from(x.as_str()))
+    }
+}
+
 impl AwsConversion for s3s::dto::BucketAccelerateStatus {
     type Target = aws_sdk_s3::types::BucketAccelerateStatus;
     type Error = S3Error;
@@ -465,6 +499,23 @@ impl AwsConversion for s3s::dto::BucketLogsPermission {
 
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         Ok(aws_sdk_s3::types::BucketLogsPermission::from(x.as_str()))
+    }
+}
+
+impl AwsConversion for s3s::dto::BucketNamespace {
+    type Target = aws_sdk_s3::types::BucketNamespace;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(match x {
+            aws_sdk_s3::types::BucketNamespace::AccountRegional => Self::from_static(Self::ACCOUNT_REGIONAL),
+            aws_sdk_s3::types::BucketNamespace::Global => Self::from_static(Self::GLOBAL),
+            _ => Self::from(x.as_str().to_owned()),
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        Ok(aws_sdk_s3::types::BucketNamespace::from(x.as_str()))
     }
 }
 
@@ -1182,6 +1233,7 @@ impl AwsConversion for s3s::dto::CreateBucketInput {
         Ok(Self {
             acl: try_from_aws(x.acl)?,
             bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            bucket_namespace: try_from_aws(x.bucket_namespace)?,
             create_bucket_configuration: try_from_aws(x.create_bucket_configuration)?,
             grant_full_control: try_from_aws(x.grant_full_control)?,
             grant_read: try_from_aws(x.grant_read)?,
@@ -1197,6 +1249,7 @@ impl AwsConversion for s3s::dto::CreateBucketInput {
         let mut y = Self::Target::builder();
         y = y.set_acl(try_into_aws(x.acl)?);
         y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_bucket_namespace(try_into_aws(x.bucket_namespace)?);
         y = y.set_create_bucket_configuration(try_into_aws(x.create_bucket_configuration)?);
         y = y.set_grant_full_control(try_into_aws(x.grant_full_control)?);
         y = y.set_grant_read(try_into_aws(x.grant_read)?);
@@ -2567,6 +2620,42 @@ impl AwsConversion for s3s::dto::FilterRuleName {
 
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         Ok(aws_sdk_s3::types::FilterRuleName::from(x.as_str()))
+    }
+}
+
+impl AwsConversion for s3s::dto::GetBucketAbacInput {
+    type Target = aws_sdk_s3::operation::get_bucket_abac::GetBucketAbacInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::GetBucketAbacOutput {
+    type Target = aws_sdk_s3::operation::get_bucket_abac::GetBucketAbacOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            abac_status: try_from_aws(x.abac_status)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_abac_status(try_into_aws(x.abac_status)?);
+        Ok(y.build())
     }
 }
 
@@ -6640,6 +6729,47 @@ impl AwsConversion for s3s::dto::PublicAccessBlockConfiguration {
         y = y.set_block_public_policy(try_into_aws(x.block_public_policy)?);
         y = y.set_ignore_public_acls(try_into_aws(x.ignore_public_acls)?);
         y = y.set_restrict_public_buckets(try_into_aws(x.restrict_public_buckets)?);
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::PutBucketAbacInput {
+    type Target = aws_sdk_s3::operation::put_bucket_abac::PutBucketAbacInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            abac_status: unwrap_from_aws(x.abac_status, "abac_status")?,
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            checksum_algorithm: try_from_aws(x.checksum_algorithm)?,
+            content_md5: try_from_aws(x.content_md5)?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_abac_status(Some(try_into_aws(x.abac_status)?));
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_checksum_algorithm(try_into_aws(x.checksum_algorithm)?);
+        y = y.set_content_md5(try_into_aws(x.content_md5)?);
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::PutBucketAbacOutput {
+    type Target = aws_sdk_s3::operation::put_bucket_abac::PutBucketAbacOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
         Ok(y.build())
     }
 }

--- a/crates/s3s-aws/src/conv/generated_minio.rs
+++ b/crates/s3s-aws/src/conv/generated_minio.rs
@@ -5,6 +5,23 @@
 
 use super::*;
 
+impl AwsConversion for s3s::dto::AbacStatus {
+    type Target = aws_sdk_s3::types::AbacStatus;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            status: try_from_aws(x.status)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_status(try_into_aws(x.status)?);
+        Ok(y.build())
+    }
+}
+
 impl AwsConversion for s3s::dto::AbortIncompleteMultipartUpload {
     type Target = aws_sdk_s3::types::AbortIncompleteMultipartUpload;
     type Error = S3Error;
@@ -276,6 +293,23 @@ impl AwsConversion for s3s::dto::Bucket {
     }
 }
 
+impl AwsConversion for s3s::dto::BucketAbacStatus {
+    type Target = aws_sdk_s3::types::BucketAbacStatus;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(match x {
+            aws_sdk_s3::types::BucketAbacStatus::Disabled => Self::from_static(Self::DISABLED),
+            aws_sdk_s3::types::BucketAbacStatus::Enabled => Self::from_static(Self::ENABLED),
+            _ => Self::from(x.as_str().to_owned()),
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        Ok(aws_sdk_s3::types::BucketAbacStatus::from(x.as_str()))
+    }
+}
+
 impl AwsConversion for s3s::dto::BucketAccelerateStatus {
     type Target = aws_sdk_s3::types::BucketAccelerateStatus;
     type Error = S3Error;
@@ -466,6 +500,23 @@ impl AwsConversion for s3s::dto::BucketLogsPermission {
 
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         Ok(aws_sdk_s3::types::BucketLogsPermission::from(x.as_str()))
+    }
+}
+
+impl AwsConversion for s3s::dto::BucketNamespace {
+    type Target = aws_sdk_s3::types::BucketNamespace;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(match x {
+            aws_sdk_s3::types::BucketNamespace::AccountRegional => Self::from_static(Self::ACCOUNT_REGIONAL),
+            aws_sdk_s3::types::BucketNamespace::Global => Self::from_static(Self::GLOBAL),
+            _ => Self::from(x.as_str().to_owned()),
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        Ok(aws_sdk_s3::types::BucketNamespace::from(x.as_str()))
     }
 }
 
@@ -1184,6 +1235,7 @@ impl AwsConversion for s3s::dto::CreateBucketInput {
         Ok(Self {
             acl: try_from_aws(x.acl)?,
             bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            bucket_namespace: try_from_aws(x.bucket_namespace)?,
             create_bucket_configuration: try_from_aws(x.create_bucket_configuration)?,
             grant_full_control: try_from_aws(x.grant_full_control)?,
             grant_read: try_from_aws(x.grant_read)?,
@@ -1199,6 +1251,7 @@ impl AwsConversion for s3s::dto::CreateBucketInput {
         let mut y = Self::Target::builder();
         y = y.set_acl(try_into_aws(x.acl)?);
         y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_bucket_namespace(try_into_aws(x.bucket_namespace)?);
         y = y.set_create_bucket_configuration(try_into_aws(x.create_bucket_configuration)?);
         y = y.set_grant_full_control(try_into_aws(x.grant_full_control)?);
         y = y.set_grant_read(try_into_aws(x.grant_read)?);
@@ -2571,6 +2624,42 @@ impl AwsConversion for s3s::dto::FilterRuleName {
 
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         Ok(aws_sdk_s3::types::FilterRuleName::from(x.as_str()))
+    }
+}
+
+impl AwsConversion for s3s::dto::GetBucketAbacInput {
+    type Target = aws_sdk_s3::operation::get_bucket_abac::GetBucketAbacInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::GetBucketAbacOutput {
+    type Target = aws_sdk_s3::operation::get_bucket_abac::GetBucketAbacOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            abac_status: try_from_aws(x.abac_status)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_abac_status(try_into_aws(x.abac_status)?);
+        Ok(y.build())
     }
 }
 
@@ -6647,6 +6736,47 @@ impl AwsConversion for s3s::dto::PublicAccessBlockConfiguration {
         y = y.set_block_public_policy(try_into_aws(x.block_public_policy)?);
         y = y.set_ignore_public_acls(try_into_aws(x.ignore_public_acls)?);
         y = y.set_restrict_public_buckets(try_into_aws(x.restrict_public_buckets)?);
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::PutBucketAbacInput {
+    type Target = aws_sdk_s3::operation::put_bucket_abac::PutBucketAbacInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            abac_status: unwrap_from_aws(x.abac_status, "abac_status")?,
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            checksum_algorithm: try_from_aws(x.checksum_algorithm)?,
+            content_md5: try_from_aws(x.content_md5)?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_abac_status(Some(try_into_aws(x.abac_status)?));
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_checksum_algorithm(try_into_aws(x.checksum_algorithm)?);
+        y = y.set_content_md5(try_into_aws(x.content_md5)?);
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::PutBucketAbacOutput {
+    type Target = aws_sdk_s3::operation::put_bucket_abac::PutBucketAbacOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
         Ok(y.build())
     }
 }

--- a/crates/s3s-aws/src/proxy/generated.rs
+++ b/crates/s3s-aws/src/proxy/generated.rs
@@ -153,6 +153,7 @@ impl S3 for Proxy {
         let mut b = self.0.create_bucket();
         b = b.set_acl(try_into_aws(input.acl)?);
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_bucket_namespace(try_into_aws(input.bucket_namespace)?);
         b = b.set_create_bucket_configuration(try_into_aws(input.create_bucket_configuration)?);
         b = b.set_grant_full_control(try_into_aws(input.grant_full_control)?);
         b = b.set_grant_read(try_into_aws(input.grant_read)?);
@@ -676,6 +677,28 @@ impl S3 for Proxy {
         let input = req.input;
         debug!(?input);
         let mut b = self.0.delete_public_access_block();
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
+    async fn get_bucket_abac(
+        &self,
+        req: S3Request<s3s::dto::GetBucketAbacInput>,
+    ) -> S3Result<S3Response<s3s::dto::GetBucketAbacOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.get_bucket_abac();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
         b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         let result = b.send().await;
@@ -1723,6 +1746,31 @@ impl S3 for Proxy {
         b = b.set_sse_customer_key(try_into_aws(input.sse_customer_key)?);
         b = b.set_sse_customer_key_md5(try_into_aws(input.sse_customer_key_md5)?);
         b = b.set_upload_id(Some(try_into_aws(input.upload_id)?));
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
+    async fn put_bucket_abac(
+        &self,
+        req: S3Request<s3s::dto::PutBucketAbacInput>,
+    ) -> S3Result<S3Response<s3s::dto::PutBucketAbacOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.put_bucket_abac();
+        b = b.set_abac_status(Some(try_into_aws(input.abac_status)?));
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_checksum_algorithm(try_into_aws(input.checksum_algorithm)?);
+        b = b.set_content_md5(try_into_aws(input.content_md5)?);
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         let result = b.send().await;
         match result {
             Ok(output) => {

--- a/crates/s3s-aws/src/proxy/generated_minio.rs
+++ b/crates/s3s-aws/src/proxy/generated_minio.rs
@@ -153,6 +153,7 @@ impl S3 for Proxy {
         let mut b = self.0.create_bucket();
         b = b.set_acl(try_into_aws(input.acl)?);
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_bucket_namespace(try_into_aws(input.bucket_namespace)?);
         b = b.set_create_bucket_configuration(try_into_aws(input.create_bucket_configuration)?);
         b = b.set_grant_full_control(try_into_aws(input.grant_full_control)?);
         b = b.set_grant_read(try_into_aws(input.grant_read)?);
@@ -676,6 +677,28 @@ impl S3 for Proxy {
         let input = req.input;
         debug!(?input);
         let mut b = self.0.delete_public_access_block();
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
+    async fn get_bucket_abac(
+        &self,
+        req: S3Request<s3s::dto::GetBucketAbacInput>,
+    ) -> S3Result<S3Response<s3s::dto::GetBucketAbacOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.get_bucket_abac();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
         b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         let result = b.send().await;
@@ -1723,6 +1746,31 @@ impl S3 for Proxy {
         b = b.set_sse_customer_key(try_into_aws(input.sse_customer_key)?);
         b = b.set_sse_customer_key_md5(try_into_aws(input.sse_customer_key_md5)?);
         b = b.set_upload_id(Some(try_into_aws(input.upload_id)?));
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
+    async fn put_bucket_abac(
+        &self,
+        req: S3Request<s3s::dto::PutBucketAbacInput>,
+    ) -> S3Result<S3Response<s3s::dto::PutBucketAbacOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.put_bucket_abac();
+        b = b.set_abac_status(Some(try_into_aws(input.abac_status)?));
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_checksum_algorithm(try_into_aws(input.checksum_algorithm)?);
+        b = b.set_content_md5(try_into_aws(input.content_md5)?);
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         let result = b.send().await;
         match result {
             Ok(output) => {

--- a/crates/s3s/src/access/generated.rs
+++ b/crates/s3s/src/access/generated.rs
@@ -223,6 +223,13 @@ pub trait S3Access: Send + Sync + 'static {
         Ok(())
     }
 
+    /// Checks whether the GetBucketAbac request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn get_bucket_abac(&self, _req: &mut S3Request<GetBucketAbacInput>) -> S3Result<()> {
+        Ok(())
+    }
+
     /// Checks whether the GetBucketAccelerateConfiguration request has accesses to the resources.
     ///
     /// This method returns `Ok(())` by default.
@@ -561,6 +568,13 @@ pub trait S3Access: Send + Sync + 'static {
     ///
     /// This method returns `Ok(())` by default.
     async fn post_object(&self, _req: &mut S3Request<PostObjectInput>) -> S3Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether the PutBucketAbac request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn put_bucket_abac(&self, _req: &mut S3Request<PutBucketAbacInput>) -> S3Result<()> {
         Ok(())
     }
 

--- a/crates/s3s/src/access/generated_minio.rs
+++ b/crates/s3s/src/access/generated_minio.rs
@@ -223,6 +223,13 @@ pub trait S3Access: Send + Sync + 'static {
         Ok(())
     }
 
+    /// Checks whether the GetBucketAbac request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn get_bucket_abac(&self, _req: &mut S3Request<GetBucketAbacInput>) -> S3Result<()> {
+        Ok(())
+    }
+
     /// Checks whether the GetBucketAccelerateConfiguration request has accesses to the resources.
     ///
     /// This method returns `Ok(())` by default.
@@ -561,6 +568,13 @@ pub trait S3Access: Send + Sync + 'static {
     ///
     /// This method returns `Ok(())` by default.
     async fn post_object(&self, _req: &mut S3Request<PostObjectInput>) -> S3Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether the PutBucketAbac request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn put_bucket_abac(&self, _req: &mut S3Request<PutBucketAbacInput>) -> S3Result<()> {
         Ok(())
     }
 

--- a/crates/s3s/src/dto/generated.rs
+++ b/crates/s3s/src/dto/generated.rs
@@ -19,6 +19,23 @@ use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use stdx::default::default;
 
+/// <p>The ABAC status of the general purpose bucket. When ABAC is enabled for the general purpose bucket, you can use tags to manage access to the general purpose buckets as well as for cost tracking purposes. When ABAC is disabled for the general purpose buckets, you can only use tags for cost tracking purposes. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging.html">Using tags with S3 general purpose buckets</a>. </p>
+#[derive(Clone, Default, PartialEq)]
+pub struct AbacStatus {
+    /// <p>The ABAC status of the general purpose bucket. </p>
+    pub status: Option<BucketAbacStatus>,
+}
+
+impl fmt::Debug for AbacStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("AbacStatus");
+        if let Some(ref val) = self.status {
+            d.field("status", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
 pub type AbortDate = Timestamp;
 
 /// <p>Specifies the days since the initiation of an incomplete multipart upload that Amazon S3 will
@@ -524,6 +541,44 @@ impl fmt::Debug for Bucket {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BucketAbacStatus(Cow<'static, str>);
+
+impl BucketAbacStatus {
+    pub const DISABLED: &'static str = "Disabled";
+
+    pub const ENABLED: &'static str = "Enabled";
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn from_static(s: &'static str) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<String> for BucketAbacStatus {
+    fn from(s: String) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<BucketAbacStatus> for Cow<'static, str> {
+    fn from(s: BucketAbacStatus) -> Self {
+        s.0
+    }
+}
+
+impl FromStr for BucketAbacStatus {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s.to_owned()))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BucketAccelerateStatus(Cow<'static, str>);
 
@@ -844,6 +899,44 @@ impl FromStr for BucketLogsPermission {
 }
 
 pub type BucketName = String;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BucketNamespace(Cow<'static, str>);
+
+impl BucketNamespace {
+    pub const ACCOUNT_REGIONAL: &'static str = "account-regional";
+
+    pub const GLOBAL: &'static str = "global";
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn from_static(s: &'static str) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<String> for BucketNamespace {
+    fn from(s: String) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<BucketNamespace> for Cow<'static, str> {
+    fn from(s: BucketNamespace) -> Self {
+        s.0
+    }
+}
+
+impl FromStr for BucketNamespace {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s.to_owned()))
+    }
+}
 
 pub type BucketRegion = String;
 
@@ -3126,10 +3219,25 @@ pub struct CreateBucketInput {
     /// <i>DOC-EXAMPLE-BUCKET</i>--<i>usw2-az1</i>--x-s3</code>). For information about bucket naming restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html">Directory bucket naming rules</a> in the <i>Amazon S3 User Guide</i>
     /// </p>
     pub bucket: BucketName,
+    /// <p>Specifies the namespace where you want to create your general purpose bucket. When you create a
+    /// general purpose bucket, you can choose to create a bucket in the shared global namespace or you can choose to
+    /// create a bucket in your account regional namespace. Your account regional namespace is a subdivision of
+    /// the global namespace that only your account can create buckets in. For more information on bucket
+    /// namespaces, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/gpbucketnamespaces.html">Namespaces for general purpose buckets</a>.</p>
+    /// <p>General purpose buckets in your account regional namespace must follow a specific naming convention. These
+    /// buckets consist of a bucket name prefix that you create, and a suffix that contains your 12-digit Amazon Web Services
+    /// Account ID, the Amazon Web Services Region code, and ends with <code>-an</code>. Bucket names must follow the format
+    /// <code>bucket-name-prefix-accountId-region-an</code> (for example,
+    /// <code>amzn-s3-demo-bucket-111122223333-us-west-2-an</code>). For information about bucket naming
+    /// restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html#account-regional-naming-rules">Account regional namespace naming rules</a>
+    /// in the <i>Amazon S3 User Guide</i>.</p>
+    /// <note>
+    /// <p>This functionality is not supported for directory buckets.</p>
+    /// </note>
+    pub bucket_namespace: Option<BucketNamespace>,
     /// <p>The configuration information for the bucket.</p>
     pub create_bucket_configuration: Option<CreateBucketConfiguration>,
-    /// <p>Allows grantee the read, write, read ACP, and write ACP permissions on the
-    /// bucket.</p>
+    /// <p>Allows grantee the read, write, read ACP, and write ACP permissions on the bucket.</p>
     /// <note>
     /// <p>This functionality is not supported for directory buckets.</p>
     /// </note>
@@ -3145,8 +3253,8 @@ pub struct CreateBucketInput {
     /// </note>
     pub grant_read_acp: Option<GrantReadACP>,
     /// <p>Allows grantee to create new objects in the bucket.</p>
-    /// <p>For the bucket and object owners of existing objects, also allows deletions and
-    /// overwrites of those objects.</p>
+    /// <p>For the bucket and object owners of existing objects, also allows deletions and overwrites of those
+    /// objects.</p>
     /// <note>
     /// <p>This functionality is not supported for directory buckets.</p>
     /// </note>
@@ -3171,6 +3279,9 @@ impl fmt::Debug for CreateBucketInput {
             d.field("acl", val);
         }
         d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.bucket_namespace {
+            d.field("bucket_namespace", val);
+        }
         if let Some(ref val) = self.create_bucket_configuration {
             d.field("create_bucket_configuration", val);
         }
@@ -7897,6 +8008,48 @@ impl FromStr for FilterRuleName {
 }
 
 pub type FilterRuleValue = String;
+
+#[derive(Clone, Default, PartialEq)]
+pub struct GetBucketAbacInput {
+    /// <p>The name of the general purpose bucket.</p>
+    pub bucket: BucketName,
+    /// <p>The Amazon Web Services account ID of the general purpose bucket's owner. </p>
+    pub expected_bucket_owner: Option<AccountId>,
+}
+
+impl fmt::Debug for GetBucketAbacInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("GetBucketAbacInput");
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl GetBucketAbacInput {
+    #[must_use]
+    pub fn builder() -> builders::GetBucketAbacInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct GetBucketAbacOutput {
+    /// <p>The ABAC status of the general purpose bucket. </p>
+    pub abac_status: Option<AbacStatus>,
+}
+
+impl fmt::Debug for GetBucketAbacOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("GetBucketAbacOutput");
+        if let Some(ref val) = self.abac_status {
+            d.field("abac_status", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
 
 #[derive(Clone, Default, PartialEq)]
 pub struct GetBucketAccelerateConfigurationInput {
@@ -16725,6 +16878,57 @@ impl fmt::Debug for PublicAccessBlockConfiguration {
 }
 
 #[derive(Clone, PartialEq)]
+pub struct PutBucketAbacInput {
+    /// <p>The ABAC status of the general purpose bucket. When ABAC is enabled for the general purpose bucket, you can use tags to manage access to the general purpose buckets as well as for cost tracking purposes. When ABAC is disabled for the general purpose buckets, you can only use tags for cost tracking purposes. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging.html">Using tags with S3 general purpose buckets</a>. </p>
+    pub abac_status: AbacStatus,
+    /// <p>The name of the general purpose bucket.</p>
+    pub bucket: BucketName,
+    /// <p>Indicates the algorithm that you want Amazon S3 to use to create the checksum. For more
+    /// information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
+    pub checksum_algorithm: Option<ChecksumAlgorithm>,
+    /// <p>The MD5 hash of the <code>PutBucketAbac</code> request body. </p>
+    /// <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+    pub content_md5: Option<ContentMD5>,
+    /// <p>The Amazon Web Services account ID of the general purpose bucket's owner. </p>
+    pub expected_bucket_owner: Option<AccountId>,
+}
+
+impl fmt::Debug for PutBucketAbacInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("PutBucketAbacInput");
+        d.field("abac_status", &self.abac_status);
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.checksum_algorithm {
+            d.field("checksum_algorithm", val);
+        }
+        if let Some(ref val) = self.content_md5 {
+            d.field("content_md5", val);
+        }
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl PutBucketAbacInput {
+    #[must_use]
+    pub fn builder() -> builders::PutBucketAbacInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct PutBucketAbacOutput {}
+
+impl fmt::Debug for PutBucketAbacOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("PutBucketAbacOutput");
+        d.finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, PartialEq)]
 pub struct PutBucketAccelerateConfigurationInput {
     /// <p>Container for setting the transfer acceleration state.</p>
     pub accelerate_configuration: AccelerateConfiguration,
@@ -22862,6 +23066,7 @@ mod tests {
         require_default::<DeleteObjectTaggingOutput>();
         require_default::<DeleteObjectsOutput>();
         require_default::<DeletePublicAccessBlockOutput>();
+        require_default::<GetBucketAbacOutput>();
         require_default::<GetBucketAccelerateConfigurationOutput>();
         require_default::<GetBucketAclOutput>();
         require_default::<GetBucketAnalyticsConfigurationOutput>();
@@ -22906,6 +23111,7 @@ mod tests {
         require_default::<ListObjectsV2Output>();
         require_default::<ListPartsOutput>();
         require_default::<PostObjectOutput>();
+        require_default::<PutBucketAbacOutput>();
         require_default::<PutBucketAccelerateConfigurationOutput>();
         require_default::<PutBucketAclOutput>();
         require_default::<PutBucketAnalyticsConfigurationOutput>();
@@ -22989,6 +23195,8 @@ mod tests {
         require_clone::<DeleteObjectsOutput>();
         require_clone::<DeletePublicAccessBlockInput>();
         require_clone::<DeletePublicAccessBlockOutput>();
+        require_clone::<GetBucketAbacInput>();
+        require_clone::<GetBucketAbacOutput>();
         require_clone::<GetBucketAccelerateConfigurationInput>();
         require_clone::<GetBucketAccelerateConfigurationOutput>();
         require_clone::<GetBucketAclInput>();
@@ -23074,6 +23282,8 @@ mod tests {
         require_clone::<ListPartsInput>();
         require_clone::<ListPartsOutput>();
         require_clone::<PostObjectOutput>();
+        require_clone::<PutBucketAbacInput>();
+        require_clone::<PutBucketAbacOutput>();
         require_clone::<PutBucketAccelerateConfigurationInput>();
         require_clone::<PutBucketAccelerateConfigurationOutput>();
         require_clone::<PutBucketAclInput>();
@@ -24230,6 +24440,8 @@ pub mod builders {
 
         bucket: Option<BucketName>,
 
+        bucket_namespace: Option<BucketNamespace>,
+
         create_bucket_configuration: Option<CreateBucketConfiguration>,
 
         grant_full_control: Option<GrantFullControl>,
@@ -24255,6 +24467,11 @@ pub mod builders {
 
         pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
             self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_bucket_namespace(&mut self, field: Option<BucketNamespace>) -> &mut Self {
+            self.bucket_namespace = field;
             self
         }
 
@@ -24311,6 +24528,12 @@ pub mod builders {
         }
 
         #[must_use]
+        pub fn bucket_namespace(mut self, field: Option<BucketNamespace>) -> Self {
+            self.bucket_namespace = field;
+            self
+        }
+
+        #[must_use]
         pub fn create_bucket_configuration(mut self, field: Option<CreateBucketConfiguration>) -> Self {
             self.create_bucket_configuration = field;
             self
@@ -24361,6 +24584,7 @@ pub mod builders {
         pub fn build(self) -> Result<CreateBucketInput, BuildError> {
             let acl = self.acl;
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let bucket_namespace = self.bucket_namespace;
             let create_bucket_configuration = self.create_bucket_configuration;
             let grant_full_control = self.grant_full_control;
             let grant_read = self.grant_read;
@@ -24372,6 +24596,7 @@ pub mod builders {
             Ok(CreateBucketInput {
                 acl,
                 bucket,
+                bucket_namespace,
                 create_bucket_configuration,
                 grant_full_control,
                 grant_read,
@@ -26066,6 +26291,47 @@ pub mod builders {
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
             let expected_bucket_owner = self.expected_bucket_owner;
             Ok(DeletePublicAccessBlockInput {
+                bucket,
+                expected_bucket_owner,
+            })
+        }
+    }
+
+    /// A builder for [`GetBucketAbacInput`]
+    #[derive(Default)]
+    pub struct GetBucketAbacInputBuilder {
+        bucket: Option<BucketName>,
+
+        expected_bucket_owner: Option<AccountId>,
+    }
+
+    impl GetBucketAbacInputBuilder {
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn build(self) -> Result<GetBucketAbacInput, BuildError> {
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            Ok(GetBucketAbacInput {
                 bucket,
                 expected_bucket_owner,
             })
@@ -30242,6 +30508,92 @@ pub mod builders {
                 success_action_redirect,
                 success_action_status,
                 policy,
+            })
+        }
+    }
+
+    /// A builder for [`PutBucketAbacInput`]
+    #[derive(Default)]
+    pub struct PutBucketAbacInputBuilder {
+        abac_status: Option<AbacStatus>,
+
+        bucket: Option<BucketName>,
+
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+
+        content_md5: Option<ContentMD5>,
+
+        expected_bucket_owner: Option<AccountId>,
+    }
+
+    impl PutBucketAbacInputBuilder {
+        pub fn set_abac_status(&mut self, field: AbacStatus) -> &mut Self {
+            self.abac_status = Some(field);
+            self
+        }
+
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_algorithm(&mut self, field: Option<ChecksumAlgorithm>) -> &mut Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        pub fn set_content_md5(&mut self, field: Option<ContentMD5>) -> &mut Self {
+            self.content_md5 = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn abac_status(mut self, field: AbacStatus) -> Self {
+            self.abac_status = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_algorithm(mut self, field: Option<ChecksumAlgorithm>) -> Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        #[must_use]
+        pub fn content_md5(mut self, field: Option<ContentMD5>) -> Self {
+            self.content_md5 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn build(self) -> Result<PutBucketAbacInput, BuildError> {
+            let abac_status = self.abac_status.ok_or_else(|| BuildError::missing_field("abac_status"))?;
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_algorithm = self.checksum_algorithm;
+            let content_md5 = self.content_md5;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            Ok(PutBucketAbacInput {
+                abac_status,
+                bucket,
+                checksum_algorithm,
+                content_md5,
+                expected_bucket_owner,
             })
         }
     }
@@ -35184,6 +35536,15 @@ pub trait DtoExt {
     /// Modifies all empty string fields from `Some("")` to `None`
     fn ignore_empty_strings(&mut self);
 }
+impl DtoExt for AbacStatus {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref val) = self.status
+            && val.as_str() == ""
+        {
+            self.status = None;
+        }
+    }
+}
 impl DtoExt for AbortIncompleteMultipartUpload {
     fn ignore_empty_strings(&mut self) {}
 }
@@ -35820,6 +36181,11 @@ impl DtoExt for CreateBucketInput {
         {
             self.acl = None;
         }
+        if let Some(ref val) = self.bucket_namespace
+            && val.as_str() == ""
+        {
+            self.bucket_namespace = None;
+        }
         if let Some(ref mut val) = self.create_bucket_configuration {
             val.ignore_empty_strings();
         }
@@ -36358,6 +36724,20 @@ impl DtoExt for FilterRule {
         }
         if self.value.as_deref() == Some("") {
             self.value = None;
+        }
+    }
+}
+impl DtoExt for GetBucketAbacInput {
+    fn ignore_empty_strings(&mut self) {
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+    }
+}
+impl DtoExt for GetBucketAbacOutput {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.abac_status {
+            val.ignore_empty_strings();
         }
     }
 }
@@ -38360,6 +38740,22 @@ impl DtoExt for ProgressEvent {
 }
 impl DtoExt for PublicAccessBlockConfiguration {
     fn ignore_empty_strings(&mut self) {}
+}
+impl DtoExt for PutBucketAbacInput {
+    fn ignore_empty_strings(&mut self) {
+        self.abac_status.ignore_empty_strings();
+        if let Some(ref val) = self.checksum_algorithm
+            && val.as_str() == ""
+        {
+            self.checksum_algorithm = None;
+        }
+        if self.content_md5.as_deref() == Some("") {
+            self.content_md5 = None;
+        }
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+    }
 }
 impl DtoExt for PutBucketAccelerateConfigurationInput {
     fn ignore_empty_strings(&mut self) {

--- a/crates/s3s/src/dto/generated_minio.rs
+++ b/crates/s3s/src/dto/generated_minio.rs
@@ -19,6 +19,23 @@ use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use stdx::default::default;
 
+/// <p>The ABAC status of the general purpose bucket. When ABAC is enabled for the general purpose bucket, you can use tags to manage access to the general purpose buckets as well as for cost tracking purposes. When ABAC is disabled for the general purpose buckets, you can only use tags for cost tracking purposes. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging.html">Using tags with S3 general purpose buckets</a>. </p>
+#[derive(Clone, Default, PartialEq)]
+pub struct AbacStatus {
+    /// <p>The ABAC status of the general purpose bucket. </p>
+    pub status: Option<BucketAbacStatus>,
+}
+
+impl fmt::Debug for AbacStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("AbacStatus");
+        if let Some(ref val) = self.status {
+            d.field("status", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
 pub type AbortDate = Timestamp;
 
 /// <p>Specifies the days since the initiation of an incomplete multipart upload that Amazon S3 will
@@ -524,6 +541,44 @@ impl fmt::Debug for Bucket {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BucketAbacStatus(Cow<'static, str>);
+
+impl BucketAbacStatus {
+    pub const DISABLED: &'static str = "Disabled";
+
+    pub const ENABLED: &'static str = "Enabled";
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn from_static(s: &'static str) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<String> for BucketAbacStatus {
+    fn from(s: String) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<BucketAbacStatus> for Cow<'static, str> {
+    fn from(s: BucketAbacStatus) -> Self {
+        s.0
+    }
+}
+
+impl FromStr for BucketAbacStatus {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s.to_owned()))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BucketAccelerateStatus(Cow<'static, str>);
 
@@ -848,6 +903,44 @@ impl FromStr for BucketLogsPermission {
 }
 
 pub type BucketName = String;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BucketNamespace(Cow<'static, str>);
+
+impl BucketNamespace {
+    pub const ACCOUNT_REGIONAL: &'static str = "account-regional";
+
+    pub const GLOBAL: &'static str = "global";
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn from_static(s: &'static str) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<String> for BucketNamespace {
+    fn from(s: String) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<BucketNamespace> for Cow<'static, str> {
+    fn from(s: BucketNamespace) -> Self {
+        s.0
+    }
+}
+
+impl FromStr for BucketNamespace {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s.to_owned()))
+    }
+}
 
 pub type BucketRegion = String;
 
@@ -3134,10 +3227,25 @@ pub struct CreateBucketInput {
     /// <i>DOC-EXAMPLE-BUCKET</i>--<i>usw2-az1</i>--x-s3</code>). For information about bucket naming restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html">Directory bucket naming rules</a> in the <i>Amazon S3 User Guide</i>
     /// </p>
     pub bucket: BucketName,
+    /// <p>Specifies the namespace where you want to create your general purpose bucket. When you create a
+    /// general purpose bucket, you can choose to create a bucket in the shared global namespace or you can choose to
+    /// create a bucket in your account regional namespace. Your account regional namespace is a subdivision of
+    /// the global namespace that only your account can create buckets in. For more information on bucket
+    /// namespaces, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/gpbucketnamespaces.html">Namespaces for general purpose buckets</a>.</p>
+    /// <p>General purpose buckets in your account regional namespace must follow a specific naming convention. These
+    /// buckets consist of a bucket name prefix that you create, and a suffix that contains your 12-digit Amazon Web Services
+    /// Account ID, the Amazon Web Services Region code, and ends with <code>-an</code>. Bucket names must follow the format
+    /// <code>bucket-name-prefix-accountId-region-an</code> (for example,
+    /// <code>amzn-s3-demo-bucket-111122223333-us-west-2-an</code>). For information about bucket naming
+    /// restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html#account-regional-naming-rules">Account regional namespace naming rules</a>
+    /// in the <i>Amazon S3 User Guide</i>.</p>
+    /// <note>
+    /// <p>This functionality is not supported for directory buckets.</p>
+    /// </note>
+    pub bucket_namespace: Option<BucketNamespace>,
     /// <p>The configuration information for the bucket.</p>
     pub create_bucket_configuration: Option<CreateBucketConfiguration>,
-    /// <p>Allows grantee the read, write, read ACP, and write ACP permissions on the
-    /// bucket.</p>
+    /// <p>Allows grantee the read, write, read ACP, and write ACP permissions on the bucket.</p>
     /// <note>
     /// <p>This functionality is not supported for directory buckets.</p>
     /// </note>
@@ -3153,8 +3261,8 @@ pub struct CreateBucketInput {
     /// </note>
     pub grant_read_acp: Option<GrantReadACP>,
     /// <p>Allows grantee to create new objects in the bucket.</p>
-    /// <p>For the bucket and object owners of existing objects, also allows deletions and
-    /// overwrites of those objects.</p>
+    /// <p>For the bucket and object owners of existing objects, also allows deletions and overwrites of those
+    /// objects.</p>
     /// <note>
     /// <p>This functionality is not supported for directory buckets.</p>
     /// </note>
@@ -3179,6 +3287,9 @@ impl fmt::Debug for CreateBucketInput {
             d.field("acl", val);
         }
         d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.bucket_namespace {
+            d.field("bucket_namespace", val);
+        }
         if let Some(ref val) = self.create_bucket_configuration {
             d.field("create_bucket_configuration", val);
         }
@@ -8002,6 +8113,48 @@ impl FromStr for FilterRuleName {
 pub type FilterRuleValue = String;
 
 pub type ForceDelete = bool;
+
+#[derive(Clone, Default, PartialEq)]
+pub struct GetBucketAbacInput {
+    /// <p>The name of the general purpose bucket.</p>
+    pub bucket: BucketName,
+    /// <p>The Amazon Web Services account ID of the general purpose bucket's owner. </p>
+    pub expected_bucket_owner: Option<AccountId>,
+}
+
+impl fmt::Debug for GetBucketAbacInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("GetBucketAbacInput");
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl GetBucketAbacInput {
+    #[must_use]
+    pub fn builder() -> builders::GetBucketAbacInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct GetBucketAbacOutput {
+    /// <p>The ABAC status of the general purpose bucket. </p>
+    pub abac_status: Option<AbacStatus>,
+}
+
+impl fmt::Debug for GetBucketAbacOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("GetBucketAbacOutput");
+        if let Some(ref val) = self.abac_status {
+            d.field("abac_status", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
 
 #[derive(Clone, Default, PartialEq)]
 pub struct GetBucketAccelerateConfigurationInput {
@@ -16878,6 +17031,57 @@ impl fmt::Debug for PublicAccessBlockConfiguration {
 }
 
 #[derive(Clone, PartialEq)]
+pub struct PutBucketAbacInput {
+    /// <p>The ABAC status of the general purpose bucket. When ABAC is enabled for the general purpose bucket, you can use tags to manage access to the general purpose buckets as well as for cost tracking purposes. When ABAC is disabled for the general purpose buckets, you can only use tags for cost tracking purposes. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging.html">Using tags with S3 general purpose buckets</a>. </p>
+    pub abac_status: AbacStatus,
+    /// <p>The name of the general purpose bucket.</p>
+    pub bucket: BucketName,
+    /// <p>Indicates the algorithm that you want Amazon S3 to use to create the checksum. For more
+    /// information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
+    pub checksum_algorithm: Option<ChecksumAlgorithm>,
+    /// <p>The MD5 hash of the <code>PutBucketAbac</code> request body. </p>
+    /// <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+    pub content_md5: Option<ContentMD5>,
+    /// <p>The Amazon Web Services account ID of the general purpose bucket's owner. </p>
+    pub expected_bucket_owner: Option<AccountId>,
+}
+
+impl fmt::Debug for PutBucketAbacInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("PutBucketAbacInput");
+        d.field("abac_status", &self.abac_status);
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.checksum_algorithm {
+            d.field("checksum_algorithm", val);
+        }
+        if let Some(ref val) = self.content_md5 {
+            d.field("content_md5", val);
+        }
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl PutBucketAbacInput {
+    #[must_use]
+    pub fn builder() -> builders::PutBucketAbacInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct PutBucketAbacOutput {}
+
+impl fmt::Debug for PutBucketAbacOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("PutBucketAbacOutput");
+        d.finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, PartialEq)]
 pub struct PutBucketAccelerateConfigurationInput {
     /// <p>Container for setting the transfer acceleration state.</p>
     pub accelerate_configuration: AccelerateConfiguration,
@@ -23059,6 +23263,7 @@ mod tests {
         require_default::<DeleteObjectTaggingOutput>();
         require_default::<DeleteObjectsOutput>();
         require_default::<DeletePublicAccessBlockOutput>();
+        require_default::<GetBucketAbacOutput>();
         require_default::<GetBucketAccelerateConfigurationOutput>();
         require_default::<GetBucketAclOutput>();
         require_default::<GetBucketAnalyticsConfigurationOutput>();
@@ -23103,6 +23308,7 @@ mod tests {
         require_default::<ListObjectsV2Output>();
         require_default::<ListPartsOutput>();
         require_default::<PostObjectOutput>();
+        require_default::<PutBucketAbacOutput>();
         require_default::<PutBucketAccelerateConfigurationOutput>();
         require_default::<PutBucketAclOutput>();
         require_default::<PutBucketAnalyticsConfigurationOutput>();
@@ -23186,6 +23392,8 @@ mod tests {
         require_clone::<DeleteObjectsOutput>();
         require_clone::<DeletePublicAccessBlockInput>();
         require_clone::<DeletePublicAccessBlockOutput>();
+        require_clone::<GetBucketAbacInput>();
+        require_clone::<GetBucketAbacOutput>();
         require_clone::<GetBucketAccelerateConfigurationInput>();
         require_clone::<GetBucketAccelerateConfigurationOutput>();
         require_clone::<GetBucketAclInput>();
@@ -23271,6 +23479,8 @@ mod tests {
         require_clone::<ListPartsInput>();
         require_clone::<ListPartsOutput>();
         require_clone::<PostObjectOutput>();
+        require_clone::<PutBucketAbacInput>();
+        require_clone::<PutBucketAbacOutput>();
         require_clone::<PutBucketAccelerateConfigurationInput>();
         require_clone::<PutBucketAccelerateConfigurationOutput>();
         require_clone::<PutBucketAclInput>();
@@ -24442,6 +24652,8 @@ pub mod builders {
 
         bucket: Option<BucketName>,
 
+        bucket_namespace: Option<BucketNamespace>,
+
         create_bucket_configuration: Option<CreateBucketConfiguration>,
 
         grant_full_control: Option<GrantFullControl>,
@@ -24467,6 +24679,11 @@ pub mod builders {
 
         pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
             self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_bucket_namespace(&mut self, field: Option<BucketNamespace>) -> &mut Self {
+            self.bucket_namespace = field;
             self
         }
 
@@ -24523,6 +24740,12 @@ pub mod builders {
         }
 
         #[must_use]
+        pub fn bucket_namespace(mut self, field: Option<BucketNamespace>) -> Self {
+            self.bucket_namespace = field;
+            self
+        }
+
+        #[must_use]
         pub fn create_bucket_configuration(mut self, field: Option<CreateBucketConfiguration>) -> Self {
             self.create_bucket_configuration = field;
             self
@@ -24573,6 +24796,7 @@ pub mod builders {
         pub fn build(self) -> Result<CreateBucketInput, BuildError> {
             let acl = self.acl;
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let bucket_namespace = self.bucket_namespace;
             let create_bucket_configuration = self.create_bucket_configuration;
             let grant_full_control = self.grant_full_control;
             let grant_read = self.grant_read;
@@ -24584,6 +24808,7 @@ pub mod builders {
             Ok(CreateBucketInput {
                 acl,
                 bucket,
+                bucket_namespace,
                 create_bucket_configuration,
                 grant_full_control,
                 grant_read,
@@ -26308,6 +26533,47 @@ pub mod builders {
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
             let expected_bucket_owner = self.expected_bucket_owner;
             Ok(DeletePublicAccessBlockInput {
+                bucket,
+                expected_bucket_owner,
+            })
+        }
+    }
+
+    /// A builder for [`GetBucketAbacInput`]
+    #[derive(Default)]
+    pub struct GetBucketAbacInputBuilder {
+        bucket: Option<BucketName>,
+
+        expected_bucket_owner: Option<AccountId>,
+    }
+
+    impl GetBucketAbacInputBuilder {
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn build(self) -> Result<GetBucketAbacInput, BuildError> {
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            Ok(GetBucketAbacInput {
                 bucket,
                 expected_bucket_owner,
             })
@@ -30499,6 +30765,92 @@ pub mod builders {
                 success_action_redirect,
                 success_action_status,
                 policy,
+            })
+        }
+    }
+
+    /// A builder for [`PutBucketAbacInput`]
+    #[derive(Default)]
+    pub struct PutBucketAbacInputBuilder {
+        abac_status: Option<AbacStatus>,
+
+        bucket: Option<BucketName>,
+
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+
+        content_md5: Option<ContentMD5>,
+
+        expected_bucket_owner: Option<AccountId>,
+    }
+
+    impl PutBucketAbacInputBuilder {
+        pub fn set_abac_status(&mut self, field: AbacStatus) -> &mut Self {
+            self.abac_status = Some(field);
+            self
+        }
+
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_algorithm(&mut self, field: Option<ChecksumAlgorithm>) -> &mut Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        pub fn set_content_md5(&mut self, field: Option<ContentMD5>) -> &mut Self {
+            self.content_md5 = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn abac_status(mut self, field: AbacStatus) -> Self {
+            self.abac_status = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_algorithm(mut self, field: Option<ChecksumAlgorithm>) -> Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        #[must_use]
+        pub fn content_md5(mut self, field: Option<ContentMD5>) -> Self {
+            self.content_md5 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn build(self) -> Result<PutBucketAbacInput, BuildError> {
+            let abac_status = self.abac_status.ok_or_else(|| BuildError::missing_field("abac_status"))?;
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_algorithm = self.checksum_algorithm;
+            let content_md5 = self.content_md5;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            Ok(PutBucketAbacInput {
+                abac_status,
+                bucket,
+                checksum_algorithm,
+                content_md5,
+                expected_bucket_owner,
             })
         }
     }
@@ -35456,6 +35808,15 @@ pub trait DtoExt {
     /// Modifies all empty string fields from `Some("")` to `None`
     fn ignore_empty_strings(&mut self);
 }
+impl DtoExt for AbacStatus {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref val) = self.status
+            && val.as_str() == ""
+        {
+            self.status = None;
+        }
+    }
+}
 impl DtoExt for AbortIncompleteMultipartUpload {
     fn ignore_empty_strings(&mut self) {}
 }
@@ -36095,6 +36456,11 @@ impl DtoExt for CreateBucketInput {
         {
             self.acl = None;
         }
+        if let Some(ref val) = self.bucket_namespace
+            && val.as_str() == ""
+        {
+            self.bucket_namespace = None;
+        }
         if let Some(ref mut val) = self.create_bucket_configuration {
             val.ignore_empty_strings();
         }
@@ -36649,6 +37015,20 @@ impl DtoExt for FilterRule {
         }
         if self.value.as_deref() == Some("") {
             self.value = None;
+        }
+    }
+}
+impl DtoExt for GetBucketAbacInput {
+    fn ignore_empty_strings(&mut self) {
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+    }
+}
+impl DtoExt for GetBucketAbacOutput {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.abac_status {
+            val.ignore_empty_strings();
         }
     }
 }
@@ -38657,6 +39037,22 @@ impl DtoExt for ProgressEvent {
 }
 impl DtoExt for PublicAccessBlockConfiguration {
     fn ignore_empty_strings(&mut self) {}
+}
+impl DtoExt for PutBucketAbacInput {
+    fn ignore_empty_strings(&mut self) {
+        self.abac_status.ignore_empty_strings();
+        if let Some(ref val) = self.checksum_algorithm
+            && val.as_str() == ""
+        {
+            self.checksum_algorithm = None;
+        }
+        if self.content_md5.as_deref() == Some("") {
+            self.content_md5 = None;
+        }
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+    }
 }
 impl DtoExt for PutBucketAccelerateConfigurationInput {
     fn ignore_empty_strings(&mut self) {

--- a/crates/s3s/src/header/generated.rs
+++ b/crates/s3s/src/header/generated.rs
@@ -61,6 +61,8 @@ pub const X_AMZ_BUCKET_LOCATION_NAME: HeaderName = HeaderName::from_static("x-am
 
 pub const X_AMZ_BUCKET_LOCATION_TYPE: HeaderName = HeaderName::from_static("x-amz-bucket-location-type");
 
+pub const X_AMZ_BUCKET_NAMESPACE: HeaderName = HeaderName::from_static("x-amz-bucket-namespace");
+
 pub const X_AMZ_BUCKET_OBJECT_LOCK_ENABLED: HeaderName = HeaderName::from_static("x-amz-bucket-object-lock-enabled");
 
 pub const X_AMZ_BUCKET_OBJECT_LOCK_TOKEN: HeaderName = HeaderName::from_static("x-amz-bucket-object-lock-token");

--- a/crates/s3s/src/header/generated_minio.rs
+++ b/crates/s3s/src/header/generated_minio.rs
@@ -61,6 +61,8 @@ pub const X_AMZ_BUCKET_LOCATION_NAME: HeaderName = HeaderName::from_static("x-am
 
 pub const X_AMZ_BUCKET_LOCATION_TYPE: HeaderName = HeaderName::from_static("x-amz-bucket-location-type");
 
+pub const X_AMZ_BUCKET_NAMESPACE: HeaderName = HeaderName::from_static("x-amz-bucket-namespace");
+
 pub const X_AMZ_BUCKET_OBJECT_LOCK_ENABLED: HeaderName = HeaderName::from_static("x-amz-bucket-object-lock-enabled");
 
 pub const X_AMZ_BUCKET_OBJECT_LOCK_TOKEN: HeaderName = HeaderName::from_static("x-amz-bucket-object-lock-token");

--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -28,6 +28,7 @@
 // DeleteObjectTagging
 // DeleteObjects
 // DeletePublicAccessBlock
+// GetBucketAbac
 // GetBucketAccelerateConfiguration
 // GetBucketAcl
 // GetBucketAnalyticsConfiguration
@@ -72,6 +73,7 @@
 // ListObjectsV2
 // ListParts
 // PostObject
+// PutBucketAbac
 // PutBucketAccelerateConfiguration
 // PutBucketAcl
 // PutBucketAnalyticsConfiguration
@@ -131,6 +133,16 @@ impl http::TryIntoHeaderValue for ArchiveStatus {
 }
 
 impl http::TryIntoHeaderValue for BucketCannedACL {
+    type Error = http::InvalidHeaderValue;
+    fn try_into_header_value(self) -> Result<http::HeaderValue, Self::Error> {
+        match Cow::from(self) {
+            Cow::Borrowed(s) => http::HeaderValue::try_from(s),
+            Cow::Owned(s) => http::HeaderValue::try_from(s),
+        }
+    }
+}
+
+impl http::TryIntoHeaderValue for BucketNamespace {
     type Error = http::InvalidHeaderValue;
     fn try_into_header_value(self) -> Result<http::HeaderValue, Self::Error> {
         match Cow::from(self) {
@@ -339,6 +351,14 @@ impl http::TryFromHeaderValue for ArchiveStatus {
 }
 
 impl http::TryFromHeaderValue for BucketCannedACL {
+    type Error = http::ParseHeaderError;
+    fn try_from_header_value(val: &http::HeaderValue) -> Result<Self, Self::Error> {
+        let val = val.to_str().map_err(|_| http::ParseHeaderError::Enum)?;
+        Ok(Self::from(val.to_owned()))
+    }
+}
+
+impl http::TryFromHeaderValue for BucketNamespace {
     type Error = http::ParseHeaderError;
     fn try_from_header_value(val: &http::HeaderValue) -> Result<Self, Self::Error> {
         let val = val.to_str().map_err(|_| http::ParseHeaderError::Enum)?;
@@ -870,6 +890,8 @@ impl CreateBucket {
 
         let acl: Option<BucketCannedACL> = http::parse_opt_header(req, &X_AMZ_ACL)?;
 
+        let bucket_namespace: Option<BucketNamespace> = http::parse_opt_header(req, &X_AMZ_BUCKET_NAMESPACE)?;
+
         let create_bucket_configuration: Option<CreateBucketConfiguration> = http::take_opt_xml_body(req)?;
 
         let grant_full_control: Option<GrantFullControl> = http::parse_opt_header(req, &X_AMZ_GRANT_FULL_CONTROL)?;
@@ -890,6 +912,7 @@ impl CreateBucket {
         Ok(CreateBucketInput {
             acl,
             bucket,
+            bucket_namespace,
             create_bucket_configuration,
             grant_full_control,
             grant_read,
@@ -2133,6 +2156,58 @@ impl super::Operation for DeletePublicAccessBlock {
             access.delete_public_access_block(&mut s3_req).await?;
         }
         let result = s3.delete_public_access_block(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
+pub struct GetBucketAbac;
+
+impl GetBucketAbac {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<GetBucketAbacInput> {
+        let bucket = http::unwrap_bucket(req);
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        Ok(GetBucketAbacInput {
+            bucket,
+            expected_bucket_owner,
+        })
+    }
+
+    pub fn serialize_http(x: GetBucketAbacOutput) -> S3Result<http::Response> {
+        let mut res = http::Response::with_status(http::StatusCode::OK);
+        if let Some(ref val) = x.abac_status {
+            http::set_xml_body(&mut res, val)?;
+        }
+        Ok(res)
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for GetBucketAbac {
+    fn name(&self) -> &'static str {
+        "GetBucketAbac"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.get_bucket_abac(&mut s3_req).await?;
+        }
+        let result = s3.get_bucket_abac(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
             Err(err) => return super::serialize_error(err, false),
@@ -4770,6 +4845,63 @@ impl super::Operation for ListParts {
             access.list_parts(&mut s3_req).await?;
         }
         let result = s3.list_parts(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
+pub struct PutBucketAbac;
+
+impl PutBucketAbac {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<PutBucketAbacInput> {
+        let bucket = http::unwrap_bucket(req);
+
+        let abac_status: AbacStatus = http::take_xml_body(req)?;
+
+        let checksum_algorithm: Option<ChecksumAlgorithm> = http::parse_checksum_algorithm_header(req)?;
+
+        let content_md5: Option<ContentMD5> = http::parse_opt_header(req, &CONTENT_MD5)?;
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        Ok(PutBucketAbacInput {
+            abac_status,
+            bucket,
+            checksum_algorithm,
+            content_md5,
+            expected_bucket_owner,
+        })
+    }
+
+    pub fn serialize_http(_: PutBucketAbacOutput) -> S3Result<http::Response> {
+        Ok(http::Response::with_status(http::StatusCode::OK))
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for PutBucketAbac {
+    fn name(&self) -> &'static str {
+        "PutBucketAbac"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.put_bucket_abac(&mut s3_req).await?;
+        }
+        let result = s3.put_bucket_abac(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
             Err(err) => return super::serialize_error(err, false),
@@ -7445,6 +7577,9 @@ pub fn resolve_route(
                     if qs.has("session") {
                         return Ok(&CreateSession as &'static dyn super::Operation);
                     }
+                    if qs.has("abac") {
+                        return Ok(&GetBucketAbac as &'static dyn super::Operation);
+                    }
                     if qs.has("accelerate") {
                         return Ok(&GetBucketAccelerateConfiguration as &'static dyn super::Operation);
                     }
@@ -7606,6 +7741,9 @@ pub fn resolve_route(
                     }
                     if qs.has("metrics") {
                         return Ok(&PutBucketMetricsConfiguration as &'static dyn super::Operation);
+                    }
+                    if qs.has("abac") {
+                        return Ok(&PutBucketAbac as &'static dyn super::Operation);
                     }
                     if qs.has("accelerate") {
                         return Ok(&PutBucketAccelerateConfiguration as &'static dyn super::Operation);

--- a/crates/s3s/src/ops/generated_minio.rs
+++ b/crates/s3s/src/ops/generated_minio.rs
@@ -28,6 +28,7 @@
 // DeleteObjectTagging
 // DeleteObjects
 // DeletePublicAccessBlock
+// GetBucketAbac
 // GetBucketAccelerateConfiguration
 // GetBucketAcl
 // GetBucketAnalyticsConfiguration
@@ -72,6 +73,7 @@
 // ListObjectsV2
 // ListParts
 // PostObject
+// PutBucketAbac
 // PutBucketAccelerateConfiguration
 // PutBucketAcl
 // PutBucketAnalyticsConfiguration
@@ -131,6 +133,16 @@ impl http::TryIntoHeaderValue for ArchiveStatus {
 }
 
 impl http::TryIntoHeaderValue for BucketCannedACL {
+    type Error = http::InvalidHeaderValue;
+    fn try_into_header_value(self) -> Result<http::HeaderValue, Self::Error> {
+        match Cow::from(self) {
+            Cow::Borrowed(s) => http::HeaderValue::try_from(s),
+            Cow::Owned(s) => http::HeaderValue::try_from(s),
+        }
+    }
+}
+
+impl http::TryIntoHeaderValue for BucketNamespace {
     type Error = http::InvalidHeaderValue;
     fn try_into_header_value(self) -> Result<http::HeaderValue, Self::Error> {
         match Cow::from(self) {
@@ -339,6 +351,14 @@ impl http::TryFromHeaderValue for ArchiveStatus {
 }
 
 impl http::TryFromHeaderValue for BucketCannedACL {
+    type Error = http::ParseHeaderError;
+    fn try_from_header_value(val: &http::HeaderValue) -> Result<Self, Self::Error> {
+        let val = val.to_str().map_err(|_| http::ParseHeaderError::Enum)?;
+        Ok(Self::from(val.to_owned()))
+    }
+}
+
+impl http::TryFromHeaderValue for BucketNamespace {
     type Error = http::ParseHeaderError;
     fn try_from_header_value(val: &http::HeaderValue) -> Result<Self, Self::Error> {
         let val = val.to_str().map_err(|_| http::ParseHeaderError::Enum)?;
@@ -873,6 +893,8 @@ impl CreateBucket {
 
         let acl: Option<BucketCannedACL> = http::parse_opt_header(req, &X_AMZ_ACL)?;
 
+        let bucket_namespace: Option<BucketNamespace> = http::parse_opt_header(req, &X_AMZ_BUCKET_NAMESPACE)?;
+
         let create_bucket_configuration: Option<CreateBucketConfiguration> = http::take_opt_xml_body(req)?;
 
         let grant_full_control: Option<GrantFullControl> = http::parse_opt_header(req, &X_AMZ_GRANT_FULL_CONTROL)?;
@@ -893,6 +915,7 @@ impl CreateBucket {
         Ok(CreateBucketInput {
             acl,
             bucket,
+            bucket_namespace,
             create_bucket_configuration,
             grant_full_control,
             grant_read,
@@ -2142,6 +2165,58 @@ impl super::Operation for DeletePublicAccessBlock {
             access.delete_public_access_block(&mut s3_req).await?;
         }
         let result = s3.delete_public_access_block(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
+pub struct GetBucketAbac;
+
+impl GetBucketAbac {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<GetBucketAbacInput> {
+        let bucket = http::unwrap_bucket(req);
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        Ok(GetBucketAbacInput {
+            bucket,
+            expected_bucket_owner,
+        })
+    }
+
+    pub fn serialize_http(x: GetBucketAbacOutput) -> S3Result<http::Response> {
+        let mut res = http::Response::with_status(http::StatusCode::OK);
+        if let Some(ref val) = x.abac_status {
+            http::set_xml_body(&mut res, val)?;
+        }
+        Ok(res)
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for GetBucketAbac {
+    fn name(&self) -> &'static str {
+        "GetBucketAbac"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.get_bucket_abac(&mut s3_req).await?;
+        }
+        let result = s3.get_bucket_abac(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
             Err(err) => return super::serialize_error(err, false),
@@ -4779,6 +4854,63 @@ impl super::Operation for ListParts {
             access.list_parts(&mut s3_req).await?;
         }
         let result = s3.list_parts(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
+pub struct PutBucketAbac;
+
+impl PutBucketAbac {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<PutBucketAbacInput> {
+        let bucket = http::unwrap_bucket(req);
+
+        let abac_status: AbacStatus = http::take_xml_body(req)?;
+
+        let checksum_algorithm: Option<ChecksumAlgorithm> = http::parse_checksum_algorithm_header(req)?;
+
+        let content_md5: Option<ContentMD5> = http::parse_opt_header(req, &CONTENT_MD5)?;
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        Ok(PutBucketAbacInput {
+            abac_status,
+            bucket,
+            checksum_algorithm,
+            content_md5,
+            expected_bucket_owner,
+        })
+    }
+
+    pub fn serialize_http(_: PutBucketAbacOutput) -> S3Result<http::Response> {
+        Ok(http::Response::with_status(http::StatusCode::OK))
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for PutBucketAbac {
+    fn name(&self) -> &'static str {
+        "PutBucketAbac"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.put_bucket_abac(&mut s3_req).await?;
+        }
+        let result = s3.put_bucket_abac(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
             Err(err) => return super::serialize_error(err, false),
@@ -7462,6 +7594,9 @@ pub fn resolve_route(
                     if qs.has("session") {
                         return Ok(&CreateSession as &'static dyn super::Operation);
                     }
+                    if qs.has("abac") {
+                        return Ok(&GetBucketAbac as &'static dyn super::Operation);
+                    }
                     if qs.has("accelerate") {
                         return Ok(&GetBucketAccelerateConfiguration as &'static dyn super::Operation);
                     }
@@ -7623,6 +7758,9 @@ pub fn resolve_route(
                     }
                     if qs.has("metrics") {
                         return Ok(&PutBucketMetricsConfiguration as &'static dyn super::Operation);
+                    }
+                    if qs.has("abac") {
+                        return Ok(&PutBucketAbac as &'static dyn super::Operation);
                     }
                     if qs.has("accelerate") {
                         return Ok(&PutBucketAccelerateConfiguration as &'static dyn super::Operation);

--- a/crates/s3s/src/ops/route_fixtures.json
+++ b/crates/s3s/src/ops/route_fixtures.json
@@ -3423,5 +3423,69 @@
     "zz"
    ]
   ]
+ },
+ {
+  "expect": "GetBucketAbac",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"abac\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "abac",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketAbac",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"abac\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "abac",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketAbac",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"abac\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "abac",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutBucketAbac",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"abac\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "abac",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
  }
 ]

--- a/crates/s3s/src/s3_trait.rs
+++ b/crates/s3s/src/s3_trait.rs
@@ -2028,6 +2028,11 @@ pub trait S3: Send + Sync + 'static {
         Err(s3_error!(NotImplemented, "DeletePublicAccessBlock is not implemented yet"))
     }
 
+    /// <p>Returns the attribute-based access control (ABAC) property of the general purpose bucket. If ABAC is enabled on your bucket, you can use tags on the bucket for access control. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging-enable-abac.html">Enabling ABAC in general purpose buckets</a>.</p>
+    async fn get_bucket_abac(&self, _req: S3Request<GetBucketAbacInput>) -> S3Result<S3Response<GetBucketAbacOutput>> {
+        Err(s3_error!(NotImplemented, "GetBucketAbac is not implemented yet"))
+    }
+
     /// <note>
     /// <p>This operation is not supported for directory buckets.</p>
     /// </note>
@@ -4437,6 +4442,11 @@ pub trait S3: Send + Sync + 'static {
             .put_object(req.map_input(crate::dto::post_object_input_into_put_object_input))
             .await?;
         Ok(resp.map_output(crate::dto::put_object_output_into_post_object_output))
+    }
+
+    /// <p>Sets the attribute-based access control (ABAC) property of the general purpose bucket. You must have <code>s3:PutBucketABAC</code> permission to perform this action. When you enable ABAC, you can use tags for access control on your buckets. Additionally, when ABAC is enabled, you must use the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_TagResource.html">TagResource</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_UntagResource.html">UntagResource</a> actions to manage tags on your buckets. You can nolonger use the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketTagging.html">PutBucketTagging</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketTagging.html">DeleteBucketTagging</a> actions to tag your bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging-enable-abac.html">Enabling ABAC in general purpose buckets</a>. </p>
+    async fn put_bucket_abac(&self, _req: S3Request<PutBucketAbacInput>) -> S3Result<S3Response<PutBucketAbacOutput>> {
+        Err(s3_error!(NotImplemented, "PutBucketAbac is not implemented yet"))
     }
 
     /// <note>

--- a/crates/s3s/src/xml/generated.rs
+++ b/crates/s3s/src/xml/generated.rs
@@ -11,6 +11,8 @@ use crate::dto::*;
 
 use std::io::Write;
 
+//   Serialize: AbacStatus
+// Deserialize: AbacStatus
 //   Serialize: AccelerateConfiguration
 // Deserialize: AccelerateConfiguration
 //   Serialize: AccessControlPolicy
@@ -122,6 +124,8 @@ use std::io::Write;
 //   Serialize: WebsiteConfiguration
 // Deserialize: WebsiteConfiguration
 
+//   SerializeContent: AbacStatus
+// DeserializeContent: AbacStatus
 //   SerializeContent: AbortIncompleteMultipartUpload
 // DeserializeContent: AbortIncompleteMultipartUpload
 //   SerializeContent: AccelerateConfiguration
@@ -172,6 +176,8 @@ use std::io::Write;
 // DeserializeContent: AssumedRoleUser
 //   SerializeContent: Bucket
 // DeserializeContent: Bucket
+//   SerializeContent: BucketAbacStatus
+// DeserializeContent: BucketAbacStatus
 //   SerializeContent: BucketAccelerateStatus
 // DeserializeContent: BucketAccelerateStatus
 //   SerializeContent: BucketInfo
@@ -836,6 +842,18 @@ use std::io::Write;
 
 const XMLNS_S3: &str = "http://s3.amazonaws.com/doc/2006-03-01/";
 
+impl Serialize for AbacStatus {
+    fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("AbacStatus", self)
+    }
+}
+
+impl<'xml> Deserialize<'xml> for AbacStatus {
+    fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.named_element("AbacStatus", Deserializer::content)
+    }
+}
+
 impl Serialize for AccelerateConfiguration {
     fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         s.content("AccelerateConfiguration", self)
@@ -1484,6 +1502,34 @@ impl<'xml> Deserialize<'xml> for WebsiteConfiguration {
     }
 }
 
+impl SerializeContent for AbacStatus {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.status {
+            s.content("Status", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for AbacStatus {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut status: Option<BucketAbacStatus> = None;
+        d.for_each_element(|d, x| match x {
+            b"Status" => {
+                if status.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                status = Some(d.content()?);
+                Ok(())
+            }
+            _ => {
+                d.skip_element_content()?;
+                Ok(())
+            }
+        })?;
+        Ok(Self { status })
+    }
+}
 impl SerializeContent for AbortIncompleteMultipartUpload {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         if let Some(ref val) = self.days_after_initiation {
@@ -1947,6 +1993,20 @@ impl<'xml> DeserializeContent<'xml> for Bucket {
             bucket_region,
             creation_date,
             name,
+        })
+    }
+}
+impl SerializeContent for BucketAbacStatus {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        self.as_str().serialize_content(s)
+    }
+}
+impl<'xml> DeserializeContent<'xml> for BucketAbacStatus {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.text(|s| match s {
+            "Disabled" => Ok(Self::from_static(BucketAbacStatus::DISABLED)),
+            "Enabled" => Ok(Self::from_static(BucketAbacStatus::ENABLED)),
+            _ => Ok(Self::from(s.to_owned())),
         })
     }
 }

--- a/crates/s3s/src/xml/generated_minio.rs
+++ b/crates/s3s/src/xml/generated_minio.rs
@@ -11,6 +11,8 @@ use crate::dto::*;
 
 use std::io::Write;
 
+//   Serialize: AbacStatus
+// Deserialize: AbacStatus
 //   Serialize: AccelerateConfiguration
 // Deserialize: AccelerateConfiguration
 //   Serialize: AccessControlPolicy
@@ -122,6 +124,8 @@ use std::io::Write;
 //   Serialize: WebsiteConfiguration
 // Deserialize: WebsiteConfiguration
 
+//   SerializeContent: AbacStatus
+// DeserializeContent: AbacStatus
 //   SerializeContent: AbortIncompleteMultipartUpload
 // DeserializeContent: AbortIncompleteMultipartUpload
 //   SerializeContent: AccelerateConfiguration
@@ -172,6 +176,8 @@ use std::io::Write;
 // DeserializeContent: AssumedRoleUser
 //   SerializeContent: Bucket
 // DeserializeContent: Bucket
+//   SerializeContent: BucketAbacStatus
+// DeserializeContent: BucketAbacStatus
 //   SerializeContent: BucketAccelerateStatus
 // DeserializeContent: BucketAccelerateStatus
 //   SerializeContent: BucketInfo
@@ -848,6 +854,18 @@ use std::io::Write;
 
 const XMLNS_S3: &str = "http://s3.amazonaws.com/doc/2006-03-01/";
 
+impl Serialize for AbacStatus {
+    fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("AbacStatus", self)
+    }
+}
+
+impl<'xml> Deserialize<'xml> for AbacStatus {
+    fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.named_element("AbacStatus", Deserializer::content)
+    }
+}
+
 impl Serialize for AccelerateConfiguration {
     fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         s.content("AccelerateConfiguration", self)
@@ -1496,6 +1514,34 @@ impl<'xml> Deserialize<'xml> for WebsiteConfiguration {
     }
 }
 
+impl SerializeContent for AbacStatus {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.status {
+            s.content("Status", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for AbacStatus {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut status: Option<BucketAbacStatus> = None;
+        d.for_each_element(|d, x| match x {
+            b"Status" => {
+                if status.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                status = Some(d.content()?);
+                Ok(())
+            }
+            _ => {
+                d.skip_element_content()?;
+                Ok(())
+            }
+        })?;
+        Ok(Self { status })
+    }
+}
 impl SerializeContent for AbortIncompleteMultipartUpload {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         if let Some(ref val) = self.days_after_initiation {
@@ -1959,6 +2005,20 @@ impl<'xml> DeserializeContent<'xml> for Bucket {
             bucket_region,
             creation_date,
             name,
+        })
+    }
+}
+impl SerializeContent for BucketAbacStatus {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        self.as_str().serialize_content(s)
+    }
+}
+impl<'xml> DeserializeContent<'xml> for BucketAbacStatus {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.text(|s| match s {
+            "Disabled" => Ok(Self::from_static(BucketAbacStatus::DISABLED)),
+            "Enabled" => Ok(Self::from_static(BucketAbacStatus::ENABLED)),
+            _ => Ok(Self::from(s.to_owned())),
         })
     }
 }

--- a/data/s3.json
+++ b/data/s3.json
@@ -29,6 +29,20 @@
         ]
     },
     "shapes": {
+        "com.amazonaws.s3#AbacStatus": {
+            "type": "structure",
+            "members": {
+                "Status": {
+                    "target": "com.amazonaws.s3#BucketAbacStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ABAC status of the general purpose bucket. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The ABAC status of the general purpose bucket. When ABAC is enabled for the general purpose bucket, you can use tags to manage access to the general purpose buckets as well as for cost tracking purposes. When ABAC is disabled for the general purpose buckets, you can only use tags for cost tracking purposes. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging.html\">Using tags with S3 general purpose buckets</a>. </p>"
+            }
+        },
         "com.amazonaws.s3#AbortDate": {
             "type": "timestamp"
         },
@@ -27301,6 +27315,23 @@
                 "smithy.api#documentation": "<p> In terms of implementation, a Bucket is a resource. </p>"
             }
         },
+        "com.amazonaws.s3#BucketAbacStatus": {
+            "type": "enum",
+            "members": {
+                "Enabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Enabled"
+                    }
+                },
+                "Disabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Disabled"
+                    }
+                }
+            }
+        },
         "com.amazonaws.s3#BucketAccelerateStatus": {
             "type": "enum",
             "members": {
@@ -27677,6 +27708,23 @@
         },
         "com.amazonaws.s3#BucketName": {
             "type": "string"
+        },
+        "com.amazonaws.s3#BucketNamespace": {
+            "type": "enum",
+            "members": {
+                "ACCOUNT_REGIONAL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "account-regional"
+                    }
+                },
+                "GLOBAL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "global"
+                    }
+                }
+            }
         },
         "com.amazonaws.s3#BucketRegion": {
             "type": "string"
@@ -29512,7 +29560,7 @@
                 "GrantFullControl": {
                     "target": "com.amazonaws.s3#GrantFullControl",
                     "traits": {
-                        "smithy.api#documentation": "<p>Allows grantee the read, write, read ACP, and write ACP permissions on the\n         bucket.</p>\n         <note>\n            <p>This functionality is not supported for directory buckets.</p>\n         </note>",
+                        "smithy.api#documentation": "<p>Allows grantee the read, write, read ACP, and write ACP permissions on the bucket.</p>\n         <note>\n            <p>This functionality is not supported for directory buckets.</p>\n         </note>",
                         "smithy.api#httpHeader": "x-amz-grant-full-control"
                     }
                 },
@@ -29533,7 +29581,7 @@
                 "GrantWrite": {
                     "target": "com.amazonaws.s3#GrantWrite",
                     "traits": {
-                        "smithy.api#documentation": "<p>Allows grantee to create new objects in the bucket.</p>\n         <p>For the bucket and object owners of existing objects, also allows deletions and\n         overwrites of those objects.</p>\n         <note>\n            <p>This functionality is not supported for directory buckets.</p>\n         </note>",
+                        "smithy.api#documentation": "<p>Allows grantee to create new objects in the bucket.</p>\n         <p>For the bucket and object owners of existing objects, also allows deletions and overwrites of those\n      objects.</p>\n         <note>\n            <p>This functionality is not supported for directory buckets.</p>\n         </note>",
                         "smithy.api#httpHeader": "x-amz-grant-write"
                     }
                 },
@@ -29555,6 +29603,13 @@
                     "target": "com.amazonaws.s3#ObjectOwnership",
                     "traits": {
                         "smithy.api#httpHeader": "x-amz-object-ownership"
+                    }
+                },
+                "BucketNamespace": {
+                    "target": "com.amazonaws.s3#BucketNamespace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the namespace where you want to create your general purpose bucket. When you create a\n    general purpose bucket, you can choose to create a bucket in the shared global namespace or you can choose to\n    create a bucket in your account regional namespace. Your account regional namespace is a subdivision of\n    the global namespace that only your account can create buckets in. For more information on bucket\n    namespaces, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/gpbucketnamespaces.html\">Namespaces for general purpose buckets</a>.</p>\n         <p>General purpose buckets in your account regional namespace must follow a specific naming convention. These\n    buckets consist of a bucket name prefix that you create, and a suffix that contains your 12-digit Amazon Web Services\n    Account ID, the Amazon Web Services Region code, and ends with <code>-an</code>. Bucket names must follow the format\n    <code>bucket-name-prefix-accountId-region-an</code> (for example,\n    <code>amzn-s3-demo-bucket-111122223333-us-west-2-an</code>). For information about bucket naming\n    restrictions, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html#account-regional-naming-rules\">Account regional namespace naming rules</a>\n    in the <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <p>This functionality is not supported for directory buckets.</p>\n         </note>",
+                        "smithy.api#httpHeader": "x-amz-bucket-namespace"
                     }
                 }
             },
@@ -32069,6 +32124,64 @@
         },
         "com.amazonaws.s3#FilterRuleValue": {
             "type": "string"
+        },
+        "com.amazonaws.s3#GetBucketAbac": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.s3#GetBucketAbacRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.s3#GetBucketAbacOutput"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Returns the attribute-based access control (ABAC) property of the general purpose bucket. If ABAC is enabled on your bucket, you can use tags on the bucket for access control. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging-enable-abac.html\">Enabling ABAC in general purpose buckets</a>.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/{Bucket}?abac",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.s3#GetBucketAbacOutput": {
+            "type": "structure",
+            "members": {
+                "AbacStatus": {
+                    "target": "com.amazonaws.s3#AbacStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ABAC status of the general purpose bucket. </p>",
+                        "smithy.api#httpPayload": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.s3#GetBucketAbacRequest": {
+            "type": "structure",
+            "members": {
+                "Bucket": {
+                    "target": "com.amazonaws.s3#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the general purpose bucket.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Bucket"
+                        }
+                    }
+                },
+                "ExpectedBucketOwner": {
+                    "target": "com.amazonaws.s3#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Web Services account ID of the general purpose bucket's owner. </p>",
+                        "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
         },
         "com.amazonaws.s3#GetBucketAccelerateConfiguration": {
             "type": "operation",
@@ -40220,6 +40333,75 @@
             },
             "traits": {
                 "smithy.api#documentation": "<p>The PublicAccessBlock configuration that you want to apply to this Amazon S3 bucket. You can\n         enable the configuration options in any combination. For more information about when Amazon S3\n         considers a bucket or object public, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status\">The Meaning of \"Public\"</a> in the <i>Amazon S3 User Guide</i>. </p>"
+            }
+        },
+        "com.amazonaws.s3#PutBucketAbac": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.s3#PutBucketAbacRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "traits": {
+                "aws.protocols#httpChecksum": {
+                    "requestAlgorithmMember": "ChecksumAlgorithm"
+                },
+                "smithy.api#documentation": "<p>Sets the attribute-based access control (ABAC) property of the general purpose bucket. You must have <code>s3:PutBucketABAC</code> permission to perform this action. When you enable ABAC, you can use tags for access control on your buckets. Additionally, when ABAC is enabled, you must use the <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_TagResource.html\">TagResource</a> and <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_UntagResource.html\">UntagResource</a> actions to manage tags on your buckets. You can nolonger use the <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketTagging.html\">PutBucketTagging</a> and <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketTagging.html\">DeleteBucketTagging</a> actions to tag your bucket. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging-enable-abac.html\">Enabling ABAC in general purpose buckets</a>. </p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/{Bucket}?abac",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.s3#PutBucketAbacRequest": {
+            "type": "structure",
+            "members": {
+                "Bucket": {
+                    "target": "com.amazonaws.s3#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the general purpose bucket.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Bucket"
+                        }
+                    }
+                },
+                "ContentMD5": {
+                    "target": "com.amazonaws.s3#ContentMD5",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The MD5 hash of the <code>PutBucketAbac</code> request body. </p>\n         <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>",
+                        "smithy.api#httpHeader": "Content-MD5"
+                    }
+                },
+                "ChecksumAlgorithm": {
+                    "target": "com.amazonaws.s3#ChecksumAlgorithm",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates the algorithm that you want Amazon S3 to use to create the checksum. For more\n         information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>",
+                        "smithy.api#httpHeader": "x-amz-sdk-checksum-algorithm"
+                    }
+                },
+                "ExpectedBucketOwner": {
+                    "target": "com.amazonaws.s3#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Web Services account ID of the general purpose bucket's owner. </p>",
+                        "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
+                    }
+                },
+                "AbacStatus": {
+                    "target": "com.amazonaws.s3#AbacStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ABAC status of the general purpose bucket. When ABAC is enabled for the general purpose bucket, you can use tags to manage access to the general purpose buckets as well as for cost tracking purposes. When ABAC is disabled for the general purpose buckets, you can only use tags for cost tracking purposes. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging.html\">Using tags with S3 general purpose buckets</a>. </p>",
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {},
+                        "smithy.api#xmlName": "AbacStatus"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3#PutBucketAccelerateConfiguration": {


### PR DESCRIPTION
## Summary

Add the attribute-based access control (ABAC) operations to the S3 model, following up on the model refresh merged in #698. Both operations get default stubs on the `S3Service` trait that return `NotImplemented` like the other operations.

## Changes

### `data/s3.json`

- +2 operations:
  - `PutBucketAbac` (`PUT /{Bucket}?abac`), request body `AbacStatus`
  - `GetBucketAbac` (`GET /{Bucket}?abac`)
- +6 shapes: `AbacStatus`, `BucketAbacStatus`, `BucketNamespace`, `PutBucketAbacRequest`, `GetBucketAbacRequest`, `GetBucketAbacOutput`
- `CreateBucketRequest` gains the `BucketNamespace` header (`x-amz-bucket-namespace`)
- All changed shapes are byte-identical to upstream `db89911`

### Generated code (`just codegen`, aws + minio variants)

- dto: new input/output types, `BucketNamespace`/`BucketAbacStatus` enums, and builders
- ops: HTTP deserialization, XML payload handling for `AbacStatus`, router rules for `?abac`
- s3_trait: `put_bucket_abac` / `get_bucket_abac` methods with `NotImplemented` stubs
- access: `put_bucket_abac` / `get_bucket_abac` access hooks
- s3s-aws conv/proxy: field wiring to `aws_sdk_s3` `PutBucketAbac` / `GetBucketAbac`

### Route fixtures

- +4 entries for the `?abac` router rules

## Verification

- `just codegen` idempotent (second run produces no diff)
- `just lint` clean
- `just test` 922 passed
- changed model shapes verified byte-identical to upstream `db89911`