### PR TITLE
feat(data): add bucket metadata configuration operations to S3 model

### DIFF
--- a/codegen/src/v1/aws_conv.rs
+++ b/codegen/src/v1/aws_conv.rs
@@ -295,9 +295,14 @@ fn has_unconditional_builder(name: &str) -> bool {
         name,
         "AnalyticsExportDestination"
             | "CreateSessionOutput"
+            | "GetBucketMetadataConfigurationResult"
             | "InventoryDestination"
-            | "RoutingRule"
+            | "JournalTableConfiguration"
+            | "JournalTableConfigurationUpdates"
+            | "MetadataConfiguration"
+            | "MetadataConfigurationResult"
             | "MetadataTableConfiguration"
             | "MetadataTableConfigurationResult"
+            | "RoutingRule"
     )
 }

--- a/crates/s3s-aws/src/conv/generated.rs
+++ b/crates/s3s-aws/src/conv/generated.rs
@@ -255,6 +255,92 @@ impl AwsConversion for s3s::dto::AnalyticsS3ExportFileFormat {
     }
 }
 
+impl AwsConversion for s3s::dto::AnnotationConfigurationState {
+    type Target = aws_sdk_s3::types::AnnotationConfigurationState;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(match x {
+            aws_sdk_s3::types::AnnotationConfigurationState::Disabled => Self::from_static(Self::DISABLED),
+            aws_sdk_s3::types::AnnotationConfigurationState::Enabled => Self::from_static(Self::ENABLED),
+            _ => Self::from(x.as_str().to_owned()),
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        Ok(aws_sdk_s3::types::AnnotationConfigurationState::from(x.as_str()))
+    }
+}
+
+impl AwsConversion for s3s::dto::AnnotationTableConfiguration {
+    type Target = aws_sdk_s3::types::AnnotationTableConfiguration;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            configuration_state: try_from_aws(x.configuration_state)?,
+            encryption_configuration: try_from_aws(x.encryption_configuration)?,
+            role: try_from_aws(x.role)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_configuration_state(Some(try_into_aws(x.configuration_state)?));
+        y = y.set_encryption_configuration(try_into_aws(x.encryption_configuration)?);
+        y = y.set_role(try_into_aws(x.role)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::AnnotationTableConfigurationResult {
+    type Target = aws_sdk_s3::types::AnnotationTableConfigurationResult;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            configuration_state: try_from_aws(x.configuration_state)?,
+            error: try_from_aws(x.error)?,
+            role: try_from_aws(x.role)?,
+            table_arn: try_from_aws(x.table_arn)?,
+            table_name: try_from_aws(x.table_name)?,
+            table_status: try_from_aws(x.table_status)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_configuration_state(Some(try_into_aws(x.configuration_state)?));
+        y = y.set_error(try_into_aws(x.error)?);
+        y = y.set_role(try_into_aws(x.role)?);
+        y = y.set_table_arn(try_into_aws(x.table_arn)?);
+        y = y.set_table_name(try_into_aws(x.table_name)?);
+        y = y.set_table_status(try_into_aws(x.table_status)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::AnnotationTableConfigurationUpdates {
+    type Target = aws_sdk_s3::types::AnnotationTableConfigurationUpdates;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            configuration_state: try_from_aws(x.configuration_state)?,
+            encryption_configuration: try_from_aws(x.encryption_configuration)?,
+            role: try_from_aws(x.role)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_configuration_state(Some(try_into_aws(x.configuration_state)?));
+        y = y.set_encryption_configuration(try_into_aws(x.encryption_configuration)?);
+        y = y.set_role(try_into_aws(x.role)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
 impl AwsConversion for s3s::dto::ArchiveStatus {
     type Target = aws_sdk_s3::types::ArchiveStatus;
     type Error = S3Error;
@@ -1262,6 +1348,47 @@ impl AwsConversion for s3s::dto::CreateBucketInput {
     }
 }
 
+impl AwsConversion for s3s::dto::CreateBucketMetadataConfigurationInput {
+    type Target = aws_sdk_s3::operation::create_bucket_metadata_configuration::CreateBucketMetadataConfigurationInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            checksum_algorithm: try_from_aws(x.checksum_algorithm)?,
+            content_md5: try_from_aws(x.content_md5)?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+            metadata_configuration: unwrap_from_aws(x.metadata_configuration, "metadata_configuration")?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_checksum_algorithm(try_into_aws(x.checksum_algorithm)?);
+        y = y.set_content_md5(try_into_aws(x.content_md5)?);
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y = y.set_metadata_configuration(Some(try_into_aws(x.metadata_configuration)?));
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::CreateBucketMetadataConfigurationOutput {
+    type Target = aws_sdk_s3::operation::create_bucket_metadata_configuration::CreateBucketMetadataConfigurationOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
+    }
+}
+
 impl AwsConversion for s3s::dto::CreateBucketMetadataTableConfigurationInput {
     type Target = aws_sdk_s3::operation::create_bucket_metadata_table_configuration::CreateBucketMetadataTableConfigurationInput;
     type Error = S3Error;
@@ -1772,6 +1899,41 @@ impl AwsConversion for s3s::dto::DeleteBucketLifecycleInput {
 
 impl AwsConversion for s3s::dto::DeleteBucketLifecycleOutput {
     type Target = aws_sdk_s3::operation::delete_bucket_lifecycle::DeleteBucketLifecycleOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::DeleteBucketMetadataConfigurationInput {
+    type Target = aws_sdk_s3::operation::delete_bucket_metadata_configuration::DeleteBucketMetadataConfigurationInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::DeleteBucketMetadataConfigurationOutput {
+    type Target = aws_sdk_s3::operation::delete_bucket_metadata_configuration::DeleteBucketMetadataConfigurationOutput;
     type Error = S3Error;
 
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
@@ -2341,6 +2503,27 @@ impl AwsConversion for s3s::dto::Destination {
     }
 }
 
+impl AwsConversion for s3s::dto::DestinationResult {
+    type Target = aws_sdk_s3::types::DestinationResult;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            table_bucket_arn: try_from_aws(x.table_bucket_arn)?,
+            table_bucket_type: try_from_aws(x.table_bucket_type)?,
+            table_namespace: try_from_aws(x.table_namespace)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_table_bucket_arn(try_into_aws(x.table_bucket_arn)?);
+        y = y.set_table_bucket_type(try_into_aws(x.table_bucket_type)?);
+        y = y.set_table_namespace(try_into_aws(x.table_namespace)?);
+        Ok(y.build())
+    }
+}
+
 impl AwsConversion for s3s::dto::EncodingType {
     type Target = aws_sdk_s3::types::EncodingType;
     type Error = S3Error;
@@ -2533,6 +2716,23 @@ impl AwsConversion for s3s::dto::ExistingObjectReplicationStatus {
 
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         Ok(aws_sdk_s3::types::ExistingObjectReplicationStatus::from(x.as_str()))
+    }
+}
+
+impl AwsConversion for s3s::dto::ExpirationState {
+    type Target = aws_sdk_s3::types::ExpirationState;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(match x {
+            aws_sdk_s3::types::ExpirationState::Disabled => Self::from_static(Self::DISABLED),
+            aws_sdk_s3::types::ExpirationState::Enabled => Self::from_static(Self::ENABLED),
+            _ => Self::from(x.as_str().to_owned()),
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        Ok(aws_sdk_s3::types::ExpirationState::from(x.as_str()))
     }
 }
 
@@ -3031,6 +3231,59 @@ impl AwsConversion for s3s::dto::GetBucketLoggingOutput {
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         let mut y = Self::Target::builder();
         y = y.set_logging_enabled(try_into_aws(x.logging_enabled)?);
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::GetBucketMetadataConfigurationInput {
+    type Target = aws_sdk_s3::operation::get_bucket_metadata_configuration::GetBucketMetadataConfigurationInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::GetBucketMetadataConfigurationOutput {
+    type Target = aws_sdk_s3::operation::get_bucket_metadata_configuration::GetBucketMetadataConfigurationOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            get_bucket_metadata_configuration_result: try_from_aws(x.get_bucket_metadata_configuration_result)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_get_bucket_metadata_configuration_result(try_into_aws(x.get_bucket_metadata_configuration_result)?);
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::GetBucketMetadataConfigurationResult {
+    type Target = aws_sdk_s3::types::GetBucketMetadataConfigurationResult;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            metadata_configuration_result: unwrap_from_aws(x.metadata_configuration_result, "metadata_configuration_result")?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_metadata_configuration_result(Some(try_into_aws(x.metadata_configuration_result)?));
         Ok(y.build())
     }
 }
@@ -4529,6 +4782,23 @@ impl AwsConversion for s3s::dto::InventoryConfiguration {
     }
 }
 
+impl AwsConversion for s3s::dto::InventoryConfigurationState {
+    type Target = aws_sdk_s3::types::InventoryConfigurationState;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(match x {
+            aws_sdk_s3::types::InventoryConfigurationState::Disabled => Self::from_static(Self::DISABLED),
+            aws_sdk_s3::types::InventoryConfigurationState::Enabled => Self::from_static(Self::ENABLED),
+            _ => Self::from(x.as_str().to_owned()),
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        Ok(aws_sdk_s3::types::InventoryConfigurationState::from(x.as_str()))
+    }
+}
+
 impl AwsConversion for s3s::dto::InventoryDestination {
     type Target = aws_sdk_s3::types::InventoryDestination;
     type Error = S3Error;
@@ -4717,6 +4987,69 @@ impl AwsConversion for s3s::dto::InventorySchedule {
     }
 }
 
+impl AwsConversion for s3s::dto::InventoryTableConfiguration {
+    type Target = aws_sdk_s3::types::InventoryTableConfiguration;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            configuration_state: try_from_aws(x.configuration_state)?,
+            encryption_configuration: try_from_aws(x.encryption_configuration)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_configuration_state(Some(try_into_aws(x.configuration_state)?));
+        y = y.set_encryption_configuration(try_into_aws(x.encryption_configuration)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::InventoryTableConfigurationResult {
+    type Target = aws_sdk_s3::types::InventoryTableConfigurationResult;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            configuration_state: try_from_aws(x.configuration_state)?,
+            error: try_from_aws(x.error)?,
+            table_arn: try_from_aws(x.table_arn)?,
+            table_name: try_from_aws(x.table_name)?,
+            table_status: try_from_aws(x.table_status)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_configuration_state(Some(try_into_aws(x.configuration_state)?));
+        y = y.set_error(try_into_aws(x.error)?);
+        y = y.set_table_arn(try_into_aws(x.table_arn)?);
+        y = y.set_table_name(try_into_aws(x.table_name)?);
+        y = y.set_table_status(try_into_aws(x.table_status)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::InventoryTableConfigurationUpdates {
+    type Target = aws_sdk_s3::types::InventoryTableConfigurationUpdates;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            configuration_state: try_from_aws(x.configuration_state)?,
+            encryption_configuration: try_from_aws(x.encryption_configuration)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_configuration_state(Some(try_into_aws(x.configuration_state)?));
+        y = y.set_encryption_configuration(try_into_aws(x.encryption_configuration)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
 impl AwsConversion for s3s::dto::JSONInput {
     type Target = aws_sdk_s3::types::JsonInput;
     type Error = S3Error;
@@ -4765,6 +5098,67 @@ impl AwsConversion for s3s::dto::JSONType {
 
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         Ok(aws_sdk_s3::types::JsonType::from(x.as_str()))
+    }
+}
+
+impl AwsConversion for s3s::dto::JournalTableConfiguration {
+    type Target = aws_sdk_s3::types::JournalTableConfiguration;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            encryption_configuration: try_from_aws(x.encryption_configuration)?,
+            record_expiration: unwrap_from_aws(x.record_expiration, "record_expiration")?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_encryption_configuration(try_into_aws(x.encryption_configuration)?);
+        y = y.set_record_expiration(Some(try_into_aws(x.record_expiration)?));
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::JournalTableConfigurationResult {
+    type Target = aws_sdk_s3::types::JournalTableConfigurationResult;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            error: try_from_aws(x.error)?,
+            record_expiration: unwrap_from_aws(x.record_expiration, "record_expiration")?,
+            table_arn: try_from_aws(x.table_arn)?,
+            table_name: try_from_aws(x.table_name)?,
+            table_status: try_from_aws(x.table_status)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_error(try_into_aws(x.error)?);
+        y = y.set_record_expiration(Some(try_into_aws(x.record_expiration)?));
+        y = y.set_table_arn(try_into_aws(x.table_arn)?);
+        y = y.set_table_name(Some(try_into_aws(x.table_name)?));
+        y = y.set_table_status(Some(try_into_aws(x.table_status)?));
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::JournalTableConfigurationUpdates {
+    type Target = aws_sdk_s3::types::JournalTableConfigurationUpdates;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            record_expiration: unwrap_from_aws(x.record_expiration, "record_expiration")?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_record_expiration(Some(try_into_aws(x.record_expiration)?));
+        Ok(y.build())
     }
 }
 
@@ -5632,6 +6026,50 @@ impl AwsConversion for s3s::dto::MFADeleteStatus {
     }
 }
 
+impl AwsConversion for s3s::dto::MetadataConfiguration {
+    type Target = aws_sdk_s3::types::MetadataConfiguration;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            annotation_table_configuration: try_from_aws(x.annotation_table_configuration)?,
+            inventory_table_configuration: try_from_aws(x.inventory_table_configuration)?,
+            journal_table_configuration: unwrap_from_aws(x.journal_table_configuration, "journal_table_configuration")?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_annotation_table_configuration(try_into_aws(x.annotation_table_configuration)?);
+        y = y.set_inventory_table_configuration(try_into_aws(x.inventory_table_configuration)?);
+        y = y.set_journal_table_configuration(Some(try_into_aws(x.journal_table_configuration)?));
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::MetadataConfigurationResult {
+    type Target = aws_sdk_s3::types::MetadataConfigurationResult;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            annotation_table_configuration_result: try_from_aws(x.annotation_table_configuration_result)?,
+            destination_result: unwrap_from_aws(x.destination_result, "destination_result")?,
+            inventory_table_configuration_result: try_from_aws(x.inventory_table_configuration_result)?,
+            journal_table_configuration_result: try_from_aws(x.journal_table_configuration_result)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_annotation_table_configuration_result(try_into_aws(x.annotation_table_configuration_result)?);
+        y = y.set_destination_result(Some(try_into_aws(x.destination_result)?));
+        y = y.set_inventory_table_configuration_result(try_into_aws(x.inventory_table_configuration_result)?);
+        y = y.set_journal_table_configuration_result(try_into_aws(x.journal_table_configuration_result)?);
+        Ok(y.build())
+    }
+}
+
 impl AwsConversion for s3s::dto::MetadataDirective {
     type Target = aws_sdk_s3::types::MetadataDirective;
     type Error = S3Error;
@@ -5699,6 +6137,25 @@ impl AwsConversion for s3s::dto::MetadataTableConfigurationResult {
         let mut y = Self::Target::builder();
         y = y.set_s3_tables_destination_result(Some(try_into_aws(x.s3_tables_destination_result)?));
         Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::MetadataTableEncryptionConfiguration {
+    type Target = aws_sdk_s3::types::MetadataTableEncryptionConfiguration;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            kms_key_arn: try_from_aws(x.kms_key_arn)?,
+            sse_algorithm: try_from_aws(x.sse_algorithm)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_kms_key_arn(try_into_aws(x.kms_key_arn)?);
+        y = y.set_sse_algorithm(Some(try_into_aws(x.sse_algorithm)?));
+        y.build().map_err(S3Error::internal_error)
     }
 }
 
@@ -8029,6 +8486,25 @@ impl AwsConversion for s3s::dto::QuoteFields {
     }
 }
 
+impl AwsConversion for s3s::dto::RecordExpiration {
+    type Target = aws_sdk_s3::types::RecordExpiration;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            days: try_from_aws(x.days)?,
+            expiration: try_from_aws(x.expiration)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_days(try_into_aws(x.days)?);
+        y = y.set_expiration(Some(try_into_aws(x.expiration)?));
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
 impl AwsConversion for s3s::dto::RecordsEvent {
     type Target = aws_sdk_s3::types::RecordsEvent;
     type Error = S3Error;
@@ -8608,6 +9084,23 @@ impl AwsConversion for s3s::dto::S3Location {
     }
 }
 
+impl AwsConversion for s3s::dto::S3TablesBucketType {
+    type Target = aws_sdk_s3::types::S3TablesBucketType;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(match x {
+            aws_sdk_s3::types::S3TablesBucketType::Aws => Self::from_static(Self::AWS),
+            aws_sdk_s3::types::S3TablesBucketType::Customer => Self::from_static(Self::CUSTOMER),
+            _ => Self::from(x.as_str().to_owned()),
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        Ok(aws_sdk_s3::types::S3TablesBucketType::from(x.as_str()))
+    }
+}
+
 impl AwsConversion for s3s::dto::S3TablesDestination {
     type Target = aws_sdk_s3::types::S3TablesDestination;
     type Error = S3Error;
@@ -9070,6 +9563,23 @@ impl AwsConversion for s3s::dto::StorageClassAnalysisSchemaVersion {
     }
 }
 
+impl AwsConversion for s3s::dto::TableSseAlgorithm {
+    type Target = aws_sdk_s3::types::TableSseAlgorithm;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(match x {
+            aws_sdk_s3::types::TableSseAlgorithm::Aes256 => Self::from_static(Self::AES256),
+            aws_sdk_s3::types::TableSseAlgorithm::AwsKms => Self::from_static(Self::AWS_KMS),
+            _ => Self::from(x.as_str().to_owned()),
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        Ok(aws_sdk_s3::types::TableSseAlgorithm::from(x.as_str()))
+    }
+}
+
 impl AwsConversion for s3s::dto::Tagging {
     type Target = aws_sdk_s3::types::Tagging;
     type Error = S3Error;
@@ -9296,6 +9806,129 @@ impl AwsConversion for s3s::dto::Type {
 
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         Ok(aws_sdk_s3::types::Type::from(x.as_str()))
+    }
+}
+
+impl AwsConversion for s3s::dto::UpdateBucketMetadataAnnotationTableConfigurationInput {
+    type Target = aws_sdk_s3::operation::update_bucket_metadata_annotation_table_configuration::UpdateBucketMetadataAnnotationTableConfigurationInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            annotation_table_configuration: unwrap_from_aws(x.annotation_table_configuration, "annotation_table_configuration")?,
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            checksum_algorithm: try_from_aws(x.checksum_algorithm)?,
+            content_md5: try_from_aws(x.content_md5)?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_annotation_table_configuration(Some(try_into_aws(x.annotation_table_configuration)?));
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_checksum_algorithm(try_into_aws(x.checksum_algorithm)?);
+        y = y.set_content_md5(try_into_aws(x.content_md5)?);
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::UpdateBucketMetadataAnnotationTableConfigurationOutput {
+    type Target = aws_sdk_s3::operation::update_bucket_metadata_annotation_table_configuration::UpdateBucketMetadataAnnotationTableConfigurationOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::UpdateBucketMetadataInventoryTableConfigurationInput {
+    type Target = aws_sdk_s3::operation::update_bucket_metadata_inventory_table_configuration::UpdateBucketMetadataInventoryTableConfigurationInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            checksum_algorithm: try_from_aws(x.checksum_algorithm)?,
+            content_md5: try_from_aws(x.content_md5)?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+            inventory_table_configuration: unwrap_from_aws(x.inventory_table_configuration, "inventory_table_configuration")?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_checksum_algorithm(try_into_aws(x.checksum_algorithm)?);
+        y = y.set_content_md5(try_into_aws(x.content_md5)?);
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y = y.set_inventory_table_configuration(Some(try_into_aws(x.inventory_table_configuration)?));
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::UpdateBucketMetadataInventoryTableConfigurationOutput {
+    type Target = aws_sdk_s3::operation::update_bucket_metadata_inventory_table_configuration::UpdateBucketMetadataInventoryTableConfigurationOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::UpdateBucketMetadataJournalTableConfigurationInput {
+    type Target = aws_sdk_s3::operation::update_bucket_metadata_journal_table_configuration::UpdateBucketMetadataJournalTableConfigurationInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            checksum_algorithm: try_from_aws(x.checksum_algorithm)?,
+            content_md5: try_from_aws(x.content_md5)?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+            journal_table_configuration: unwrap_from_aws(x.journal_table_configuration, "journal_table_configuration")?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_checksum_algorithm(try_into_aws(x.checksum_algorithm)?);
+        y = y.set_content_md5(try_into_aws(x.content_md5)?);
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y = y.set_journal_table_configuration(Some(try_into_aws(x.journal_table_configuration)?));
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::UpdateBucketMetadataJournalTableConfigurationOutput {
+    type Target = aws_sdk_s3::operation::update_bucket_metadata_journal_table_configuration::UpdateBucketMetadataJournalTableConfigurationOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
     }
 }
 

--- a/crates/s3s-aws/src/conv/generated_minio.rs
+++ b/crates/s3s-aws/src/conv/generated_minio.rs
@@ -255,6 +255,92 @@ impl AwsConversion for s3s::dto::AnalyticsS3ExportFileFormat {
     }
 }
 
+impl AwsConversion for s3s::dto::AnnotationConfigurationState {
+    type Target = aws_sdk_s3::types::AnnotationConfigurationState;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(match x {
+            aws_sdk_s3::types::AnnotationConfigurationState::Disabled => Self::from_static(Self::DISABLED),
+            aws_sdk_s3::types::AnnotationConfigurationState::Enabled => Self::from_static(Self::ENABLED),
+            _ => Self::from(x.as_str().to_owned()),
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        Ok(aws_sdk_s3::types::AnnotationConfigurationState::from(x.as_str()))
+    }
+}
+
+impl AwsConversion for s3s::dto::AnnotationTableConfiguration {
+    type Target = aws_sdk_s3::types::AnnotationTableConfiguration;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            configuration_state: try_from_aws(x.configuration_state)?,
+            encryption_configuration: try_from_aws(x.encryption_configuration)?,
+            role: try_from_aws(x.role)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_configuration_state(Some(try_into_aws(x.configuration_state)?));
+        y = y.set_encryption_configuration(try_into_aws(x.encryption_configuration)?);
+        y = y.set_role(try_into_aws(x.role)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::AnnotationTableConfigurationResult {
+    type Target = aws_sdk_s3::types::AnnotationTableConfigurationResult;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            configuration_state: try_from_aws(x.configuration_state)?,
+            error: try_from_aws(x.error)?,
+            role: try_from_aws(x.role)?,
+            table_arn: try_from_aws(x.table_arn)?,
+            table_name: try_from_aws(x.table_name)?,
+            table_status: try_from_aws(x.table_status)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_configuration_state(Some(try_into_aws(x.configuration_state)?));
+        y = y.set_error(try_into_aws(x.error)?);
+        y = y.set_role(try_into_aws(x.role)?);
+        y = y.set_table_arn(try_into_aws(x.table_arn)?);
+        y = y.set_table_name(try_into_aws(x.table_name)?);
+        y = y.set_table_status(try_into_aws(x.table_status)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::AnnotationTableConfigurationUpdates {
+    type Target = aws_sdk_s3::types::AnnotationTableConfigurationUpdates;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            configuration_state: try_from_aws(x.configuration_state)?,
+            encryption_configuration: try_from_aws(x.encryption_configuration)?,
+            role: try_from_aws(x.role)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_configuration_state(Some(try_into_aws(x.configuration_state)?));
+        y = y.set_encryption_configuration(try_into_aws(x.encryption_configuration)?);
+        y = y.set_role(try_into_aws(x.role)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
 impl AwsConversion for s3s::dto::ArchiveStatus {
     type Target = aws_sdk_s3::types::ArchiveStatus;
     type Error = S3Error;
@@ -1264,6 +1350,47 @@ impl AwsConversion for s3s::dto::CreateBucketInput {
     }
 }
 
+impl AwsConversion for s3s::dto::CreateBucketMetadataConfigurationInput {
+    type Target = aws_sdk_s3::operation::create_bucket_metadata_configuration::CreateBucketMetadataConfigurationInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            checksum_algorithm: try_from_aws(x.checksum_algorithm)?,
+            content_md5: try_from_aws(x.content_md5)?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+            metadata_configuration: unwrap_from_aws(x.metadata_configuration, "metadata_configuration")?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_checksum_algorithm(try_into_aws(x.checksum_algorithm)?);
+        y = y.set_content_md5(try_into_aws(x.content_md5)?);
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y = y.set_metadata_configuration(Some(try_into_aws(x.metadata_configuration)?));
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::CreateBucketMetadataConfigurationOutput {
+    type Target = aws_sdk_s3::operation::create_bucket_metadata_configuration::CreateBucketMetadataConfigurationOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
+    }
+}
+
 impl AwsConversion for s3s::dto::CreateBucketMetadataTableConfigurationInput {
     type Target = aws_sdk_s3::operation::create_bucket_metadata_table_configuration::CreateBucketMetadataTableConfigurationInput;
     type Error = S3Error;
@@ -1776,6 +1903,41 @@ impl AwsConversion for s3s::dto::DeleteBucketLifecycleInput {
 
 impl AwsConversion for s3s::dto::DeleteBucketLifecycleOutput {
     type Target = aws_sdk_s3::operation::delete_bucket_lifecycle::DeleteBucketLifecycleOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::DeleteBucketMetadataConfigurationInput {
+    type Target = aws_sdk_s3::operation::delete_bucket_metadata_configuration::DeleteBucketMetadataConfigurationInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::DeleteBucketMetadataConfigurationOutput {
+    type Target = aws_sdk_s3::operation::delete_bucket_metadata_configuration::DeleteBucketMetadataConfigurationOutput;
     type Error = S3Error;
 
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
@@ -2345,6 +2507,27 @@ impl AwsConversion for s3s::dto::Destination {
     }
 }
 
+impl AwsConversion for s3s::dto::DestinationResult {
+    type Target = aws_sdk_s3::types::DestinationResult;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            table_bucket_arn: try_from_aws(x.table_bucket_arn)?,
+            table_bucket_type: try_from_aws(x.table_bucket_type)?,
+            table_namespace: try_from_aws(x.table_namespace)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_table_bucket_arn(try_into_aws(x.table_bucket_arn)?);
+        y = y.set_table_bucket_type(try_into_aws(x.table_bucket_type)?);
+        y = y.set_table_namespace(try_into_aws(x.table_namespace)?);
+        Ok(y.build())
+    }
+}
+
 impl AwsConversion for s3s::dto::EncodingType {
     type Target = aws_sdk_s3::types::EncodingType;
     type Error = S3Error;
@@ -2537,6 +2720,23 @@ impl AwsConversion for s3s::dto::ExistingObjectReplicationStatus {
 
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         Ok(aws_sdk_s3::types::ExistingObjectReplicationStatus::from(x.as_str()))
+    }
+}
+
+impl AwsConversion for s3s::dto::ExpirationState {
+    type Target = aws_sdk_s3::types::ExpirationState;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(match x {
+            aws_sdk_s3::types::ExpirationState::Disabled => Self::from_static(Self::DISABLED),
+            aws_sdk_s3::types::ExpirationState::Enabled => Self::from_static(Self::ENABLED),
+            _ => Self::from(x.as_str().to_owned()),
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        Ok(aws_sdk_s3::types::ExpirationState::from(x.as_str()))
     }
 }
 
@@ -3035,6 +3235,59 @@ impl AwsConversion for s3s::dto::GetBucketLoggingOutput {
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         let mut y = Self::Target::builder();
         y = y.set_logging_enabled(try_into_aws(x.logging_enabled)?);
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::GetBucketMetadataConfigurationInput {
+    type Target = aws_sdk_s3::operation::get_bucket_metadata_configuration::GetBucketMetadataConfigurationInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::GetBucketMetadataConfigurationOutput {
+    type Target = aws_sdk_s3::operation::get_bucket_metadata_configuration::GetBucketMetadataConfigurationOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            get_bucket_metadata_configuration_result: try_from_aws(x.get_bucket_metadata_configuration_result)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_get_bucket_metadata_configuration_result(try_into_aws(x.get_bucket_metadata_configuration_result)?);
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::GetBucketMetadataConfigurationResult {
+    type Target = aws_sdk_s3::types::GetBucketMetadataConfigurationResult;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            metadata_configuration_result: unwrap_from_aws(x.metadata_configuration_result, "metadata_configuration_result")?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_metadata_configuration_result(Some(try_into_aws(x.metadata_configuration_result)?));
         Ok(y.build())
     }
 }
@@ -4533,6 +4786,23 @@ impl AwsConversion for s3s::dto::InventoryConfiguration {
     }
 }
 
+impl AwsConversion for s3s::dto::InventoryConfigurationState {
+    type Target = aws_sdk_s3::types::InventoryConfigurationState;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(match x {
+            aws_sdk_s3::types::InventoryConfigurationState::Disabled => Self::from_static(Self::DISABLED),
+            aws_sdk_s3::types::InventoryConfigurationState::Enabled => Self::from_static(Self::ENABLED),
+            _ => Self::from(x.as_str().to_owned()),
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        Ok(aws_sdk_s3::types::InventoryConfigurationState::from(x.as_str()))
+    }
+}
+
 impl AwsConversion for s3s::dto::InventoryDestination {
     type Target = aws_sdk_s3::types::InventoryDestination;
     type Error = S3Error;
@@ -4721,6 +4991,69 @@ impl AwsConversion for s3s::dto::InventorySchedule {
     }
 }
 
+impl AwsConversion for s3s::dto::InventoryTableConfiguration {
+    type Target = aws_sdk_s3::types::InventoryTableConfiguration;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            configuration_state: try_from_aws(x.configuration_state)?,
+            encryption_configuration: try_from_aws(x.encryption_configuration)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_configuration_state(Some(try_into_aws(x.configuration_state)?));
+        y = y.set_encryption_configuration(try_into_aws(x.encryption_configuration)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::InventoryTableConfigurationResult {
+    type Target = aws_sdk_s3::types::InventoryTableConfigurationResult;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            configuration_state: try_from_aws(x.configuration_state)?,
+            error: try_from_aws(x.error)?,
+            table_arn: try_from_aws(x.table_arn)?,
+            table_name: try_from_aws(x.table_name)?,
+            table_status: try_from_aws(x.table_status)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_configuration_state(Some(try_into_aws(x.configuration_state)?));
+        y = y.set_error(try_into_aws(x.error)?);
+        y = y.set_table_arn(try_into_aws(x.table_arn)?);
+        y = y.set_table_name(try_into_aws(x.table_name)?);
+        y = y.set_table_status(try_into_aws(x.table_status)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::InventoryTableConfigurationUpdates {
+    type Target = aws_sdk_s3::types::InventoryTableConfigurationUpdates;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            configuration_state: try_from_aws(x.configuration_state)?,
+            encryption_configuration: try_from_aws(x.encryption_configuration)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_configuration_state(Some(try_into_aws(x.configuration_state)?));
+        y = y.set_encryption_configuration(try_into_aws(x.encryption_configuration)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
 impl AwsConversion for s3s::dto::JSONInput {
     type Target = aws_sdk_s3::types::JsonInput;
     type Error = S3Error;
@@ -4769,6 +5102,67 @@ impl AwsConversion for s3s::dto::JSONType {
 
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         Ok(aws_sdk_s3::types::JsonType::from(x.as_str()))
+    }
+}
+
+impl AwsConversion for s3s::dto::JournalTableConfiguration {
+    type Target = aws_sdk_s3::types::JournalTableConfiguration;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            encryption_configuration: try_from_aws(x.encryption_configuration)?,
+            record_expiration: unwrap_from_aws(x.record_expiration, "record_expiration")?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_encryption_configuration(try_into_aws(x.encryption_configuration)?);
+        y = y.set_record_expiration(Some(try_into_aws(x.record_expiration)?));
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::JournalTableConfigurationResult {
+    type Target = aws_sdk_s3::types::JournalTableConfigurationResult;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            error: try_from_aws(x.error)?,
+            record_expiration: unwrap_from_aws(x.record_expiration, "record_expiration")?,
+            table_arn: try_from_aws(x.table_arn)?,
+            table_name: try_from_aws(x.table_name)?,
+            table_status: try_from_aws(x.table_status)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_error(try_into_aws(x.error)?);
+        y = y.set_record_expiration(Some(try_into_aws(x.record_expiration)?));
+        y = y.set_table_arn(try_into_aws(x.table_arn)?);
+        y = y.set_table_name(Some(try_into_aws(x.table_name)?));
+        y = y.set_table_status(Some(try_into_aws(x.table_status)?));
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::JournalTableConfigurationUpdates {
+    type Target = aws_sdk_s3::types::JournalTableConfigurationUpdates;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            record_expiration: unwrap_from_aws(x.record_expiration, "record_expiration")?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_record_expiration(Some(try_into_aws(x.record_expiration)?));
+        Ok(y.build())
     }
 }
 
@@ -5639,6 +6033,50 @@ impl AwsConversion for s3s::dto::MFADeleteStatus {
     }
 }
 
+impl AwsConversion for s3s::dto::MetadataConfiguration {
+    type Target = aws_sdk_s3::types::MetadataConfiguration;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            annotation_table_configuration: try_from_aws(x.annotation_table_configuration)?,
+            inventory_table_configuration: try_from_aws(x.inventory_table_configuration)?,
+            journal_table_configuration: unwrap_from_aws(x.journal_table_configuration, "journal_table_configuration")?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_annotation_table_configuration(try_into_aws(x.annotation_table_configuration)?);
+        y = y.set_inventory_table_configuration(try_into_aws(x.inventory_table_configuration)?);
+        y = y.set_journal_table_configuration(Some(try_into_aws(x.journal_table_configuration)?));
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::MetadataConfigurationResult {
+    type Target = aws_sdk_s3::types::MetadataConfigurationResult;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            annotation_table_configuration_result: try_from_aws(x.annotation_table_configuration_result)?,
+            destination_result: unwrap_from_aws(x.destination_result, "destination_result")?,
+            inventory_table_configuration_result: try_from_aws(x.inventory_table_configuration_result)?,
+            journal_table_configuration_result: try_from_aws(x.journal_table_configuration_result)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_annotation_table_configuration_result(try_into_aws(x.annotation_table_configuration_result)?);
+        y = y.set_destination_result(Some(try_into_aws(x.destination_result)?));
+        y = y.set_inventory_table_configuration_result(try_into_aws(x.inventory_table_configuration_result)?);
+        y = y.set_journal_table_configuration_result(try_into_aws(x.journal_table_configuration_result)?);
+        Ok(y.build())
+    }
+}
+
 impl AwsConversion for s3s::dto::MetadataDirective {
     type Target = aws_sdk_s3::types::MetadataDirective;
     type Error = S3Error;
@@ -5706,6 +6144,25 @@ impl AwsConversion for s3s::dto::MetadataTableConfigurationResult {
         let mut y = Self::Target::builder();
         y = y.set_s3_tables_destination_result(Some(try_into_aws(x.s3_tables_destination_result)?));
         Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::MetadataTableEncryptionConfiguration {
+    type Target = aws_sdk_s3::types::MetadataTableEncryptionConfiguration;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            kms_key_arn: try_from_aws(x.kms_key_arn)?,
+            sse_algorithm: try_from_aws(x.sse_algorithm)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_kms_key_arn(try_into_aws(x.kms_key_arn)?);
+        y = y.set_sse_algorithm(Some(try_into_aws(x.sse_algorithm)?));
+        y.build().map_err(S3Error::internal_error)
     }
 }
 
@@ -8037,6 +8494,25 @@ impl AwsConversion for s3s::dto::QuoteFields {
     }
 }
 
+impl AwsConversion for s3s::dto::RecordExpiration {
+    type Target = aws_sdk_s3::types::RecordExpiration;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            days: try_from_aws(x.days)?,
+            expiration: try_from_aws(x.expiration)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_days(try_into_aws(x.days)?);
+        y = y.set_expiration(Some(try_into_aws(x.expiration)?));
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
 impl AwsConversion for s3s::dto::RecordsEvent {
     type Target = aws_sdk_s3::types::RecordsEvent;
     type Error = S3Error;
@@ -8618,6 +9094,23 @@ impl AwsConversion for s3s::dto::S3Location {
     }
 }
 
+impl AwsConversion for s3s::dto::S3TablesBucketType {
+    type Target = aws_sdk_s3::types::S3TablesBucketType;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(match x {
+            aws_sdk_s3::types::S3TablesBucketType::Aws => Self::from_static(Self::AWS),
+            aws_sdk_s3::types::S3TablesBucketType::Customer => Self::from_static(Self::CUSTOMER),
+            _ => Self::from(x.as_str().to_owned()),
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        Ok(aws_sdk_s3::types::S3TablesBucketType::from(x.as_str()))
+    }
+}
+
 impl AwsConversion for s3s::dto::S3TablesDestination {
     type Target = aws_sdk_s3::types::S3TablesDestination;
     type Error = S3Error;
@@ -9080,6 +9573,23 @@ impl AwsConversion for s3s::dto::StorageClassAnalysisSchemaVersion {
     }
 }
 
+impl AwsConversion for s3s::dto::TableSseAlgorithm {
+    type Target = aws_sdk_s3::types::TableSseAlgorithm;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(match x {
+            aws_sdk_s3::types::TableSseAlgorithm::Aes256 => Self::from_static(Self::AES256),
+            aws_sdk_s3::types::TableSseAlgorithm::AwsKms => Self::from_static(Self::AWS_KMS),
+            _ => Self::from(x.as_str().to_owned()),
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        Ok(aws_sdk_s3::types::TableSseAlgorithm::from(x.as_str()))
+    }
+}
+
 impl AwsConversion for s3s::dto::Tagging {
     type Target = aws_sdk_s3::types::Tagging;
     type Error = S3Error;
@@ -9306,6 +9816,129 @@ impl AwsConversion for s3s::dto::Type {
 
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         Ok(aws_sdk_s3::types::Type::from(x.as_str()))
+    }
+}
+
+impl AwsConversion for s3s::dto::UpdateBucketMetadataAnnotationTableConfigurationInput {
+    type Target = aws_sdk_s3::operation::update_bucket_metadata_annotation_table_configuration::UpdateBucketMetadataAnnotationTableConfigurationInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            annotation_table_configuration: unwrap_from_aws(x.annotation_table_configuration, "annotation_table_configuration")?,
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            checksum_algorithm: try_from_aws(x.checksum_algorithm)?,
+            content_md5: try_from_aws(x.content_md5)?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_annotation_table_configuration(Some(try_into_aws(x.annotation_table_configuration)?));
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_checksum_algorithm(try_into_aws(x.checksum_algorithm)?);
+        y = y.set_content_md5(try_into_aws(x.content_md5)?);
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::UpdateBucketMetadataAnnotationTableConfigurationOutput {
+    type Target = aws_sdk_s3::operation::update_bucket_metadata_annotation_table_configuration::UpdateBucketMetadataAnnotationTableConfigurationOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::UpdateBucketMetadataInventoryTableConfigurationInput {
+    type Target = aws_sdk_s3::operation::update_bucket_metadata_inventory_table_configuration::UpdateBucketMetadataInventoryTableConfigurationInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            checksum_algorithm: try_from_aws(x.checksum_algorithm)?,
+            content_md5: try_from_aws(x.content_md5)?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+            inventory_table_configuration: unwrap_from_aws(x.inventory_table_configuration, "inventory_table_configuration")?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_checksum_algorithm(try_into_aws(x.checksum_algorithm)?);
+        y = y.set_content_md5(try_into_aws(x.content_md5)?);
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y = y.set_inventory_table_configuration(Some(try_into_aws(x.inventory_table_configuration)?));
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::UpdateBucketMetadataInventoryTableConfigurationOutput {
+    type Target = aws_sdk_s3::operation::update_bucket_metadata_inventory_table_configuration::UpdateBucketMetadataInventoryTableConfigurationOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::UpdateBucketMetadataJournalTableConfigurationInput {
+    type Target = aws_sdk_s3::operation::update_bucket_metadata_journal_table_configuration::UpdateBucketMetadataJournalTableConfigurationInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            checksum_algorithm: try_from_aws(x.checksum_algorithm)?,
+            content_md5: try_from_aws(x.content_md5)?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+            journal_table_configuration: unwrap_from_aws(x.journal_table_configuration, "journal_table_configuration")?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_checksum_algorithm(try_into_aws(x.checksum_algorithm)?);
+        y = y.set_content_md5(try_into_aws(x.content_md5)?);
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y = y.set_journal_table_configuration(Some(try_into_aws(x.journal_table_configuration)?));
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::UpdateBucketMetadataJournalTableConfigurationOutput {
+    type Target = aws_sdk_s3::operation::update_bucket_metadata_journal_table_configuration::UpdateBucketMetadataJournalTableConfigurationOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
     }
 }
 

--- a/crates/s3s-aws/src/proxy/generated.rs
+++ b/crates/s3s-aws/src/proxy/generated.rs
@@ -175,6 +175,31 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, req))]
+    async fn create_bucket_metadata_configuration(
+        &self,
+        req: S3Request<s3s::dto::CreateBucketMetadataConfigurationInput>,
+    ) -> S3Result<S3Response<s3s::dto::CreateBucketMetadataConfigurationOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.create_bucket_metadata_configuration();
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_checksum_algorithm(try_into_aws(input.checksum_algorithm)?);
+        b = b.set_content_md5(try_into_aws(input.content_md5)?);
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        b = b.set_metadata_configuration(Some(try_into_aws(input.metadata_configuration)?));
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
     async fn create_bucket_metadata_table_configuration(
         &self,
         req: S3Request<s3s::dto::CreateBucketMetadataTableConfigurationInput>,
@@ -419,6 +444,28 @@ impl S3 for Proxy {
         let input = req.input;
         debug!(?input);
         let mut b = self.0.delete_bucket_lifecycle();
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
+    async fn delete_bucket_metadata_configuration(
+        &self,
+        req: S3Request<s3s::dto::DeleteBucketMetadataConfigurationInput>,
+    ) -> S3Result<S3Response<s3s::dto::DeleteBucketMetadataConfigurationOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.delete_bucket_metadata_configuration();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
         b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         let result = b.send().await;
@@ -923,6 +970,28 @@ impl S3 for Proxy {
         let input = req.input;
         debug!(?input);
         let mut b = self.0.get_bucket_logging();
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
+    async fn get_bucket_metadata_configuration(
+        &self,
+        req: S3Request<s3s::dto::GetBucketMetadataConfigurationInput>,
+    ) -> S3Result<S3Response<s3s::dto::GetBucketMetadataConfigurationOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.get_bucket_metadata_configuration();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
         b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         let result = b.send().await;
@@ -2549,6 +2618,81 @@ impl S3 for Proxy {
         b = b.set_output_serialization(Some(try_into_aws(input.request.output_serialization)?));
         b = b.set_request_progress(try_into_aws(input.request.request_progress)?);
         b = b.set_scan_range(try_into_aws(input.request.scan_range)?);
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
+    async fn update_bucket_metadata_annotation_table_configuration(
+        &self,
+        req: S3Request<s3s::dto::UpdateBucketMetadataAnnotationTableConfigurationInput>,
+    ) -> S3Result<S3Response<s3s::dto::UpdateBucketMetadataAnnotationTableConfigurationOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.update_bucket_metadata_annotation_table_configuration();
+        b = b.set_annotation_table_configuration(Some(try_into_aws(input.annotation_table_configuration)?));
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_checksum_algorithm(try_into_aws(input.checksum_algorithm)?);
+        b = b.set_content_md5(try_into_aws(input.content_md5)?);
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
+    async fn update_bucket_metadata_inventory_table_configuration(
+        &self,
+        req: S3Request<s3s::dto::UpdateBucketMetadataInventoryTableConfigurationInput>,
+    ) -> S3Result<S3Response<s3s::dto::UpdateBucketMetadataInventoryTableConfigurationOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.update_bucket_metadata_inventory_table_configuration();
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_checksum_algorithm(try_into_aws(input.checksum_algorithm)?);
+        b = b.set_content_md5(try_into_aws(input.content_md5)?);
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        b = b.set_inventory_table_configuration(Some(try_into_aws(input.inventory_table_configuration)?));
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
+    async fn update_bucket_metadata_journal_table_configuration(
+        &self,
+        req: S3Request<s3s::dto::UpdateBucketMetadataJournalTableConfigurationInput>,
+    ) -> S3Result<S3Response<s3s::dto::UpdateBucketMetadataJournalTableConfigurationOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.update_bucket_metadata_journal_table_configuration();
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_checksum_algorithm(try_into_aws(input.checksum_algorithm)?);
+        b = b.set_content_md5(try_into_aws(input.content_md5)?);
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        b = b.set_journal_table_configuration(Some(try_into_aws(input.journal_table_configuration)?));
         let result = b.send().await;
         match result {
             Ok(output) => {

--- a/crates/s3s-aws/src/proxy/generated_minio.rs
+++ b/crates/s3s-aws/src/proxy/generated_minio.rs
@@ -175,6 +175,31 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, req))]
+    async fn create_bucket_metadata_configuration(
+        &self,
+        req: S3Request<s3s::dto::CreateBucketMetadataConfigurationInput>,
+    ) -> S3Result<S3Response<s3s::dto::CreateBucketMetadataConfigurationOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.create_bucket_metadata_configuration();
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_checksum_algorithm(try_into_aws(input.checksum_algorithm)?);
+        b = b.set_content_md5(try_into_aws(input.content_md5)?);
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        b = b.set_metadata_configuration(Some(try_into_aws(input.metadata_configuration)?));
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
     async fn create_bucket_metadata_table_configuration(
         &self,
         req: S3Request<s3s::dto::CreateBucketMetadataTableConfigurationInput>,
@@ -419,6 +444,28 @@ impl S3 for Proxy {
         let input = req.input;
         debug!(?input);
         let mut b = self.0.delete_bucket_lifecycle();
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
+    async fn delete_bucket_metadata_configuration(
+        &self,
+        req: S3Request<s3s::dto::DeleteBucketMetadataConfigurationInput>,
+    ) -> S3Result<S3Response<s3s::dto::DeleteBucketMetadataConfigurationOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.delete_bucket_metadata_configuration();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
         b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         let result = b.send().await;
@@ -923,6 +970,28 @@ impl S3 for Proxy {
         let input = req.input;
         debug!(?input);
         let mut b = self.0.get_bucket_logging();
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
+    async fn get_bucket_metadata_configuration(
+        &self,
+        req: S3Request<s3s::dto::GetBucketMetadataConfigurationInput>,
+    ) -> S3Result<S3Response<s3s::dto::GetBucketMetadataConfigurationOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.get_bucket_metadata_configuration();
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
         b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         let result = b.send().await;
@@ -2549,6 +2618,81 @@ impl S3 for Proxy {
         b = b.set_output_serialization(Some(try_into_aws(input.request.output_serialization)?));
         b = b.set_request_progress(try_into_aws(input.request.request_progress)?);
         b = b.set_scan_range(try_into_aws(input.request.scan_range)?);
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
+    async fn update_bucket_metadata_annotation_table_configuration(
+        &self,
+        req: S3Request<s3s::dto::UpdateBucketMetadataAnnotationTableConfigurationInput>,
+    ) -> S3Result<S3Response<s3s::dto::UpdateBucketMetadataAnnotationTableConfigurationOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.update_bucket_metadata_annotation_table_configuration();
+        b = b.set_annotation_table_configuration(Some(try_into_aws(input.annotation_table_configuration)?));
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_checksum_algorithm(try_into_aws(input.checksum_algorithm)?);
+        b = b.set_content_md5(try_into_aws(input.content_md5)?);
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
+    async fn update_bucket_metadata_inventory_table_configuration(
+        &self,
+        req: S3Request<s3s::dto::UpdateBucketMetadataInventoryTableConfigurationInput>,
+    ) -> S3Result<S3Response<s3s::dto::UpdateBucketMetadataInventoryTableConfigurationOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.update_bucket_metadata_inventory_table_configuration();
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_checksum_algorithm(try_into_aws(input.checksum_algorithm)?);
+        b = b.set_content_md5(try_into_aws(input.content_md5)?);
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        b = b.set_inventory_table_configuration(Some(try_into_aws(input.inventory_table_configuration)?));
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
+    async fn update_bucket_metadata_journal_table_configuration(
+        &self,
+        req: S3Request<s3s::dto::UpdateBucketMetadataJournalTableConfigurationInput>,
+    ) -> S3Result<S3Response<s3s::dto::UpdateBucketMetadataJournalTableConfigurationOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.0.update_bucket_metadata_journal_table_configuration();
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_checksum_algorithm(try_into_aws(input.checksum_algorithm)?);
+        b = b.set_content_md5(try_into_aws(input.content_md5)?);
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        b = b.set_journal_table_configuration(Some(try_into_aws(input.journal_table_configuration)?));
         let result = b.send().await;
         match result {
             Ok(output) => {

--- a/crates/s3s/src/access/generated.rs
+++ b/crates/s3s/src/access/generated.rs
@@ -58,6 +58,16 @@ pub trait S3Access: Send + Sync + 'static {
         Ok(())
     }
 
+    /// Checks whether the CreateBucketMetadataConfiguration request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn create_bucket_metadata_configuration(
+        &self,
+        _req: &mut S3Request<CreateBucketMetadataConfigurationInput>,
+    ) -> S3Result<()> {
+        Ok(())
+    }
+
     /// Checks whether the CreateBucketMetadataTableConfiguration request has accesses to the resources.
     ///
     /// This method returns `Ok(())` by default.
@@ -137,6 +147,16 @@ pub trait S3Access: Send + Sync + 'static {
     ///
     /// This method returns `Ok(())` by default.
     async fn delete_bucket_lifecycle(&self, _req: &mut S3Request<DeleteBucketLifecycleInput>) -> S3Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether the DeleteBucketMetadataConfiguration request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn delete_bucket_metadata_configuration(
+        &self,
+        _req: &mut S3Request<DeleteBucketMetadataConfigurationInput>,
+    ) -> S3Result<()> {
         Ok(())
     }
 
@@ -312,6 +332,13 @@ pub trait S3Access: Send + Sync + 'static {
     ///
     /// This method returns `Ok(())` by default.
     async fn get_bucket_logging(&self, _req: &mut S3Request<GetBucketLoggingInput>) -> S3Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether the GetBucketMetadataConfiguration request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn get_bucket_metadata_configuration(&self, _req: &mut S3Request<GetBucketMetadataConfigurationInput>) -> S3Result<()> {
         Ok(())
     }
 
@@ -789,6 +816,36 @@ pub trait S3Access: Send + Sync + 'static {
     ///
     /// This method returns `Ok(())` by default.
     async fn select_object_content(&self, _req: &mut S3Request<SelectObjectContentInput>) -> S3Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether the UpdateBucketMetadataAnnotationTableConfiguration request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn update_bucket_metadata_annotation_table_configuration(
+        &self,
+        _req: &mut S3Request<UpdateBucketMetadataAnnotationTableConfigurationInput>,
+    ) -> S3Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether the UpdateBucketMetadataInventoryTableConfiguration request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn update_bucket_metadata_inventory_table_configuration(
+        &self,
+        _req: &mut S3Request<UpdateBucketMetadataInventoryTableConfigurationInput>,
+    ) -> S3Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether the UpdateBucketMetadataJournalTableConfiguration request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn update_bucket_metadata_journal_table_configuration(
+        &self,
+        _req: &mut S3Request<UpdateBucketMetadataJournalTableConfigurationInput>,
+    ) -> S3Result<()> {
         Ok(())
     }
 

--- a/crates/s3s/src/access/generated_minio.rs
+++ b/crates/s3s/src/access/generated_minio.rs
@@ -58,6 +58,16 @@ pub trait S3Access: Send + Sync + 'static {
         Ok(())
     }
 
+    /// Checks whether the CreateBucketMetadataConfiguration request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn create_bucket_metadata_configuration(
+        &self,
+        _req: &mut S3Request<CreateBucketMetadataConfigurationInput>,
+    ) -> S3Result<()> {
+        Ok(())
+    }
+
     /// Checks whether the CreateBucketMetadataTableConfiguration request has accesses to the resources.
     ///
     /// This method returns `Ok(())` by default.
@@ -137,6 +147,16 @@ pub trait S3Access: Send + Sync + 'static {
     ///
     /// This method returns `Ok(())` by default.
     async fn delete_bucket_lifecycle(&self, _req: &mut S3Request<DeleteBucketLifecycleInput>) -> S3Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether the DeleteBucketMetadataConfiguration request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn delete_bucket_metadata_configuration(
+        &self,
+        _req: &mut S3Request<DeleteBucketMetadataConfigurationInput>,
+    ) -> S3Result<()> {
         Ok(())
     }
 
@@ -312,6 +332,13 @@ pub trait S3Access: Send + Sync + 'static {
     ///
     /// This method returns `Ok(())` by default.
     async fn get_bucket_logging(&self, _req: &mut S3Request<GetBucketLoggingInput>) -> S3Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether the GetBucketMetadataConfiguration request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn get_bucket_metadata_configuration(&self, _req: &mut S3Request<GetBucketMetadataConfigurationInput>) -> S3Result<()> {
         Ok(())
     }
 
@@ -789,6 +816,36 @@ pub trait S3Access: Send + Sync + 'static {
     ///
     /// This method returns `Ok(())` by default.
     async fn select_object_content(&self, _req: &mut S3Request<SelectObjectContentInput>) -> S3Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether the UpdateBucketMetadataAnnotationTableConfiguration request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn update_bucket_metadata_annotation_table_configuration(
+        &self,
+        _req: &mut S3Request<UpdateBucketMetadataAnnotationTableConfigurationInput>,
+    ) -> S3Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether the UpdateBucketMetadataInventoryTableConfiguration request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn update_bucket_metadata_inventory_table_configuration(
+        &self,
+        _req: &mut S3Request<UpdateBucketMetadataInventoryTableConfigurationInput>,
+    ) -> S3Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether the UpdateBucketMetadataJournalTableConfiguration request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn update_bucket_metadata_journal_table_configuration(
+        &self,
+        _req: &mut S3Request<UpdateBucketMetadataJournalTableConfigurationInput>,
+    ) -> S3Result<()> {
         Ok(())
     }
 

--- a/crates/s3s/src/dto/generated.rs
+++ b/crates/s3s/src/dto/generated.rs
@@ -391,6 +391,145 @@ impl FromStr for AnalyticsS3ExportFileFormat {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AnnotationConfigurationState(Cow<'static, str>);
+
+impl AnnotationConfigurationState {
+    pub const DISABLED: &'static str = "DISABLED";
+
+    pub const ENABLED: &'static str = "ENABLED";
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn from_static(s: &'static str) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<String> for AnnotationConfigurationState {
+    fn from(s: String) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<AnnotationConfigurationState> for Cow<'static, str> {
+    fn from(s: AnnotationConfigurationState) -> Self {
+        s.0
+    }
+}
+
+impl FromStr for AnnotationConfigurationState {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s.to_owned()))
+    }
+}
+
+/// <p>Specifies the configuration for the annotation table associated with a bucket's Amazon S3 Metadata
+/// configuration. The annotation table is an Iceberg table that records annotation events for objects
+/// in the bucket.</p>
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct AnnotationTableConfiguration {
+    /// <p>The state of the annotation table. Valid values are <code>ENABLED</code> and <code>DISABLED</code>.</p>
+    pub configuration_state: AnnotationConfigurationState,
+    pub encryption_configuration: Option<MetadataTableEncryptionConfiguration>,
+    /// <p>The ARN of the IAM role used to manage the annotation table.</p>
+    pub role: Option<Role>,
+}
+
+impl fmt::Debug for AnnotationTableConfiguration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("AnnotationTableConfiguration");
+        d.field("configuration_state", &self.configuration_state);
+        if let Some(ref val) = self.encryption_configuration {
+            d.field("encryption_configuration", val);
+        }
+        if let Some(ref val) = self.role {
+            d.field("role", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl Default for AnnotationTableConfiguration {
+    fn default() -> Self {
+        Self {
+            configuration_state: String::new().into(),
+            encryption_configuration: None,
+            role: None,
+        }
+    }
+}
+
+/// <p>Contains the current state of the annotation table associated with a bucket's Amazon S3 Metadata
+/// configuration, including its provisioning status and identifiers.</p>
+#[derive(Clone, PartialEq)]
+pub struct AnnotationTableConfigurationResult {
+    /// <p>The current configuration state of the annotation table.</p>
+    pub configuration_state: AnnotationConfigurationState,
+    pub error: Option<ErrorDetails>,
+    /// <p>The ARN of the IAM role associated with the annotation table.</p>
+    pub role: Option<Role>,
+    /// <p>The ARN of the annotation table.</p>
+    pub table_arn: Option<S3TablesArn>,
+    /// <p>The name of the annotation table.</p>
+    pub table_name: Option<S3TablesName>,
+    /// <p>The provisioning status of the annotation table. Possible values: <code>CREATING</code>, <code>BACKFILLING</code>, <code>ACTIVE</code>, <code>FAILED</code>.</p>
+    pub table_status: Option<MetadataTableStatus>,
+}
+
+impl fmt::Debug for AnnotationTableConfigurationResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("AnnotationTableConfigurationResult");
+        d.field("configuration_state", &self.configuration_state);
+        if let Some(ref val) = self.error {
+            d.field("error", val);
+        }
+        if let Some(ref val) = self.role {
+            d.field("role", val);
+        }
+        if let Some(ref val) = self.table_arn {
+            d.field("table_arn", val);
+        }
+        if let Some(ref val) = self.table_name {
+            d.field("table_name", val);
+        }
+        if let Some(ref val) = self.table_status {
+            d.field("table_status", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+/// <p>Specifies updates to apply to the annotation table configuration. Used as the request body for
+/// <code>UpdateBucketMetadataAnnotationTableConfiguration</code>.</p>
+#[derive(Clone, PartialEq)]
+pub struct AnnotationTableConfigurationUpdates {
+    /// <p>The new configuration state to apply.</p>
+    pub configuration_state: AnnotationConfigurationState,
+    pub encryption_configuration: Option<MetadataTableEncryptionConfiguration>,
+    /// <p>The new IAM role ARN to apply.</p>
+    pub role: Option<Role>,
+}
+
+impl fmt::Debug for AnnotationTableConfigurationUpdates {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("AnnotationTableConfigurationUpdates");
+        d.field("configuration_state", &self.configuration_state);
+        if let Some(ref val) = self.encryption_configuration {
+            d.field("encryption_configuration", val);
+        }
+        if let Some(ref val) = self.role {
+            d.field("role", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArchiveStatus(Cow<'static, str>);
 
@@ -3318,6 +3457,65 @@ impl CreateBucketInput {
 }
 
 #[derive(Clone, PartialEq)]
+pub struct CreateBucketMetadataConfigurationInput {
+    /// <p>
+    /// The general purpose bucket that you want to create the metadata configuration for.
+    /// </p>
+    pub bucket: BucketName,
+    /// <p>
+    /// The checksum algorithm to use with your metadata configuration.
+    /// </p>
+    pub checksum_algorithm: Option<ChecksumAlgorithm>,
+    /// <p>
+    /// The <code>Content-MD5</code> header for the metadata configuration.
+    /// </p>
+    pub content_md5: Option<ContentMD5>,
+    /// <p>
+    /// The expected owner of the general purpose bucket that corresponds to your metadata configuration.
+    /// </p>
+    pub expected_bucket_owner: Option<AccountId>,
+    /// <p>
+    /// The contents of your metadata configuration.
+    /// </p>
+    pub metadata_configuration: MetadataConfiguration,
+}
+
+impl fmt::Debug for CreateBucketMetadataConfigurationInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("CreateBucketMetadataConfigurationInput");
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.checksum_algorithm {
+            d.field("checksum_algorithm", val);
+        }
+        if let Some(ref val) = self.content_md5 {
+            d.field("content_md5", val);
+        }
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.field("metadata_configuration", &self.metadata_configuration);
+        d.finish_non_exhaustive()
+    }
+}
+
+impl CreateBucketMetadataConfigurationInput {
+    #[must_use]
+    pub fn builder() -> builders::CreateBucketMetadataConfigurationInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct CreateBucketMetadataConfigurationOutput {}
+
+impl fmt::Debug for CreateBucketMetadataConfigurationOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("CreateBucketMetadataConfigurationOutput");
+        d.finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, PartialEq)]
 pub struct CreateBucketMetadataTableConfigurationInput {
     /// <p>
     /// The general purpose bucket that you want to create the metadata table configuration in.
@@ -4635,6 +4833,47 @@ impl fmt::Debug for DeleteBucketLifecycleOutput {
 }
 
 #[derive(Clone, Default, PartialEq)]
+pub struct DeleteBucketMetadataConfigurationInput {
+    /// <p>
+    /// The general purpose bucket that you want to remove the metadata configuration from.
+    /// </p>
+    pub bucket: BucketName,
+    /// <p>
+    /// The expected bucket owner of the general purpose bucket that you want to remove the metadata table
+    /// configuration from.
+    /// </p>
+    pub expected_bucket_owner: Option<AccountId>,
+}
+
+impl fmt::Debug for DeleteBucketMetadataConfigurationInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("DeleteBucketMetadataConfigurationInput");
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl DeleteBucketMetadataConfigurationInput {
+    #[must_use]
+    pub fn builder() -> builders::DeleteBucketMetadataConfigurationInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct DeleteBucketMetadataConfigurationOutput {}
+
+impl fmt::Debug for DeleteBucketMetadataConfigurationOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("DeleteBucketMetadataConfigurationOutput");
+        d.finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
 pub struct DeleteBucketMetadataTableConfigurationInput {
     /// <p>
     /// The general purpose bucket that you want to remove the metadata table configuration from.
@@ -5531,6 +5770,45 @@ impl fmt::Debug for Destination {
         }
         if let Some(ref val) = self.storage_class {
             d.field("storage_class", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+/// <p>
+/// The destination information for the S3 Metadata configuration.
+/// </p>
+#[derive(Clone, Default, PartialEq)]
+pub struct DestinationResult {
+    /// <p>
+    /// The Amazon Resource Name (ARN) of the table bucket where the metadata configuration is stored.
+    /// </p>
+    pub table_bucket_arn: Option<S3TablesBucketArn>,
+    /// <p>
+    /// The type of the table bucket where the metadata configuration is stored. The <code>aws</code>
+    /// value indicates an Amazon Web Services managed table bucket, and the <code>customer</code> value indicates a
+    /// customer-managed table bucket. V2 metadata configurations are stored in Amazon Web Services managed table
+    /// buckets, and V1 metadata configurations are stored in customer-managed table buckets.
+    /// </p>
+    pub table_bucket_type: Option<S3TablesBucketType>,
+    /// <p>
+    /// The namespace in the table bucket where the metadata tables for a metadata configuration are
+    /// stored.
+    /// </p>
+    pub table_namespace: Option<S3TablesNamespace>,
+}
+
+impl fmt::Debug for DestinationResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("DestinationResult");
+        if let Some(ref val) = self.table_bucket_arn {
+            d.field("table_bucket_arn", val);
+        }
+        if let Some(ref val) = self.table_bucket_type {
+            d.field("table_bucket_type", val);
+        }
+        if let Some(ref val) = self.table_namespace {
+            d.field("table_namespace", val);
         }
         d.finish_non_exhaustive()
     }
@@ -7806,6 +8084,44 @@ impl FromStr for ExistingObjectReplicationStatus {
 pub type Expiration = String;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExpirationState(Cow<'static, str>);
+
+impl ExpirationState {
+    pub const DISABLED: &'static str = "DISABLED";
+
+    pub const ENABLED: &'static str = "ENABLED";
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn from_static(s: &'static str) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<String> for ExpirationState {
+    fn from(s: String) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<ExpirationState> for Cow<'static, str> {
+    fn from(s: ExpirationState) -> Self {
+        s.0
+    }
+}
+
+impl FromStr for ExpirationState {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s.to_owned()))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExpirationStatus(Cow<'static, str>);
 
 impl ExpirationStatus {
@@ -8548,6 +8864,75 @@ impl fmt::Debug for GetBucketLoggingOutput {
         if let Some(ref val) = self.logging_enabled {
             d.field("logging_enabled", val);
         }
+        d.finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct GetBucketMetadataConfigurationInput {
+    /// <p>
+    /// The general purpose bucket that corresponds to the metadata configuration that you want to
+    /// retrieve.
+    /// </p>
+    pub bucket: BucketName,
+    /// <p>
+    /// The expected owner of the general purpose bucket that you want to retrieve the metadata table
+    /// configuration for.
+    /// </p>
+    pub expected_bucket_owner: Option<AccountId>,
+}
+
+impl fmt::Debug for GetBucketMetadataConfigurationInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("GetBucketMetadataConfigurationInput");
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl GetBucketMetadataConfigurationInput {
+    #[must_use]
+    pub fn builder() -> builders::GetBucketMetadataConfigurationInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct GetBucketMetadataConfigurationOutput {
+    /// <p>
+    /// The metadata configuration for the general purpose bucket.
+    /// </p>
+    pub get_bucket_metadata_configuration_result: Option<GetBucketMetadataConfigurationResult>,
+}
+
+impl fmt::Debug for GetBucketMetadataConfigurationOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("GetBucketMetadataConfigurationOutput");
+        if let Some(ref val) = self.get_bucket_metadata_configuration_result {
+            d.field("get_bucket_metadata_configuration_result", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+/// <p>
+/// The S3 Metadata configuration for a general purpose bucket.
+/// </p>
+#[derive(Clone, PartialEq)]
+pub struct GetBucketMetadataConfigurationResult {
+    /// <p>
+    /// The metadata configuration for a general purpose bucket.
+    /// </p>
+    pub metadata_configuration_result: MetadataConfigurationResult,
+}
+
+impl fmt::Debug for GetBucketMetadataConfigurationResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("GetBucketMetadataConfigurationResult");
+        d.field("metadata_configuration_result", &self.metadata_configuration_result);
         d.finish_non_exhaustive()
     }
 }
@@ -11623,6 +12008,44 @@ impl Default for InventoryConfiguration {
 
 pub type InventoryConfigurationList = List<InventoryConfiguration>;
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InventoryConfigurationState(Cow<'static, str>);
+
+impl InventoryConfigurationState {
+    pub const DISABLED: &'static str = "DISABLED";
+
+    pub const ENABLED: &'static str = "ENABLED";
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn from_static(s: &'static str) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<String> for InventoryConfigurationState {
+    fn from(s: String) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<InventoryConfigurationState> for Cow<'static, str> {
+    fn from(s: InventoryConfigurationState) -> Self {
+        s.0
+    }
+}
+
+impl FromStr for InventoryConfigurationState {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s.to_owned()))
+    }
+}
+
 /// <p>Specifies the inventory configuration for an Amazon S3 bucket.</p>
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct InventoryDestination {
@@ -11948,6 +12371,140 @@ impl Default for InventorySchedule {
     }
 }
 
+/// <p>
+/// The inventory table configuration for an S3 Metadata configuration.
+/// </p>
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct InventoryTableConfiguration {
+    /// <p>
+    /// The configuration state of the inventory table, indicating whether the inventory table is enabled
+    /// or disabled.
+    /// </p>
+    pub configuration_state: InventoryConfigurationState,
+    /// <p>
+    /// The encryption configuration for the inventory table.
+    /// </p>
+    pub encryption_configuration: Option<MetadataTableEncryptionConfiguration>,
+}
+
+impl fmt::Debug for InventoryTableConfiguration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("InventoryTableConfiguration");
+        d.field("configuration_state", &self.configuration_state);
+        if let Some(ref val) = self.encryption_configuration {
+            d.field("encryption_configuration", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl Default for InventoryTableConfiguration {
+    fn default() -> Self {
+        Self {
+            configuration_state: String::new().into(),
+            encryption_configuration: None,
+        }
+    }
+}
+
+/// <p>
+/// The inventory table configuration for an S3 Metadata configuration.
+/// </p>
+#[derive(Clone, PartialEq)]
+pub struct InventoryTableConfigurationResult {
+    /// <p>
+    /// The configuration state of the inventory table, indicating whether the inventory table is enabled
+    /// or disabled.
+    /// </p>
+    pub configuration_state: InventoryConfigurationState,
+    pub error: Option<ErrorDetails>,
+    /// <p>
+    /// The Amazon Resource Name (ARN) for the inventory table.
+    /// </p>
+    pub table_arn: Option<S3TablesArn>,
+    /// <p>
+    /// The name of the inventory table.
+    /// </p>
+    pub table_name: Option<S3TablesName>,
+    /// <p> The status of the inventory table. The status values are: </p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <code>CREATING</code> - The inventory table is in the process of being created in the specified
+    /// Amazon Web Services managed table bucket.</p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>BACKFILLING</code> - The inventory table is in the process of being backfilled. When
+    /// you enable the inventory table for your metadata configuration, the table goes through a
+    /// process known as backfilling, during which Amazon S3 scans your general purpose bucket to retrieve
+    /// the initial metadata for all objects in the bucket. Depending on the number of objects in your
+    /// bucket, this process can take several hours. When the backfilling process is finished, the
+    /// status of your inventory table changes from <code>BACKFILLING</code> to <code>ACTIVE</code>.
+    /// After backfilling is completed, updates to your objects are reflected in the inventory table
+    /// within one hour.</p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>ACTIVE</code> - The inventory table has been created successfully, and records are being
+    /// delivered to the table. </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>FAILED</code> - Amazon S3 is unable to create the inventory table, or Amazon S3 is unable to deliver
+    /// records.</p>
+    /// </li>
+    /// </ul>
+    pub table_status: Option<MetadataTableStatus>,
+}
+
+impl fmt::Debug for InventoryTableConfigurationResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("InventoryTableConfigurationResult");
+        d.field("configuration_state", &self.configuration_state);
+        if let Some(ref val) = self.error {
+            d.field("error", val);
+        }
+        if let Some(ref val) = self.table_arn {
+            d.field("table_arn", val);
+        }
+        if let Some(ref val) = self.table_name {
+            d.field("table_name", val);
+        }
+        if let Some(ref val) = self.table_status {
+            d.field("table_status", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+/// <p>
+/// The specified updates to the S3 Metadata inventory table configuration.
+/// </p>
+#[derive(Clone, PartialEq)]
+pub struct InventoryTableConfigurationUpdates {
+    /// <p>
+    /// The configuration state of the inventory table, indicating whether the inventory table is enabled
+    /// or disabled.
+    /// </p>
+    pub configuration_state: InventoryConfigurationState,
+    /// <p>
+    /// The encryption configuration for the inventory table.
+    /// </p>
+    pub encryption_configuration: Option<MetadataTableEncryptionConfiguration>,
+}
+
+impl fmt::Debug for InventoryTableConfigurationUpdates {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("InventoryTableConfigurationUpdates");
+        d.field("configuration_state", &self.configuration_state);
+        if let Some(ref val) = self.encryption_configuration {
+            d.field("encryption_configuration", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
 pub type IsEnabled = bool;
 
 pub type IsLatest = bool;
@@ -12031,6 +12588,115 @@ impl FromStr for JSONType {
     }
 }
 
+/// <p>
+/// The journal table configuration for an S3 Metadata configuration.
+/// </p>
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct JournalTableConfiguration {
+    /// <p>
+    /// The encryption configuration for the journal table.
+    /// </p>
+    pub encryption_configuration: Option<MetadataTableEncryptionConfiguration>,
+    /// <p>
+    /// The journal table record expiration settings for the journal table.
+    /// </p>
+    pub record_expiration: RecordExpiration,
+}
+
+impl fmt::Debug for JournalTableConfiguration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("JournalTableConfiguration");
+        if let Some(ref val) = self.encryption_configuration {
+            d.field("encryption_configuration", val);
+        }
+        d.field("record_expiration", &self.record_expiration);
+        d.finish_non_exhaustive()
+    }
+}
+
+impl Default for JournalTableConfiguration {
+    fn default() -> Self {
+        Self {
+            encryption_configuration: None,
+            record_expiration: default(),
+        }
+    }
+}
+
+/// <p>
+/// The journal table configuration for the S3 Metadata configuration.
+/// </p>
+#[derive(Clone, PartialEq)]
+pub struct JournalTableConfigurationResult {
+    pub error: Option<ErrorDetails>,
+    /// <p>
+    /// The journal table record expiration settings for the journal table.
+    /// </p>
+    pub record_expiration: RecordExpiration,
+    /// <p>
+    /// The Amazon Resource Name (ARN) for the journal table.
+    /// </p>
+    pub table_arn: Option<S3TablesArn>,
+    /// <p>
+    /// The name of the journal table.
+    /// </p>
+    pub table_name: S3TablesName,
+    /// <p> The status of the journal table. The status values are: </p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <code>CREATING</code> - The journal table is in the process of being created in the specified
+    /// table bucket.</p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>ACTIVE</code> - The journal table has been created successfully, and records are being
+    /// delivered to the table. </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>FAILED</code> - Amazon S3 is unable to create the journal table, or Amazon S3 is unable to deliver
+    /// records.</p>
+    /// </li>
+    /// </ul>
+    pub table_status: MetadataTableStatus,
+}
+
+impl fmt::Debug for JournalTableConfigurationResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("JournalTableConfigurationResult");
+        if let Some(ref val) = self.error {
+            d.field("error", val);
+        }
+        d.field("record_expiration", &self.record_expiration);
+        if let Some(ref val) = self.table_arn {
+            d.field("table_arn", val);
+        }
+        d.field("table_name", &self.table_name);
+        d.field("table_status", &self.table_status);
+        d.finish_non_exhaustive()
+    }
+}
+
+/// <p>
+/// The specified updates to the S3 Metadata journal table configuration.
+/// </p>
+#[derive(Clone, PartialEq)]
+pub struct JournalTableConfigurationUpdates {
+    /// <p>
+    /// The journal table record expiration settings for the journal table.
+    /// </p>
+    pub record_expiration: RecordExpiration,
+}
+
+impl fmt::Debug for JournalTableConfigurationUpdates {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("JournalTableConfigurationUpdates");
+        d.field("record_expiration", &self.record_expiration);
+        d.finish_non_exhaustive()
+    }
+}
+
 pub type KMSContext = String;
 
 pub type KeyCount = i32;
@@ -12038,6 +12704,8 @@ pub type KeyCount = i32;
 pub type KeyMarker = String;
 
 pub type KeyPrefixEquals = String;
+
+pub type KmsKeyArn = String;
 
 pub type LambdaFunctionArn = String;
 
@@ -14053,6 +14721,85 @@ pub type Message = String;
 
 pub type Metadata = Map<MetadataKey, MetadataValue>;
 
+/// <p>
+/// The S3 Metadata configuration for a general purpose bucket.
+/// </p>
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct MetadataConfiguration {
+    /// <p>Optional annotation table configuration to include with the metadata configuration.</p>
+    pub annotation_table_configuration: Option<AnnotationTableConfiguration>,
+    /// <p>
+    /// The inventory table configuration for a metadata configuration.
+    /// </p>
+    pub inventory_table_configuration: Option<InventoryTableConfiguration>,
+    /// <p>
+    /// The journal table configuration for a metadata configuration.
+    /// </p>
+    pub journal_table_configuration: JournalTableConfiguration,
+}
+
+impl fmt::Debug for MetadataConfiguration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("MetadataConfiguration");
+        if let Some(ref val) = self.annotation_table_configuration {
+            d.field("annotation_table_configuration", val);
+        }
+        if let Some(ref val) = self.inventory_table_configuration {
+            d.field("inventory_table_configuration", val);
+        }
+        d.field("journal_table_configuration", &self.journal_table_configuration);
+        d.finish_non_exhaustive()
+    }
+}
+
+impl Default for MetadataConfiguration {
+    fn default() -> Self {
+        Self {
+            annotation_table_configuration: None,
+            inventory_table_configuration: None,
+            journal_table_configuration: default(),
+        }
+    }
+}
+
+/// <p>
+/// The S3 Metadata configuration for a general purpose bucket.
+/// </p>
+#[derive(Clone, PartialEq)]
+pub struct MetadataConfigurationResult {
+    /// <p>The annotation table configuration result, if an annotation table is configured.</p>
+    pub annotation_table_configuration_result: Option<AnnotationTableConfigurationResult>,
+    /// <p>
+    /// The destination settings for a metadata configuration.
+    /// </p>
+    pub destination_result: DestinationResult,
+    /// <p>
+    /// The inventory table configuration for a metadata configuration.
+    /// </p>
+    pub inventory_table_configuration_result: Option<InventoryTableConfigurationResult>,
+    /// <p>
+    /// The journal table configuration for a metadata configuration.
+    /// </p>
+    pub journal_table_configuration_result: Option<JournalTableConfigurationResult>,
+}
+
+impl fmt::Debug for MetadataConfigurationResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("MetadataConfigurationResult");
+        if let Some(ref val) = self.annotation_table_configuration_result {
+            d.field("annotation_table_configuration_result", val);
+        }
+        d.field("destination_result", &self.destination_result);
+        if let Some(ref val) = self.inventory_table_configuration_result {
+            d.field("inventory_table_configuration_result", val);
+        }
+        if let Some(ref val) = self.journal_table_configuration_result {
+            d.field("journal_table_configuration_result", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MetadataDirective(Cow<'static, str>);
 
@@ -14167,6 +14914,46 @@ impl fmt::Debug for MetadataTableConfigurationResult {
         let mut d = f.debug_struct("MetadataTableConfigurationResult");
         d.field("s3_tables_destination_result", &self.s3_tables_destination_result);
         d.finish_non_exhaustive()
+    }
+}
+
+/// <p>
+/// The encryption settings for an S3 Metadata journal table or inventory table configuration.
+/// </p>
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct MetadataTableEncryptionConfiguration {
+    /// <p>
+    /// If server-side encryption with Key Management Service (KMS) keys (SSE-KMS) is specified, you must also
+    /// specify the KMS key Amazon Resource Name (ARN). You must specify a customer-managed KMS key
+    /// that's located in the same Region as the general purpose bucket that corresponds to the metadata
+    /// table configuration.
+    /// </p>
+    pub kms_key_arn: Option<KmsKeyArn>,
+    /// <p>
+    /// The encryption type specified for a metadata table. To specify server-side encryption with
+    /// Key Management Service (KMS) keys (SSE-KMS), use the <code>aws:kms</code> value. To specify server-side
+    /// encryption with Amazon S3 managed keys (SSE-S3), use the <code>AES256</code> value.
+    /// </p>
+    pub sse_algorithm: TableSseAlgorithm,
+}
+
+impl fmt::Debug for MetadataTableEncryptionConfiguration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("MetadataTableEncryptionConfiguration");
+        if let Some(ref val) = self.kms_key_arn {
+            d.field("kms_key_arn", val);
+        }
+        d.field("sse_algorithm", &self.sse_algorithm);
+        d.finish_non_exhaustive()
+    }
+}
+
+impl Default for MetadataTableEncryptionConfiguration {
+    fn default() -> Self {
+        Self {
+            kms_key_arn: None,
+            sse_algorithm: String::new().into(),
+        }
     }
 }
 
@@ -19418,6 +20205,46 @@ impl FromStr for QuoteFields {
 
 pub type RecordDelimiter = String;
 
+/// <p>
+/// The journal table record expiration settings for a journal table in an S3 Metadata configuration.
+/// </p>
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct RecordExpiration {
+    /// <p>
+    /// If you enable journal table record expiration, you can set the number of days to retain your
+    /// journal table records. Journal table records must be retained for a minimum of 7 days. To set
+    /// this value, specify any whole number from <code>7</code> to <code>2147483647</code>. For example,
+    /// to retain your journal table records for one year, set this value to <code>365</code>.
+    /// </p>
+    pub days: Option<RecordExpirationDays>,
+    /// <p>
+    /// Specifies whether journal table record expiration is enabled or disabled.
+    /// </p>
+    pub expiration: ExpirationState,
+}
+
+impl fmt::Debug for RecordExpiration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("RecordExpiration");
+        if let Some(ref val) = self.days {
+            d.field("days", val);
+        }
+        d.field("expiration", &self.expiration);
+        d.finish_non_exhaustive()
+    }
+}
+
+impl Default for RecordExpiration {
+    fn default() -> Self {
+        Self {
+            days: None,
+            expiration: String::new().into(),
+        }
+    }
+}
+
+pub type RecordExpirationDays = i32;
+
 /// <p>The container for the records event.</p>
 #[derive(Clone, Default, PartialEq)]
 pub struct RecordsEvent {
@@ -20516,6 +21343,44 @@ pub type S3TablesArn = String;
 
 pub type S3TablesBucketArn = String;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct S3TablesBucketType(Cow<'static, str>);
+
+impl S3TablesBucketType {
+    pub const AWS: &'static str = "aws";
+
+    pub const CUSTOMER: &'static str = "customer";
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn from_static(s: &'static str) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<String> for S3TablesBucketType {
+    fn from(s: String) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<S3TablesBucketType> for Cow<'static, str> {
+    fn from(s: S3TablesBucketType) -> Self {
+        s.0
+    }
+}
+
+impl FromStr for S3TablesBucketType {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s.to_owned()))
+    }
+}
+
 /// <p>
 /// The destination information for the metadata table configuration. The destination table bucket
 /// must be in the same Region and Amazon Web Services account as the general purpose bucket. The specified metadata
@@ -21486,6 +22351,44 @@ impl FromStr for StorageClassAnalysisSchemaVersion {
 
 pub type Suffix = String;
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TableSseAlgorithm(Cow<'static, str>);
+
+impl TableSseAlgorithm {
+    pub const AES256: &'static str = "AES256";
+
+    pub const AWS_KMS: &'static str = "aws:kms";
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn from_static(s: &'static str) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<String> for TableSseAlgorithm {
+    fn from(s: String) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<TableSseAlgorithm> for Cow<'static, str> {
+    fn from(s: TableSseAlgorithm) -> Self {
+        s.0
+    }
+}
+
+impl FromStr for TableSseAlgorithm {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s.to_owned()))
+    }
+}
+
 /// <p>A container of a key value name pair.</p>
 #[derive(Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
@@ -21908,6 +22811,177 @@ impl FromStr for Type {
 }
 
 pub type URI = String;
+
+#[derive(Clone, PartialEq)]
+pub struct UpdateBucketMetadataAnnotationTableConfigurationInput {
+    /// <p>The annotation table configuration updates to apply.</p>
+    pub annotation_table_configuration: AnnotationTableConfigurationUpdates,
+    /// <p>The name of the bucket whose annotation table configuration to update.</p>
+    pub bucket: BucketName,
+    /// <p>Checksum algorithm for the request payload.</p>
+    pub checksum_algorithm: Option<ChecksumAlgorithm>,
+    /// <p>Base64-encoded MD5 digest of the message body.</p>
+    pub content_md5: Option<ContentMD5>,
+    /// <p>The account ID of the expected bucket owner.</p>
+    pub expected_bucket_owner: Option<AccountId>,
+}
+
+impl fmt::Debug for UpdateBucketMetadataAnnotationTableConfigurationInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("UpdateBucketMetadataAnnotationTableConfigurationInput");
+        d.field("annotation_table_configuration", &self.annotation_table_configuration);
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.checksum_algorithm {
+            d.field("checksum_algorithm", val);
+        }
+        if let Some(ref val) = self.content_md5 {
+            d.field("content_md5", val);
+        }
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl UpdateBucketMetadataAnnotationTableConfigurationInput {
+    #[must_use]
+    pub fn builder() -> builders::UpdateBucketMetadataAnnotationTableConfigurationInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct UpdateBucketMetadataAnnotationTableConfigurationOutput {}
+
+impl fmt::Debug for UpdateBucketMetadataAnnotationTableConfigurationOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("UpdateBucketMetadataAnnotationTableConfigurationOutput");
+        d.finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct UpdateBucketMetadataInventoryTableConfigurationInput {
+    /// <p>
+    /// The general purpose bucket that corresponds to the metadata configuration that you want to
+    /// enable or disable an inventory table for.
+    /// </p>
+    pub bucket: BucketName,
+    /// <p>
+    /// The checksum algorithm to use with your inventory table configuration.
+    /// </p>
+    pub checksum_algorithm: Option<ChecksumAlgorithm>,
+    /// <p>
+    /// The <code>Content-MD5</code> header for the inventory table configuration.
+    /// </p>
+    pub content_md5: Option<ContentMD5>,
+    /// <p>
+    /// The expected owner of the general purpose bucket that corresponds to the metadata table
+    /// configuration that you want to enable or disable an inventory table for.
+    /// </p>
+    pub expected_bucket_owner: Option<AccountId>,
+    /// <p>
+    /// The contents of your inventory table configuration.      
+    /// </p>
+    pub inventory_table_configuration: InventoryTableConfigurationUpdates,
+}
+
+impl fmt::Debug for UpdateBucketMetadataInventoryTableConfigurationInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("UpdateBucketMetadataInventoryTableConfigurationInput");
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.checksum_algorithm {
+            d.field("checksum_algorithm", val);
+        }
+        if let Some(ref val) = self.content_md5 {
+            d.field("content_md5", val);
+        }
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.field("inventory_table_configuration", &self.inventory_table_configuration);
+        d.finish_non_exhaustive()
+    }
+}
+
+impl UpdateBucketMetadataInventoryTableConfigurationInput {
+    #[must_use]
+    pub fn builder() -> builders::UpdateBucketMetadataInventoryTableConfigurationInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct UpdateBucketMetadataInventoryTableConfigurationOutput {}
+
+impl fmt::Debug for UpdateBucketMetadataInventoryTableConfigurationOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("UpdateBucketMetadataInventoryTableConfigurationOutput");
+        d.finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct UpdateBucketMetadataJournalTableConfigurationInput {
+    /// <p>
+    /// The general purpose bucket that corresponds to the metadata configuration that you want to
+    /// enable or disable journal table record expiration for.
+    /// </p>
+    pub bucket: BucketName,
+    /// <p>
+    /// The checksum algorithm to use with your journal table configuration.
+    /// </p>
+    pub checksum_algorithm: Option<ChecksumAlgorithm>,
+    /// <p>
+    /// The <code>Content-MD5</code> header for the journal table configuration.
+    /// </p>
+    pub content_md5: Option<ContentMD5>,
+    /// <p>
+    /// The expected owner of the general purpose bucket that corresponds to the metadata table
+    /// configuration that you want to enable or disable journal table record expiration for.      
+    /// </p>
+    pub expected_bucket_owner: Option<AccountId>,
+    /// <p>
+    /// The contents of your journal table configuration.
+    /// </p>
+    pub journal_table_configuration: JournalTableConfigurationUpdates,
+}
+
+impl fmt::Debug for UpdateBucketMetadataJournalTableConfigurationInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("UpdateBucketMetadataJournalTableConfigurationInput");
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.checksum_algorithm {
+            d.field("checksum_algorithm", val);
+        }
+        if let Some(ref val) = self.content_md5 {
+            d.field("content_md5", val);
+        }
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.field("journal_table_configuration", &self.journal_table_configuration);
+        d.finish_non_exhaustive()
+    }
+}
+
+impl UpdateBucketMetadataJournalTableConfigurationInput {
+    #[must_use]
+    pub fn builder() -> builders::UpdateBucketMetadataJournalTableConfigurationInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct UpdateBucketMetadataJournalTableConfigurationOutput {}
+
+impl fmt::Debug for UpdateBucketMetadataJournalTableConfigurationOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("UpdateBucketMetadataJournalTableConfigurationOutput");
+        d.finish_non_exhaustive()
+    }
+}
 
 pub type UploadIdMarker = String;
 
@@ -23045,6 +24119,7 @@ mod tests {
         require_default::<CompleteMultipartUploadOutput>();
         require_default::<CopyObjectOutput>();
         require_default::<CreateBucketOutput>();
+        require_default::<CreateBucketMetadataConfigurationOutput>();
         require_default::<CreateBucketMetadataTableConfigurationOutput>();
         require_default::<CreateMultipartUploadOutput>();
         require_default::<CreateSessionOutput>();
@@ -23055,6 +24130,7 @@ mod tests {
         require_default::<DeleteBucketIntelligentTieringConfigurationOutput>();
         require_default::<DeleteBucketInventoryConfigurationOutput>();
         require_default::<DeleteBucketLifecycleOutput>();
+        require_default::<DeleteBucketMetadataConfigurationOutput>();
         require_default::<DeleteBucketMetadataTableConfigurationOutput>();
         require_default::<DeleteBucketMetricsConfigurationOutput>();
         require_default::<DeleteBucketOwnershipControlsOutput>();
@@ -23077,6 +24153,7 @@ mod tests {
         require_default::<GetBucketLifecycleConfigurationOutput>();
         require_default::<GetBucketLocationOutput>();
         require_default::<GetBucketLoggingOutput>();
+        require_default::<GetBucketMetadataConfigurationOutput>();
         require_default::<GetBucketMetadataTableConfigurationOutput>();
         require_default::<GetBucketMetricsConfigurationOutput>();
         require_default::<GetBucketNotificationConfigurationOutput>();
@@ -23140,6 +24217,9 @@ mod tests {
         require_default::<RenameObjectOutput>();
         require_default::<RestoreObjectOutput>();
         require_default::<SelectObjectContentOutput>();
+        require_default::<UpdateBucketMetadataAnnotationTableConfigurationOutput>();
+        require_default::<UpdateBucketMetadataInventoryTableConfigurationOutput>();
+        require_default::<UpdateBucketMetadataJournalTableConfigurationOutput>();
         require_default::<UploadPartOutput>();
         require_default::<UploadPartCopyOutput>();
         require_default::<WriteGetObjectResponseOutput>();
@@ -23153,6 +24233,8 @@ mod tests {
         require_clone::<CopyObjectOutput>();
         require_clone::<CreateBucketInput>();
         require_clone::<CreateBucketOutput>();
+        require_clone::<CreateBucketMetadataConfigurationInput>();
+        require_clone::<CreateBucketMetadataConfigurationOutput>();
         require_clone::<CreateBucketMetadataTableConfigurationInput>();
         require_clone::<CreateBucketMetadataTableConfigurationOutput>();
         require_clone::<CreateMultipartUploadInput>();
@@ -23173,6 +24255,8 @@ mod tests {
         require_clone::<DeleteBucketInventoryConfigurationOutput>();
         require_clone::<DeleteBucketLifecycleInput>();
         require_clone::<DeleteBucketLifecycleOutput>();
+        require_clone::<DeleteBucketMetadataConfigurationInput>();
+        require_clone::<DeleteBucketMetadataConfigurationOutput>();
         require_clone::<DeleteBucketMetadataTableConfigurationInput>();
         require_clone::<DeleteBucketMetadataTableConfigurationOutput>();
         require_clone::<DeleteBucketMetricsConfigurationInput>();
@@ -23217,6 +24301,8 @@ mod tests {
         require_clone::<GetBucketLocationOutput>();
         require_clone::<GetBucketLoggingInput>();
         require_clone::<GetBucketLoggingOutput>();
+        require_clone::<GetBucketMetadataConfigurationInput>();
+        require_clone::<GetBucketMetadataConfigurationOutput>();
         require_clone::<GetBucketMetadataTableConfigurationInput>();
         require_clone::<GetBucketMetadataTableConfigurationOutput>();
         require_clone::<GetBucketMetricsConfigurationInput>();
@@ -23338,6 +24424,12 @@ mod tests {
         require_clone::<RestoreObjectInput>();
         require_clone::<RestoreObjectOutput>();
         require_clone::<SelectObjectContentInput>();
+        require_clone::<UpdateBucketMetadataAnnotationTableConfigurationInput>();
+        require_clone::<UpdateBucketMetadataAnnotationTableConfigurationOutput>();
+        require_clone::<UpdateBucketMetadataInventoryTableConfigurationInput>();
+        require_clone::<UpdateBucketMetadataInventoryTableConfigurationOutput>();
+        require_clone::<UpdateBucketMetadataJournalTableConfigurationInput>();
+        require_clone::<UpdateBucketMetadataJournalTableConfigurationOutput>();
         require_clone::<UploadPartOutput>();
         require_clone::<UploadPartCopyInput>();
         require_clone::<UploadPartCopyOutput>();
@@ -24609,6 +25701,94 @@ pub mod builders {
         }
     }
 
+    /// A builder for [`CreateBucketMetadataConfigurationInput`]
+    #[derive(Default)]
+    pub struct CreateBucketMetadataConfigurationInputBuilder {
+        bucket: Option<BucketName>,
+
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+
+        content_md5: Option<ContentMD5>,
+
+        expected_bucket_owner: Option<AccountId>,
+
+        metadata_configuration: Option<MetadataConfiguration>,
+    }
+
+    impl CreateBucketMetadataConfigurationInputBuilder {
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_algorithm(&mut self, field: Option<ChecksumAlgorithm>) -> &mut Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        pub fn set_content_md5(&mut self, field: Option<ContentMD5>) -> &mut Self {
+            self.content_md5 = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn set_metadata_configuration(&mut self, field: MetadataConfiguration) -> &mut Self {
+            self.metadata_configuration = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_algorithm(mut self, field: Option<ChecksumAlgorithm>) -> Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        #[must_use]
+        pub fn content_md5(mut self, field: Option<ContentMD5>) -> Self {
+            self.content_md5 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn metadata_configuration(mut self, field: MetadataConfiguration) -> Self {
+            self.metadata_configuration = Some(field);
+            self
+        }
+
+        pub fn build(self) -> Result<CreateBucketMetadataConfigurationInput, BuildError> {
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_algorithm = self.checksum_algorithm;
+            let content_md5 = self.content_md5;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            let metadata_configuration = self
+                .metadata_configuration
+                .ok_or_else(|| BuildError::missing_field("metadata_configuration"))?;
+            Ok(CreateBucketMetadataConfigurationInput {
+                bucket,
+                checksum_algorithm,
+                content_md5,
+                expected_bucket_owner,
+                metadata_configuration,
+            })
+        }
+    }
+
     /// A builder for [`CreateBucketMetadataTableConfigurationInput`]
     #[derive(Default)]
     pub struct CreateBucketMetadataTableConfigurationInputBuilder {
@@ -25600,6 +26780,47 @@ pub mod builders {
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
             let expected_bucket_owner = self.expected_bucket_owner;
             Ok(DeleteBucketLifecycleInput {
+                bucket,
+                expected_bucket_owner,
+            })
+        }
+    }
+
+    /// A builder for [`DeleteBucketMetadataConfigurationInput`]
+    #[derive(Default)]
+    pub struct DeleteBucketMetadataConfigurationInputBuilder {
+        bucket: Option<BucketName>,
+
+        expected_bucket_owner: Option<AccountId>,
+    }
+
+    impl DeleteBucketMetadataConfigurationInputBuilder {
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn build(self) -> Result<DeleteBucketMetadataConfigurationInput, BuildError> {
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            Ok(DeleteBucketMetadataConfigurationInput {
                 bucket,
                 expected_bucket_owner,
             })
@@ -26802,6 +28023,47 @@ pub mod builders {
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
             let expected_bucket_owner = self.expected_bucket_owner;
             Ok(GetBucketLoggingInput {
+                bucket,
+                expected_bucket_owner,
+            })
+        }
+    }
+
+    /// A builder for [`GetBucketMetadataConfigurationInput`]
+    #[derive(Default)]
+    pub struct GetBucketMetadataConfigurationInputBuilder {
+        bucket: Option<BucketName>,
+
+        expected_bucket_owner: Option<AccountId>,
+    }
+
+    impl GetBucketMetadataConfigurationInputBuilder {
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn build(self) -> Result<GetBucketMetadataConfigurationInput, BuildError> {
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            Ok(GetBucketMetadataConfigurationInput {
                 bucket,
                 expected_bucket_owner,
             })
@@ -34179,6 +35441,270 @@ pub mod builders {
         }
     }
 
+    /// A builder for [`UpdateBucketMetadataAnnotationTableConfigurationInput`]
+    #[derive(Default)]
+    pub struct UpdateBucketMetadataAnnotationTableConfigurationInputBuilder {
+        annotation_table_configuration: Option<AnnotationTableConfigurationUpdates>,
+
+        bucket: Option<BucketName>,
+
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+
+        content_md5: Option<ContentMD5>,
+
+        expected_bucket_owner: Option<AccountId>,
+    }
+
+    impl UpdateBucketMetadataAnnotationTableConfigurationInputBuilder {
+        pub fn set_annotation_table_configuration(&mut self, field: AnnotationTableConfigurationUpdates) -> &mut Self {
+            self.annotation_table_configuration = Some(field);
+            self
+        }
+
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_algorithm(&mut self, field: Option<ChecksumAlgorithm>) -> &mut Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        pub fn set_content_md5(&mut self, field: Option<ContentMD5>) -> &mut Self {
+            self.content_md5 = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn annotation_table_configuration(mut self, field: AnnotationTableConfigurationUpdates) -> Self {
+            self.annotation_table_configuration = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_algorithm(mut self, field: Option<ChecksumAlgorithm>) -> Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        #[must_use]
+        pub fn content_md5(mut self, field: Option<ContentMD5>) -> Self {
+            self.content_md5 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn build(self) -> Result<UpdateBucketMetadataAnnotationTableConfigurationInput, BuildError> {
+            let annotation_table_configuration = self
+                .annotation_table_configuration
+                .ok_or_else(|| BuildError::missing_field("annotation_table_configuration"))?;
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_algorithm = self.checksum_algorithm;
+            let content_md5 = self.content_md5;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            Ok(UpdateBucketMetadataAnnotationTableConfigurationInput {
+                annotation_table_configuration,
+                bucket,
+                checksum_algorithm,
+                content_md5,
+                expected_bucket_owner,
+            })
+        }
+    }
+
+    /// A builder for [`UpdateBucketMetadataInventoryTableConfigurationInput`]
+    #[derive(Default)]
+    pub struct UpdateBucketMetadataInventoryTableConfigurationInputBuilder {
+        bucket: Option<BucketName>,
+
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+
+        content_md5: Option<ContentMD5>,
+
+        expected_bucket_owner: Option<AccountId>,
+
+        inventory_table_configuration: Option<InventoryTableConfigurationUpdates>,
+    }
+
+    impl UpdateBucketMetadataInventoryTableConfigurationInputBuilder {
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_algorithm(&mut self, field: Option<ChecksumAlgorithm>) -> &mut Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        pub fn set_content_md5(&mut self, field: Option<ContentMD5>) -> &mut Self {
+            self.content_md5 = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn set_inventory_table_configuration(&mut self, field: InventoryTableConfigurationUpdates) -> &mut Self {
+            self.inventory_table_configuration = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_algorithm(mut self, field: Option<ChecksumAlgorithm>) -> Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        #[must_use]
+        pub fn content_md5(mut self, field: Option<ContentMD5>) -> Self {
+            self.content_md5 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn inventory_table_configuration(mut self, field: InventoryTableConfigurationUpdates) -> Self {
+            self.inventory_table_configuration = Some(field);
+            self
+        }
+
+        pub fn build(self) -> Result<UpdateBucketMetadataInventoryTableConfigurationInput, BuildError> {
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_algorithm = self.checksum_algorithm;
+            let content_md5 = self.content_md5;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            let inventory_table_configuration = self
+                .inventory_table_configuration
+                .ok_or_else(|| BuildError::missing_field("inventory_table_configuration"))?;
+            Ok(UpdateBucketMetadataInventoryTableConfigurationInput {
+                bucket,
+                checksum_algorithm,
+                content_md5,
+                expected_bucket_owner,
+                inventory_table_configuration,
+            })
+        }
+    }
+
+    /// A builder for [`UpdateBucketMetadataJournalTableConfigurationInput`]
+    #[derive(Default)]
+    pub struct UpdateBucketMetadataJournalTableConfigurationInputBuilder {
+        bucket: Option<BucketName>,
+
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+
+        content_md5: Option<ContentMD5>,
+
+        expected_bucket_owner: Option<AccountId>,
+
+        journal_table_configuration: Option<JournalTableConfigurationUpdates>,
+    }
+
+    impl UpdateBucketMetadataJournalTableConfigurationInputBuilder {
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_algorithm(&mut self, field: Option<ChecksumAlgorithm>) -> &mut Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        pub fn set_content_md5(&mut self, field: Option<ContentMD5>) -> &mut Self {
+            self.content_md5 = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn set_journal_table_configuration(&mut self, field: JournalTableConfigurationUpdates) -> &mut Self {
+            self.journal_table_configuration = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_algorithm(mut self, field: Option<ChecksumAlgorithm>) -> Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        #[must_use]
+        pub fn content_md5(mut self, field: Option<ContentMD5>) -> Self {
+            self.content_md5 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn journal_table_configuration(mut self, field: JournalTableConfigurationUpdates) -> Self {
+            self.journal_table_configuration = Some(field);
+            self
+        }
+
+        pub fn build(self) -> Result<UpdateBucketMetadataJournalTableConfigurationInput, BuildError> {
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_algorithm = self.checksum_algorithm;
+            let content_md5 = self.content_md5;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            let journal_table_configuration = self
+                .journal_table_configuration
+                .ok_or_else(|| BuildError::missing_field("journal_table_configuration"))?;
+            Ok(UpdateBucketMetadataJournalTableConfigurationInput {
+                bucket,
+                checksum_algorithm,
+                content_md5,
+                expected_bucket_owner,
+                journal_table_configuration,
+            })
+        }
+    }
+
     /// A builder for [`UploadPartInput`]
     #[derive(Default)]
     pub struct UploadPartInputBuilder {
@@ -35615,6 +37141,45 @@ impl DtoExt for AnalyticsS3BucketDestination {
         }
     }
 }
+impl DtoExt for AnnotationTableConfiguration {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.encryption_configuration {
+            val.ignore_empty_strings();
+        }
+        if self.role.as_deref() == Some("") {
+            self.role = None;
+        }
+    }
+}
+impl DtoExt for AnnotationTableConfigurationResult {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.error {
+            val.ignore_empty_strings();
+        }
+        if self.role.as_deref() == Some("") {
+            self.role = None;
+        }
+        if self.table_arn.as_deref() == Some("") {
+            self.table_arn = None;
+        }
+        if self.table_name.as_deref() == Some("") {
+            self.table_name = None;
+        }
+        if self.table_status.as_deref() == Some("") {
+            self.table_status = None;
+        }
+    }
+}
+impl DtoExt for AnnotationTableConfigurationUpdates {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.encryption_configuration {
+            val.ignore_empty_strings();
+        }
+        if self.role.as_deref() == Some("") {
+            self.role = None;
+        }
+    }
+}
 impl DtoExt for AssumeRoleOutput {
     fn ignore_empty_strings(&mut self) {
         if let Some(ref mut val) = self.assumed_role_user {
@@ -36211,6 +37776,22 @@ impl DtoExt for CreateBucketInput {
         }
     }
 }
+impl DtoExt for CreateBucketMetadataConfigurationInput {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref val) = self.checksum_algorithm
+            && val.as_str() == ""
+        {
+            self.checksum_algorithm = None;
+        }
+        if self.content_md5.as_deref() == Some("") {
+            self.content_md5 = None;
+        }
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+        self.metadata_configuration.ignore_empty_strings();
+    }
+}
 impl DtoExt for CreateBucketMetadataTableConfigurationInput {
     fn ignore_empty_strings(&mut self) {
         if let Some(ref val) = self.checksum_algorithm
@@ -36474,6 +38055,13 @@ impl DtoExt for DeleteBucketLifecycleInput {
         }
     }
 }
+impl DtoExt for DeleteBucketMetadataConfigurationInput {
+    fn ignore_empty_strings(&mut self) {
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+    }
+}
 impl DtoExt for DeleteBucketMetadataTableConfigurationInput {
     fn ignore_empty_strings(&mut self) {
         if self.expected_bucket_owner.as_deref() == Some("") {
@@ -36663,6 +38251,21 @@ impl DtoExt for Destination {
             && val.as_str() == ""
         {
             self.storage_class = None;
+        }
+    }
+}
+impl DtoExt for DestinationResult {
+    fn ignore_empty_strings(&mut self) {
+        if self.table_bucket_arn.as_deref() == Some("") {
+            self.table_bucket_arn = None;
+        }
+        if let Some(ref val) = self.table_bucket_type
+            && val.as_str() == ""
+        {
+            self.table_bucket_type = None;
+        }
+        if self.table_namespace.as_deref() == Some("") {
+            self.table_namespace = None;
         }
     }
 }
@@ -36891,6 +38494,25 @@ impl DtoExt for GetBucketLoggingOutput {
         if let Some(ref mut val) = self.logging_enabled {
             val.ignore_empty_strings();
         }
+    }
+}
+impl DtoExt for GetBucketMetadataConfigurationInput {
+    fn ignore_empty_strings(&mut self) {
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+    }
+}
+impl DtoExt for GetBucketMetadataConfigurationOutput {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.get_bucket_metadata_configuration_result {
+            val.ignore_empty_strings();
+        }
+    }
+}
+impl DtoExt for GetBucketMetadataConfigurationResult {
+    fn ignore_empty_strings(&mut self) {
+        self.metadata_configuration_result.ignore_empty_strings();
     }
 }
 impl DtoExt for GetBucketMetadataTableConfigurationInput {
@@ -37725,6 +39347,36 @@ impl DtoExt for InventoryS3BucketDestination {
 impl DtoExt for InventorySchedule {
     fn ignore_empty_strings(&mut self) {}
 }
+impl DtoExt for InventoryTableConfiguration {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.encryption_configuration {
+            val.ignore_empty_strings();
+        }
+    }
+}
+impl DtoExt for InventoryTableConfigurationResult {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.error {
+            val.ignore_empty_strings();
+        }
+        if self.table_arn.as_deref() == Some("") {
+            self.table_arn = None;
+        }
+        if self.table_name.as_deref() == Some("") {
+            self.table_name = None;
+        }
+        if self.table_status.as_deref() == Some("") {
+            self.table_status = None;
+        }
+    }
+}
+impl DtoExt for InventoryTableConfigurationUpdates {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.encryption_configuration {
+            val.ignore_empty_strings();
+        }
+    }
+}
 impl DtoExt for JSONInput {
     fn ignore_empty_strings(&mut self) {
         if let Some(ref val) = self.type_
@@ -37739,6 +39391,30 @@ impl DtoExt for JSONOutput {
         if self.record_delimiter.as_deref() == Some("") {
             self.record_delimiter = None;
         }
+    }
+}
+impl DtoExt for JournalTableConfiguration {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.encryption_configuration {
+            val.ignore_empty_strings();
+        }
+        self.record_expiration.ignore_empty_strings();
+    }
+}
+impl DtoExt for JournalTableConfigurationResult {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.error {
+            val.ignore_empty_strings();
+        }
+        self.record_expiration.ignore_empty_strings();
+        if self.table_arn.as_deref() == Some("") {
+            self.table_arn = None;
+        }
+    }
+}
+impl DtoExt for JournalTableConfigurationUpdates {
+    fn ignore_empty_strings(&mut self) {
+        self.record_expiration.ignore_empty_strings();
     }
 }
 impl DtoExt for LambdaFunctionConfiguration {
@@ -38242,6 +39918,31 @@ impl DtoExt for LoggingEnabled {
         }
     }
 }
+impl DtoExt for MetadataConfiguration {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.annotation_table_configuration {
+            val.ignore_empty_strings();
+        }
+        if let Some(ref mut val) = self.inventory_table_configuration {
+            val.ignore_empty_strings();
+        }
+        self.journal_table_configuration.ignore_empty_strings();
+    }
+}
+impl DtoExt for MetadataConfigurationResult {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.annotation_table_configuration_result {
+            val.ignore_empty_strings();
+        }
+        self.destination_result.ignore_empty_strings();
+        if let Some(ref mut val) = self.inventory_table_configuration_result {
+            val.ignore_empty_strings();
+        }
+        if let Some(ref mut val) = self.journal_table_configuration_result {
+            val.ignore_empty_strings();
+        }
+    }
+}
 impl DtoExt for MetadataEntry {
     fn ignore_empty_strings(&mut self) {
         if self.name.as_deref() == Some("") {
@@ -38260,6 +39961,13 @@ impl DtoExt for MetadataTableConfiguration {
 impl DtoExt for MetadataTableConfigurationResult {
     fn ignore_empty_strings(&mut self) {
         self.s3_tables_destination_result.ignore_empty_strings();
+    }
+}
+impl DtoExt for MetadataTableEncryptionConfiguration {
+    fn ignore_empty_strings(&mut self) {
+        if self.kms_key_arn.as_deref() == Some("") {
+            self.kms_key_arn = None;
+        }
     }
 }
 impl DtoExt for Metrics {
@@ -39446,6 +41154,9 @@ impl DtoExt for QueueConfiguration {
         }
     }
 }
+impl DtoExt for RecordExpiration {
+    fn ignore_empty_strings(&mut self) {}
+}
 impl DtoExt for RecordsEvent {
     fn ignore_empty_strings(&mut self) {}
 }
@@ -39807,6 +41518,54 @@ impl DtoExt for Transition {
         {
             self.storage_class = None;
         }
+    }
+}
+impl DtoExt for UpdateBucketMetadataAnnotationTableConfigurationInput {
+    fn ignore_empty_strings(&mut self) {
+        self.annotation_table_configuration.ignore_empty_strings();
+        if let Some(ref val) = self.checksum_algorithm
+            && val.as_str() == ""
+        {
+            self.checksum_algorithm = None;
+        }
+        if self.content_md5.as_deref() == Some("") {
+            self.content_md5 = None;
+        }
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+    }
+}
+impl DtoExt for UpdateBucketMetadataInventoryTableConfigurationInput {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref val) = self.checksum_algorithm
+            && val.as_str() == ""
+        {
+            self.checksum_algorithm = None;
+        }
+        if self.content_md5.as_deref() == Some("") {
+            self.content_md5 = None;
+        }
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+        self.inventory_table_configuration.ignore_empty_strings();
+    }
+}
+impl DtoExt for UpdateBucketMetadataJournalTableConfigurationInput {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref val) = self.checksum_algorithm
+            && val.as_str() == ""
+        {
+            self.checksum_algorithm = None;
+        }
+        if self.content_md5.as_deref() == Some("") {
+            self.content_md5 = None;
+        }
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+        self.journal_table_configuration.ignore_empty_strings();
     }
 }
 impl DtoExt for UploadPartCopyInput {

--- a/crates/s3s/src/dto/generated_minio.rs
+++ b/crates/s3s/src/dto/generated_minio.rs
@@ -391,6 +391,145 @@ impl FromStr for AnalyticsS3ExportFileFormat {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AnnotationConfigurationState(Cow<'static, str>);
+
+impl AnnotationConfigurationState {
+    pub const DISABLED: &'static str = "DISABLED";
+
+    pub const ENABLED: &'static str = "ENABLED";
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn from_static(s: &'static str) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<String> for AnnotationConfigurationState {
+    fn from(s: String) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<AnnotationConfigurationState> for Cow<'static, str> {
+    fn from(s: AnnotationConfigurationState) -> Self {
+        s.0
+    }
+}
+
+impl FromStr for AnnotationConfigurationState {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s.to_owned()))
+    }
+}
+
+/// <p>Specifies the configuration for the annotation table associated with a bucket's Amazon S3 Metadata
+/// configuration. The annotation table is an Iceberg table that records annotation events for objects
+/// in the bucket.</p>
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct AnnotationTableConfiguration {
+    /// <p>The state of the annotation table. Valid values are <code>ENABLED</code> and <code>DISABLED</code>.</p>
+    pub configuration_state: AnnotationConfigurationState,
+    pub encryption_configuration: Option<MetadataTableEncryptionConfiguration>,
+    /// <p>The ARN of the IAM role used to manage the annotation table.</p>
+    pub role: Option<Role>,
+}
+
+impl fmt::Debug for AnnotationTableConfiguration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("AnnotationTableConfiguration");
+        d.field("configuration_state", &self.configuration_state);
+        if let Some(ref val) = self.encryption_configuration {
+            d.field("encryption_configuration", val);
+        }
+        if let Some(ref val) = self.role {
+            d.field("role", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl Default for AnnotationTableConfiguration {
+    fn default() -> Self {
+        Self {
+            configuration_state: String::new().into(),
+            encryption_configuration: None,
+            role: None,
+        }
+    }
+}
+
+/// <p>Contains the current state of the annotation table associated with a bucket's Amazon S3 Metadata
+/// configuration, including its provisioning status and identifiers.</p>
+#[derive(Clone, PartialEq)]
+pub struct AnnotationTableConfigurationResult {
+    /// <p>The current configuration state of the annotation table.</p>
+    pub configuration_state: AnnotationConfigurationState,
+    pub error: Option<ErrorDetails>,
+    /// <p>The ARN of the IAM role associated with the annotation table.</p>
+    pub role: Option<Role>,
+    /// <p>The ARN of the annotation table.</p>
+    pub table_arn: Option<S3TablesArn>,
+    /// <p>The name of the annotation table.</p>
+    pub table_name: Option<S3TablesName>,
+    /// <p>The provisioning status of the annotation table. Possible values: <code>CREATING</code>, <code>BACKFILLING</code>, <code>ACTIVE</code>, <code>FAILED</code>.</p>
+    pub table_status: Option<MetadataTableStatus>,
+}
+
+impl fmt::Debug for AnnotationTableConfigurationResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("AnnotationTableConfigurationResult");
+        d.field("configuration_state", &self.configuration_state);
+        if let Some(ref val) = self.error {
+            d.field("error", val);
+        }
+        if let Some(ref val) = self.role {
+            d.field("role", val);
+        }
+        if let Some(ref val) = self.table_arn {
+            d.field("table_arn", val);
+        }
+        if let Some(ref val) = self.table_name {
+            d.field("table_name", val);
+        }
+        if let Some(ref val) = self.table_status {
+            d.field("table_status", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+/// <p>Specifies updates to apply to the annotation table configuration. Used as the request body for
+/// <code>UpdateBucketMetadataAnnotationTableConfiguration</code>.</p>
+#[derive(Clone, PartialEq)]
+pub struct AnnotationTableConfigurationUpdates {
+    /// <p>The new configuration state to apply.</p>
+    pub configuration_state: AnnotationConfigurationState,
+    pub encryption_configuration: Option<MetadataTableEncryptionConfiguration>,
+    /// <p>The new IAM role ARN to apply.</p>
+    pub role: Option<Role>,
+}
+
+impl fmt::Debug for AnnotationTableConfigurationUpdates {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("AnnotationTableConfigurationUpdates");
+        d.field("configuration_state", &self.configuration_state);
+        if let Some(ref val) = self.encryption_configuration {
+            d.field("encryption_configuration", val);
+        }
+        if let Some(ref val) = self.role {
+            d.field("role", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArchiveStatus(Cow<'static, str>);
 
@@ -3326,6 +3465,65 @@ impl CreateBucketInput {
 }
 
 #[derive(Clone, PartialEq)]
+pub struct CreateBucketMetadataConfigurationInput {
+    /// <p>
+    /// The general purpose bucket that you want to create the metadata configuration for.
+    /// </p>
+    pub bucket: BucketName,
+    /// <p>
+    /// The checksum algorithm to use with your metadata configuration.
+    /// </p>
+    pub checksum_algorithm: Option<ChecksumAlgorithm>,
+    /// <p>
+    /// The <code>Content-MD5</code> header for the metadata configuration.
+    /// </p>
+    pub content_md5: Option<ContentMD5>,
+    /// <p>
+    /// The expected owner of the general purpose bucket that corresponds to your metadata configuration.
+    /// </p>
+    pub expected_bucket_owner: Option<AccountId>,
+    /// <p>
+    /// The contents of your metadata configuration.
+    /// </p>
+    pub metadata_configuration: MetadataConfiguration,
+}
+
+impl fmt::Debug for CreateBucketMetadataConfigurationInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("CreateBucketMetadataConfigurationInput");
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.checksum_algorithm {
+            d.field("checksum_algorithm", val);
+        }
+        if let Some(ref val) = self.content_md5 {
+            d.field("content_md5", val);
+        }
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.field("metadata_configuration", &self.metadata_configuration);
+        d.finish_non_exhaustive()
+    }
+}
+
+impl CreateBucketMetadataConfigurationInput {
+    #[must_use]
+    pub fn builder() -> builders::CreateBucketMetadataConfigurationInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct CreateBucketMetadataConfigurationOutput {}
+
+impl fmt::Debug for CreateBucketMetadataConfigurationOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("CreateBucketMetadataConfigurationOutput");
+        d.finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, PartialEq)]
 pub struct CreateBucketMetadataTableConfigurationInput {
     /// <p>
     /// The general purpose bucket that you want to create the metadata table configuration in.
@@ -4666,6 +4864,47 @@ impl fmt::Debug for DeleteBucketLifecycleOutput {
 }
 
 #[derive(Clone, Default, PartialEq)]
+pub struct DeleteBucketMetadataConfigurationInput {
+    /// <p>
+    /// The general purpose bucket that you want to remove the metadata configuration from.
+    /// </p>
+    pub bucket: BucketName,
+    /// <p>
+    /// The expected bucket owner of the general purpose bucket that you want to remove the metadata table
+    /// configuration from.
+    /// </p>
+    pub expected_bucket_owner: Option<AccountId>,
+}
+
+impl fmt::Debug for DeleteBucketMetadataConfigurationInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("DeleteBucketMetadataConfigurationInput");
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl DeleteBucketMetadataConfigurationInput {
+    #[must_use]
+    pub fn builder() -> builders::DeleteBucketMetadataConfigurationInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct DeleteBucketMetadataConfigurationOutput {}
+
+impl fmt::Debug for DeleteBucketMetadataConfigurationOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("DeleteBucketMetadataConfigurationOutput");
+        d.finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
 pub struct DeleteBucketMetadataTableConfigurationInput {
     /// <p>
     /// The general purpose bucket that you want to remove the metadata table configuration from.
@@ -5613,6 +5852,45 @@ impl fmt::Debug for Destination {
         }
         if let Some(ref val) = self.storage_class {
             d.field("storage_class", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+/// <p>
+/// The destination information for the S3 Metadata configuration.
+/// </p>
+#[derive(Clone, Default, PartialEq)]
+pub struct DestinationResult {
+    /// <p>
+    /// The Amazon Resource Name (ARN) of the table bucket where the metadata configuration is stored.
+    /// </p>
+    pub table_bucket_arn: Option<S3TablesBucketArn>,
+    /// <p>
+    /// The type of the table bucket where the metadata configuration is stored. The <code>aws</code>
+    /// value indicates an Amazon Web Services managed table bucket, and the <code>customer</code> value indicates a
+    /// customer-managed table bucket. V2 metadata configurations are stored in Amazon Web Services managed table
+    /// buckets, and V1 metadata configurations are stored in customer-managed table buckets.
+    /// </p>
+    pub table_bucket_type: Option<S3TablesBucketType>,
+    /// <p>
+    /// The namespace in the table bucket where the metadata tables for a metadata configuration are
+    /// stored.
+    /// </p>
+    pub table_namespace: Option<S3TablesNamespace>,
+}
+
+impl fmt::Debug for DestinationResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("DestinationResult");
+        if let Some(ref val) = self.table_bucket_arn {
+            d.field("table_bucket_arn", val);
+        }
+        if let Some(ref val) = self.table_bucket_type {
+            d.field("table_bucket_type", val);
+        }
+        if let Some(ref val) = self.table_namespace {
+            d.field("table_namespace", val);
         }
         d.finish_non_exhaustive()
     }
@@ -7907,6 +8185,44 @@ impl FromStr for ExistingObjectReplicationStatus {
 pub type Expiration = String;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExpirationState(Cow<'static, str>);
+
+impl ExpirationState {
+    pub const DISABLED: &'static str = "DISABLED";
+
+    pub const ENABLED: &'static str = "ENABLED";
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn from_static(s: &'static str) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<String> for ExpirationState {
+    fn from(s: String) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<ExpirationState> for Cow<'static, str> {
+    fn from(s: ExpirationState) -> Self {
+        s.0
+    }
+}
+
+impl FromStr for ExpirationState {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s.to_owned()))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExpirationStatus(Cow<'static, str>);
 
 impl ExpirationStatus {
@@ -8653,6 +8969,75 @@ impl fmt::Debug for GetBucketLoggingOutput {
         if let Some(ref val) = self.logging_enabled {
             d.field("logging_enabled", val);
         }
+        d.finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct GetBucketMetadataConfigurationInput {
+    /// <p>
+    /// The general purpose bucket that corresponds to the metadata configuration that you want to
+    /// retrieve.
+    /// </p>
+    pub bucket: BucketName,
+    /// <p>
+    /// The expected owner of the general purpose bucket that you want to retrieve the metadata table
+    /// configuration for.
+    /// </p>
+    pub expected_bucket_owner: Option<AccountId>,
+}
+
+impl fmt::Debug for GetBucketMetadataConfigurationInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("GetBucketMetadataConfigurationInput");
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl GetBucketMetadataConfigurationInput {
+    #[must_use]
+    pub fn builder() -> builders::GetBucketMetadataConfigurationInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct GetBucketMetadataConfigurationOutput {
+    /// <p>
+    /// The metadata configuration for the general purpose bucket.
+    /// </p>
+    pub get_bucket_metadata_configuration_result: Option<GetBucketMetadataConfigurationResult>,
+}
+
+impl fmt::Debug for GetBucketMetadataConfigurationOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("GetBucketMetadataConfigurationOutput");
+        if let Some(ref val) = self.get_bucket_metadata_configuration_result {
+            d.field("get_bucket_metadata_configuration_result", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+/// <p>
+/// The S3 Metadata configuration for a general purpose bucket.
+/// </p>
+#[derive(Clone, PartialEq)]
+pub struct GetBucketMetadataConfigurationResult {
+    /// <p>
+    /// The metadata configuration for a general purpose bucket.
+    /// </p>
+    pub metadata_configuration_result: MetadataConfigurationResult,
+}
+
+impl fmt::Debug for GetBucketMetadataConfigurationResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("GetBucketMetadataConfigurationResult");
+        d.field("metadata_configuration_result", &self.metadata_configuration_result);
         d.finish_non_exhaustive()
     }
 }
@@ -11728,6 +12113,44 @@ impl Default for InventoryConfiguration {
 
 pub type InventoryConfigurationList = List<InventoryConfiguration>;
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InventoryConfigurationState(Cow<'static, str>);
+
+impl InventoryConfigurationState {
+    pub const DISABLED: &'static str = "DISABLED";
+
+    pub const ENABLED: &'static str = "ENABLED";
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn from_static(s: &'static str) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<String> for InventoryConfigurationState {
+    fn from(s: String) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<InventoryConfigurationState> for Cow<'static, str> {
+    fn from(s: InventoryConfigurationState) -> Self {
+        s.0
+    }
+}
+
+impl FromStr for InventoryConfigurationState {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s.to_owned()))
+    }
+}
+
 /// <p>Specifies the inventory configuration for an Amazon S3 bucket.</p>
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct InventoryDestination {
@@ -12053,6 +12476,140 @@ impl Default for InventorySchedule {
     }
 }
 
+/// <p>
+/// The inventory table configuration for an S3 Metadata configuration.
+/// </p>
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct InventoryTableConfiguration {
+    /// <p>
+    /// The configuration state of the inventory table, indicating whether the inventory table is enabled
+    /// or disabled.
+    /// </p>
+    pub configuration_state: InventoryConfigurationState,
+    /// <p>
+    /// The encryption configuration for the inventory table.
+    /// </p>
+    pub encryption_configuration: Option<MetadataTableEncryptionConfiguration>,
+}
+
+impl fmt::Debug for InventoryTableConfiguration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("InventoryTableConfiguration");
+        d.field("configuration_state", &self.configuration_state);
+        if let Some(ref val) = self.encryption_configuration {
+            d.field("encryption_configuration", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl Default for InventoryTableConfiguration {
+    fn default() -> Self {
+        Self {
+            configuration_state: String::new().into(),
+            encryption_configuration: None,
+        }
+    }
+}
+
+/// <p>
+/// The inventory table configuration for an S3 Metadata configuration.
+/// </p>
+#[derive(Clone, PartialEq)]
+pub struct InventoryTableConfigurationResult {
+    /// <p>
+    /// The configuration state of the inventory table, indicating whether the inventory table is enabled
+    /// or disabled.
+    /// </p>
+    pub configuration_state: InventoryConfigurationState,
+    pub error: Option<ErrorDetails>,
+    /// <p>
+    /// The Amazon Resource Name (ARN) for the inventory table.
+    /// </p>
+    pub table_arn: Option<S3TablesArn>,
+    /// <p>
+    /// The name of the inventory table.
+    /// </p>
+    pub table_name: Option<S3TablesName>,
+    /// <p> The status of the inventory table. The status values are: </p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <code>CREATING</code> - The inventory table is in the process of being created in the specified
+    /// Amazon Web Services managed table bucket.</p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>BACKFILLING</code> - The inventory table is in the process of being backfilled. When
+    /// you enable the inventory table for your metadata configuration, the table goes through a
+    /// process known as backfilling, during which Amazon S3 scans your general purpose bucket to retrieve
+    /// the initial metadata for all objects in the bucket. Depending on the number of objects in your
+    /// bucket, this process can take several hours. When the backfilling process is finished, the
+    /// status of your inventory table changes from <code>BACKFILLING</code> to <code>ACTIVE</code>.
+    /// After backfilling is completed, updates to your objects are reflected in the inventory table
+    /// within one hour.</p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>ACTIVE</code> - The inventory table has been created successfully, and records are being
+    /// delivered to the table. </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>FAILED</code> - Amazon S3 is unable to create the inventory table, or Amazon S3 is unable to deliver
+    /// records.</p>
+    /// </li>
+    /// </ul>
+    pub table_status: Option<MetadataTableStatus>,
+}
+
+impl fmt::Debug for InventoryTableConfigurationResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("InventoryTableConfigurationResult");
+        d.field("configuration_state", &self.configuration_state);
+        if let Some(ref val) = self.error {
+            d.field("error", val);
+        }
+        if let Some(ref val) = self.table_arn {
+            d.field("table_arn", val);
+        }
+        if let Some(ref val) = self.table_name {
+            d.field("table_name", val);
+        }
+        if let Some(ref val) = self.table_status {
+            d.field("table_status", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+/// <p>
+/// The specified updates to the S3 Metadata inventory table configuration.
+/// </p>
+#[derive(Clone, PartialEq)]
+pub struct InventoryTableConfigurationUpdates {
+    /// <p>
+    /// The configuration state of the inventory table, indicating whether the inventory table is enabled
+    /// or disabled.
+    /// </p>
+    pub configuration_state: InventoryConfigurationState,
+    /// <p>
+    /// The encryption configuration for the inventory table.
+    /// </p>
+    pub encryption_configuration: Option<MetadataTableEncryptionConfiguration>,
+}
+
+impl fmt::Debug for InventoryTableConfigurationUpdates {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("InventoryTableConfigurationUpdates");
+        d.field("configuration_state", &self.configuration_state);
+        if let Some(ref val) = self.encryption_configuration {
+            d.field("encryption_configuration", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
 pub type IsEnabled = bool;
 
 pub type IsLatest = bool;
@@ -12136,6 +12693,115 @@ impl FromStr for JSONType {
     }
 }
 
+/// <p>
+/// The journal table configuration for an S3 Metadata configuration.
+/// </p>
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct JournalTableConfiguration {
+    /// <p>
+    /// The encryption configuration for the journal table.
+    /// </p>
+    pub encryption_configuration: Option<MetadataTableEncryptionConfiguration>,
+    /// <p>
+    /// The journal table record expiration settings for the journal table.
+    /// </p>
+    pub record_expiration: RecordExpiration,
+}
+
+impl fmt::Debug for JournalTableConfiguration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("JournalTableConfiguration");
+        if let Some(ref val) = self.encryption_configuration {
+            d.field("encryption_configuration", val);
+        }
+        d.field("record_expiration", &self.record_expiration);
+        d.finish_non_exhaustive()
+    }
+}
+
+impl Default for JournalTableConfiguration {
+    fn default() -> Self {
+        Self {
+            encryption_configuration: None,
+            record_expiration: default(),
+        }
+    }
+}
+
+/// <p>
+/// The journal table configuration for the S3 Metadata configuration.
+/// </p>
+#[derive(Clone, PartialEq)]
+pub struct JournalTableConfigurationResult {
+    pub error: Option<ErrorDetails>,
+    /// <p>
+    /// The journal table record expiration settings for the journal table.
+    /// </p>
+    pub record_expiration: RecordExpiration,
+    /// <p>
+    /// The Amazon Resource Name (ARN) for the journal table.
+    /// </p>
+    pub table_arn: Option<S3TablesArn>,
+    /// <p>
+    /// The name of the journal table.
+    /// </p>
+    pub table_name: S3TablesName,
+    /// <p> The status of the journal table. The status values are: </p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <code>CREATING</code> - The journal table is in the process of being created in the specified
+    /// table bucket.</p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>ACTIVE</code> - The journal table has been created successfully, and records are being
+    /// delivered to the table. </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>FAILED</code> - Amazon S3 is unable to create the journal table, or Amazon S3 is unable to deliver
+    /// records.</p>
+    /// </li>
+    /// </ul>
+    pub table_status: MetadataTableStatus,
+}
+
+impl fmt::Debug for JournalTableConfigurationResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("JournalTableConfigurationResult");
+        if let Some(ref val) = self.error {
+            d.field("error", val);
+        }
+        d.field("record_expiration", &self.record_expiration);
+        if let Some(ref val) = self.table_arn {
+            d.field("table_arn", val);
+        }
+        d.field("table_name", &self.table_name);
+        d.field("table_status", &self.table_status);
+        d.finish_non_exhaustive()
+    }
+}
+
+/// <p>
+/// The specified updates to the S3 Metadata journal table configuration.
+/// </p>
+#[derive(Clone, PartialEq)]
+pub struct JournalTableConfigurationUpdates {
+    /// <p>
+    /// The journal table record expiration settings for the journal table.
+    /// </p>
+    pub record_expiration: RecordExpiration,
+}
+
+impl fmt::Debug for JournalTableConfigurationUpdates {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("JournalTableConfigurationUpdates");
+        d.field("record_expiration", &self.record_expiration);
+        d.finish_non_exhaustive()
+    }
+}
+
 pub type KMSContext = String;
 
 pub type KeyCount = i32;
@@ -12143,6 +12809,8 @@ pub type KeyCount = i32;
 pub type KeyMarker = String;
 
 pub type KeyPrefixEquals = String;
+
+pub type KmsKeyArn = String;
 
 pub type LambdaFunctionArn = String;
 
@@ -14202,6 +14870,85 @@ pub type Message = String;
 
 pub type Metadata = Map<MetadataKey, MetadataValue>;
 
+/// <p>
+/// The S3 Metadata configuration for a general purpose bucket.
+/// </p>
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct MetadataConfiguration {
+    /// <p>Optional annotation table configuration to include with the metadata configuration.</p>
+    pub annotation_table_configuration: Option<AnnotationTableConfiguration>,
+    /// <p>
+    /// The inventory table configuration for a metadata configuration.
+    /// </p>
+    pub inventory_table_configuration: Option<InventoryTableConfiguration>,
+    /// <p>
+    /// The journal table configuration for a metadata configuration.
+    /// </p>
+    pub journal_table_configuration: JournalTableConfiguration,
+}
+
+impl fmt::Debug for MetadataConfiguration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("MetadataConfiguration");
+        if let Some(ref val) = self.annotation_table_configuration {
+            d.field("annotation_table_configuration", val);
+        }
+        if let Some(ref val) = self.inventory_table_configuration {
+            d.field("inventory_table_configuration", val);
+        }
+        d.field("journal_table_configuration", &self.journal_table_configuration);
+        d.finish_non_exhaustive()
+    }
+}
+
+impl Default for MetadataConfiguration {
+    fn default() -> Self {
+        Self {
+            annotation_table_configuration: None,
+            inventory_table_configuration: None,
+            journal_table_configuration: default(),
+        }
+    }
+}
+
+/// <p>
+/// The S3 Metadata configuration for a general purpose bucket.
+/// </p>
+#[derive(Clone, PartialEq)]
+pub struct MetadataConfigurationResult {
+    /// <p>The annotation table configuration result, if an annotation table is configured.</p>
+    pub annotation_table_configuration_result: Option<AnnotationTableConfigurationResult>,
+    /// <p>
+    /// The destination settings for a metadata configuration.
+    /// </p>
+    pub destination_result: DestinationResult,
+    /// <p>
+    /// The inventory table configuration for a metadata configuration.
+    /// </p>
+    pub inventory_table_configuration_result: Option<InventoryTableConfigurationResult>,
+    /// <p>
+    /// The journal table configuration for a metadata configuration.
+    /// </p>
+    pub journal_table_configuration_result: Option<JournalTableConfigurationResult>,
+}
+
+impl fmt::Debug for MetadataConfigurationResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("MetadataConfigurationResult");
+        if let Some(ref val) = self.annotation_table_configuration_result {
+            d.field("annotation_table_configuration_result", val);
+        }
+        d.field("destination_result", &self.destination_result);
+        if let Some(ref val) = self.inventory_table_configuration_result {
+            d.field("inventory_table_configuration_result", val);
+        }
+        if let Some(ref val) = self.journal_table_configuration_result {
+            d.field("journal_table_configuration_result", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MetadataDirective(Cow<'static, str>);
 
@@ -14316,6 +15063,46 @@ impl fmt::Debug for MetadataTableConfigurationResult {
         let mut d = f.debug_struct("MetadataTableConfigurationResult");
         d.field("s3_tables_destination_result", &self.s3_tables_destination_result);
         d.finish_non_exhaustive()
+    }
+}
+
+/// <p>
+/// The encryption settings for an S3 Metadata journal table or inventory table configuration.
+/// </p>
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct MetadataTableEncryptionConfiguration {
+    /// <p>
+    /// If server-side encryption with Key Management Service (KMS) keys (SSE-KMS) is specified, you must also
+    /// specify the KMS key Amazon Resource Name (ARN). You must specify a customer-managed KMS key
+    /// that's located in the same Region as the general purpose bucket that corresponds to the metadata
+    /// table configuration.
+    /// </p>
+    pub kms_key_arn: Option<KmsKeyArn>,
+    /// <p>
+    /// The encryption type specified for a metadata table. To specify server-side encryption with
+    /// Key Management Service (KMS) keys (SSE-KMS), use the <code>aws:kms</code> value. To specify server-side
+    /// encryption with Amazon S3 managed keys (SSE-S3), use the <code>AES256</code> value.
+    /// </p>
+    pub sse_algorithm: TableSseAlgorithm,
+}
+
+impl fmt::Debug for MetadataTableEncryptionConfiguration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("MetadataTableEncryptionConfiguration");
+        if let Some(ref val) = self.kms_key_arn {
+            d.field("kms_key_arn", val);
+        }
+        d.field("sse_algorithm", &self.sse_algorithm);
+        d.finish_non_exhaustive()
+    }
+}
+
+impl Default for MetadataTableEncryptionConfiguration {
+    fn default() -> Self {
+        Self {
+            kms_key_arn: None,
+            sse_algorithm: String::new().into(),
+        }
     }
 }
 
@@ -19575,6 +20362,46 @@ impl FromStr for QuoteFields {
 
 pub type RecordDelimiter = String;
 
+/// <p>
+/// The journal table record expiration settings for a journal table in an S3 Metadata configuration.
+/// </p>
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct RecordExpiration {
+    /// <p>
+    /// If you enable journal table record expiration, you can set the number of days to retain your
+    /// journal table records. Journal table records must be retained for a minimum of 7 days. To set
+    /// this value, specify any whole number from <code>7</code> to <code>2147483647</code>. For example,
+    /// to retain your journal table records for one year, set this value to <code>365</code>.
+    /// </p>
+    pub days: Option<RecordExpirationDays>,
+    /// <p>
+    /// Specifies whether journal table record expiration is enabled or disabled.
+    /// </p>
+    pub expiration: ExpirationState,
+}
+
+impl fmt::Debug for RecordExpiration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("RecordExpiration");
+        if let Some(ref val) = self.days {
+            d.field("days", val);
+        }
+        d.field("expiration", &self.expiration);
+        d.finish_non_exhaustive()
+    }
+}
+
+impl Default for RecordExpiration {
+    fn default() -> Self {
+        Self {
+            days: None,
+            expiration: String::new().into(),
+        }
+    }
+}
+
+pub type RecordExpirationDays = i32;
+
 /// <p>The container for the records event.</p>
 #[derive(Clone, Default, PartialEq)]
 pub struct RecordsEvent {
@@ -20705,6 +21532,44 @@ pub type S3TablesArn = String;
 
 pub type S3TablesBucketArn = String;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct S3TablesBucketType(Cow<'static, str>);
+
+impl S3TablesBucketType {
+    pub const AWS: &'static str = "aws";
+
+    pub const CUSTOMER: &'static str = "customer";
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn from_static(s: &'static str) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<String> for S3TablesBucketType {
+    fn from(s: String) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<S3TablesBucketType> for Cow<'static, str> {
+    fn from(s: S3TablesBucketType) -> Self {
+        s.0
+    }
+}
+
+impl FromStr for S3TablesBucketType {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s.to_owned()))
+    }
+}
+
 /// <p>
 /// The destination information for the metadata table configuration. The destination table bucket
 /// must be in the same Region and Amazon Web Services account as the general purpose bucket. The specified metadata
@@ -21675,6 +22540,44 @@ impl FromStr for StorageClassAnalysisSchemaVersion {
 
 pub type Suffix = String;
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TableSseAlgorithm(Cow<'static, str>);
+
+impl TableSseAlgorithm {
+    pub const AES256: &'static str = "AES256";
+
+    pub const AWS_KMS: &'static str = "aws:kms";
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn from_static(s: &'static str) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<String> for TableSseAlgorithm {
+    fn from(s: String) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<TableSseAlgorithm> for Cow<'static, str> {
+    fn from(s: TableSseAlgorithm) -> Self {
+        s.0
+    }
+}
+
+impl FromStr for TableSseAlgorithm {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s.to_owned()))
+    }
+}
+
 /// <p>A container of a key value name pair.</p>
 #[derive(Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
@@ -22097,6 +23000,177 @@ impl FromStr for Type {
 }
 
 pub type URI = String;
+
+#[derive(Clone, PartialEq)]
+pub struct UpdateBucketMetadataAnnotationTableConfigurationInput {
+    /// <p>The annotation table configuration updates to apply.</p>
+    pub annotation_table_configuration: AnnotationTableConfigurationUpdates,
+    /// <p>The name of the bucket whose annotation table configuration to update.</p>
+    pub bucket: BucketName,
+    /// <p>Checksum algorithm for the request payload.</p>
+    pub checksum_algorithm: Option<ChecksumAlgorithm>,
+    /// <p>Base64-encoded MD5 digest of the message body.</p>
+    pub content_md5: Option<ContentMD5>,
+    /// <p>The account ID of the expected bucket owner.</p>
+    pub expected_bucket_owner: Option<AccountId>,
+}
+
+impl fmt::Debug for UpdateBucketMetadataAnnotationTableConfigurationInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("UpdateBucketMetadataAnnotationTableConfigurationInput");
+        d.field("annotation_table_configuration", &self.annotation_table_configuration);
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.checksum_algorithm {
+            d.field("checksum_algorithm", val);
+        }
+        if let Some(ref val) = self.content_md5 {
+            d.field("content_md5", val);
+        }
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl UpdateBucketMetadataAnnotationTableConfigurationInput {
+    #[must_use]
+    pub fn builder() -> builders::UpdateBucketMetadataAnnotationTableConfigurationInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct UpdateBucketMetadataAnnotationTableConfigurationOutput {}
+
+impl fmt::Debug for UpdateBucketMetadataAnnotationTableConfigurationOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("UpdateBucketMetadataAnnotationTableConfigurationOutput");
+        d.finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct UpdateBucketMetadataInventoryTableConfigurationInput {
+    /// <p>
+    /// The general purpose bucket that corresponds to the metadata configuration that you want to
+    /// enable or disable an inventory table for.
+    /// </p>
+    pub bucket: BucketName,
+    /// <p>
+    /// The checksum algorithm to use with your inventory table configuration.
+    /// </p>
+    pub checksum_algorithm: Option<ChecksumAlgorithm>,
+    /// <p>
+    /// The <code>Content-MD5</code> header for the inventory table configuration.
+    /// </p>
+    pub content_md5: Option<ContentMD5>,
+    /// <p>
+    /// The expected owner of the general purpose bucket that corresponds to the metadata table
+    /// configuration that you want to enable or disable an inventory table for.
+    /// </p>
+    pub expected_bucket_owner: Option<AccountId>,
+    /// <p>
+    /// The contents of your inventory table configuration.      
+    /// </p>
+    pub inventory_table_configuration: InventoryTableConfigurationUpdates,
+}
+
+impl fmt::Debug for UpdateBucketMetadataInventoryTableConfigurationInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("UpdateBucketMetadataInventoryTableConfigurationInput");
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.checksum_algorithm {
+            d.field("checksum_algorithm", val);
+        }
+        if let Some(ref val) = self.content_md5 {
+            d.field("content_md5", val);
+        }
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.field("inventory_table_configuration", &self.inventory_table_configuration);
+        d.finish_non_exhaustive()
+    }
+}
+
+impl UpdateBucketMetadataInventoryTableConfigurationInput {
+    #[must_use]
+    pub fn builder() -> builders::UpdateBucketMetadataInventoryTableConfigurationInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct UpdateBucketMetadataInventoryTableConfigurationOutput {}
+
+impl fmt::Debug for UpdateBucketMetadataInventoryTableConfigurationOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("UpdateBucketMetadataInventoryTableConfigurationOutput");
+        d.finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct UpdateBucketMetadataJournalTableConfigurationInput {
+    /// <p>
+    /// The general purpose bucket that corresponds to the metadata configuration that you want to
+    /// enable or disable journal table record expiration for.
+    /// </p>
+    pub bucket: BucketName,
+    /// <p>
+    /// The checksum algorithm to use with your journal table configuration.
+    /// </p>
+    pub checksum_algorithm: Option<ChecksumAlgorithm>,
+    /// <p>
+    /// The <code>Content-MD5</code> header for the journal table configuration.
+    /// </p>
+    pub content_md5: Option<ContentMD5>,
+    /// <p>
+    /// The expected owner of the general purpose bucket that corresponds to the metadata table
+    /// configuration that you want to enable or disable journal table record expiration for.      
+    /// </p>
+    pub expected_bucket_owner: Option<AccountId>,
+    /// <p>
+    /// The contents of your journal table configuration.
+    /// </p>
+    pub journal_table_configuration: JournalTableConfigurationUpdates,
+}
+
+impl fmt::Debug for UpdateBucketMetadataJournalTableConfigurationInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("UpdateBucketMetadataJournalTableConfigurationInput");
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.checksum_algorithm {
+            d.field("checksum_algorithm", val);
+        }
+        if let Some(ref val) = self.content_md5 {
+            d.field("content_md5", val);
+        }
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.field("journal_table_configuration", &self.journal_table_configuration);
+        d.finish_non_exhaustive()
+    }
+}
+
+impl UpdateBucketMetadataJournalTableConfigurationInput {
+    #[must_use]
+    pub fn builder() -> builders::UpdateBucketMetadataJournalTableConfigurationInputBuilder {
+        default()
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct UpdateBucketMetadataJournalTableConfigurationOutput {}
+
+impl fmt::Debug for UpdateBucketMetadataJournalTableConfigurationOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("UpdateBucketMetadataJournalTableConfigurationOutput");
+        d.finish_non_exhaustive()
+    }
+}
 
 pub type UploadIdMarker = String;
 
@@ -23242,6 +24316,7 @@ mod tests {
         require_default::<CompleteMultipartUploadOutput>();
         require_default::<CopyObjectOutput>();
         require_default::<CreateBucketOutput>();
+        require_default::<CreateBucketMetadataConfigurationOutput>();
         require_default::<CreateBucketMetadataTableConfigurationOutput>();
         require_default::<CreateMultipartUploadOutput>();
         require_default::<CreateSessionOutput>();
@@ -23252,6 +24327,7 @@ mod tests {
         require_default::<DeleteBucketIntelligentTieringConfigurationOutput>();
         require_default::<DeleteBucketInventoryConfigurationOutput>();
         require_default::<DeleteBucketLifecycleOutput>();
+        require_default::<DeleteBucketMetadataConfigurationOutput>();
         require_default::<DeleteBucketMetadataTableConfigurationOutput>();
         require_default::<DeleteBucketMetricsConfigurationOutput>();
         require_default::<DeleteBucketOwnershipControlsOutput>();
@@ -23274,6 +24350,7 @@ mod tests {
         require_default::<GetBucketLifecycleConfigurationOutput>();
         require_default::<GetBucketLocationOutput>();
         require_default::<GetBucketLoggingOutput>();
+        require_default::<GetBucketMetadataConfigurationOutput>();
         require_default::<GetBucketMetadataTableConfigurationOutput>();
         require_default::<GetBucketMetricsConfigurationOutput>();
         require_default::<GetBucketNotificationConfigurationOutput>();
@@ -23337,6 +24414,9 @@ mod tests {
         require_default::<RenameObjectOutput>();
         require_default::<RestoreObjectOutput>();
         require_default::<SelectObjectContentOutput>();
+        require_default::<UpdateBucketMetadataAnnotationTableConfigurationOutput>();
+        require_default::<UpdateBucketMetadataInventoryTableConfigurationOutput>();
+        require_default::<UpdateBucketMetadataJournalTableConfigurationOutput>();
         require_default::<UploadPartOutput>();
         require_default::<UploadPartCopyOutput>();
         require_default::<WriteGetObjectResponseOutput>();
@@ -23350,6 +24430,8 @@ mod tests {
         require_clone::<CopyObjectOutput>();
         require_clone::<CreateBucketInput>();
         require_clone::<CreateBucketOutput>();
+        require_clone::<CreateBucketMetadataConfigurationInput>();
+        require_clone::<CreateBucketMetadataConfigurationOutput>();
         require_clone::<CreateBucketMetadataTableConfigurationInput>();
         require_clone::<CreateBucketMetadataTableConfigurationOutput>();
         require_clone::<CreateMultipartUploadInput>();
@@ -23370,6 +24452,8 @@ mod tests {
         require_clone::<DeleteBucketInventoryConfigurationOutput>();
         require_clone::<DeleteBucketLifecycleInput>();
         require_clone::<DeleteBucketLifecycleOutput>();
+        require_clone::<DeleteBucketMetadataConfigurationInput>();
+        require_clone::<DeleteBucketMetadataConfigurationOutput>();
         require_clone::<DeleteBucketMetadataTableConfigurationInput>();
         require_clone::<DeleteBucketMetadataTableConfigurationOutput>();
         require_clone::<DeleteBucketMetricsConfigurationInput>();
@@ -23414,6 +24498,8 @@ mod tests {
         require_clone::<GetBucketLocationOutput>();
         require_clone::<GetBucketLoggingInput>();
         require_clone::<GetBucketLoggingOutput>();
+        require_clone::<GetBucketMetadataConfigurationInput>();
+        require_clone::<GetBucketMetadataConfigurationOutput>();
         require_clone::<GetBucketMetadataTableConfigurationInput>();
         require_clone::<GetBucketMetadataTableConfigurationOutput>();
         require_clone::<GetBucketMetricsConfigurationInput>();
@@ -23535,6 +24621,12 @@ mod tests {
         require_clone::<RestoreObjectInput>();
         require_clone::<RestoreObjectOutput>();
         require_clone::<SelectObjectContentInput>();
+        require_clone::<UpdateBucketMetadataAnnotationTableConfigurationInput>();
+        require_clone::<UpdateBucketMetadataAnnotationTableConfigurationOutput>();
+        require_clone::<UpdateBucketMetadataInventoryTableConfigurationInput>();
+        require_clone::<UpdateBucketMetadataInventoryTableConfigurationOutput>();
+        require_clone::<UpdateBucketMetadataJournalTableConfigurationInput>();
+        require_clone::<UpdateBucketMetadataJournalTableConfigurationOutput>();
         require_clone::<UploadPartOutput>();
         require_clone::<UploadPartCopyInput>();
         require_clone::<UploadPartCopyOutput>();
@@ -24821,6 +25913,94 @@ pub mod builders {
         }
     }
 
+    /// A builder for [`CreateBucketMetadataConfigurationInput`]
+    #[derive(Default)]
+    pub struct CreateBucketMetadataConfigurationInputBuilder {
+        bucket: Option<BucketName>,
+
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+
+        content_md5: Option<ContentMD5>,
+
+        expected_bucket_owner: Option<AccountId>,
+
+        metadata_configuration: Option<MetadataConfiguration>,
+    }
+
+    impl CreateBucketMetadataConfigurationInputBuilder {
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_algorithm(&mut self, field: Option<ChecksumAlgorithm>) -> &mut Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        pub fn set_content_md5(&mut self, field: Option<ContentMD5>) -> &mut Self {
+            self.content_md5 = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn set_metadata_configuration(&mut self, field: MetadataConfiguration) -> &mut Self {
+            self.metadata_configuration = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_algorithm(mut self, field: Option<ChecksumAlgorithm>) -> Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        #[must_use]
+        pub fn content_md5(mut self, field: Option<ContentMD5>) -> Self {
+            self.content_md5 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn metadata_configuration(mut self, field: MetadataConfiguration) -> Self {
+            self.metadata_configuration = Some(field);
+            self
+        }
+
+        pub fn build(self) -> Result<CreateBucketMetadataConfigurationInput, BuildError> {
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_algorithm = self.checksum_algorithm;
+            let content_md5 = self.content_md5;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            let metadata_configuration = self
+                .metadata_configuration
+                .ok_or_else(|| BuildError::missing_field("metadata_configuration"))?;
+            Ok(CreateBucketMetadataConfigurationInput {
+                bucket,
+                checksum_algorithm,
+                content_md5,
+                expected_bucket_owner,
+                metadata_configuration,
+            })
+        }
+    }
+
     /// A builder for [`CreateBucketMetadataTableConfigurationInput`]
     #[derive(Default)]
     pub struct CreateBucketMetadataTableConfigurationInputBuilder {
@@ -25842,6 +27022,47 @@ pub mod builders {
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
             let expected_bucket_owner = self.expected_bucket_owner;
             Ok(DeleteBucketLifecycleInput {
+                bucket,
+                expected_bucket_owner,
+            })
+        }
+    }
+
+    /// A builder for [`DeleteBucketMetadataConfigurationInput`]
+    #[derive(Default)]
+    pub struct DeleteBucketMetadataConfigurationInputBuilder {
+        bucket: Option<BucketName>,
+
+        expected_bucket_owner: Option<AccountId>,
+    }
+
+    impl DeleteBucketMetadataConfigurationInputBuilder {
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn build(self) -> Result<DeleteBucketMetadataConfigurationInput, BuildError> {
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            Ok(DeleteBucketMetadataConfigurationInput {
                 bucket,
                 expected_bucket_owner,
             })
@@ -27044,6 +28265,47 @@ pub mod builders {
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
             let expected_bucket_owner = self.expected_bucket_owner;
             Ok(GetBucketLoggingInput {
+                bucket,
+                expected_bucket_owner,
+            })
+        }
+    }
+
+    /// A builder for [`GetBucketMetadataConfigurationInput`]
+    #[derive(Default)]
+    pub struct GetBucketMetadataConfigurationInputBuilder {
+        bucket: Option<BucketName>,
+
+        expected_bucket_owner: Option<AccountId>,
+    }
+
+    impl GetBucketMetadataConfigurationInputBuilder {
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn build(self) -> Result<GetBucketMetadataConfigurationInput, BuildError> {
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            Ok(GetBucketMetadataConfigurationInput {
                 bucket,
                 expected_bucket_owner,
             })
@@ -34451,6 +35713,270 @@ pub mod builders {
         }
     }
 
+    /// A builder for [`UpdateBucketMetadataAnnotationTableConfigurationInput`]
+    #[derive(Default)]
+    pub struct UpdateBucketMetadataAnnotationTableConfigurationInputBuilder {
+        annotation_table_configuration: Option<AnnotationTableConfigurationUpdates>,
+
+        bucket: Option<BucketName>,
+
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+
+        content_md5: Option<ContentMD5>,
+
+        expected_bucket_owner: Option<AccountId>,
+    }
+
+    impl UpdateBucketMetadataAnnotationTableConfigurationInputBuilder {
+        pub fn set_annotation_table_configuration(&mut self, field: AnnotationTableConfigurationUpdates) -> &mut Self {
+            self.annotation_table_configuration = Some(field);
+            self
+        }
+
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_algorithm(&mut self, field: Option<ChecksumAlgorithm>) -> &mut Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        pub fn set_content_md5(&mut self, field: Option<ContentMD5>) -> &mut Self {
+            self.content_md5 = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn annotation_table_configuration(mut self, field: AnnotationTableConfigurationUpdates) -> Self {
+            self.annotation_table_configuration = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_algorithm(mut self, field: Option<ChecksumAlgorithm>) -> Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        #[must_use]
+        pub fn content_md5(mut self, field: Option<ContentMD5>) -> Self {
+            self.content_md5 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn build(self) -> Result<UpdateBucketMetadataAnnotationTableConfigurationInput, BuildError> {
+            let annotation_table_configuration = self
+                .annotation_table_configuration
+                .ok_or_else(|| BuildError::missing_field("annotation_table_configuration"))?;
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_algorithm = self.checksum_algorithm;
+            let content_md5 = self.content_md5;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            Ok(UpdateBucketMetadataAnnotationTableConfigurationInput {
+                annotation_table_configuration,
+                bucket,
+                checksum_algorithm,
+                content_md5,
+                expected_bucket_owner,
+            })
+        }
+    }
+
+    /// A builder for [`UpdateBucketMetadataInventoryTableConfigurationInput`]
+    #[derive(Default)]
+    pub struct UpdateBucketMetadataInventoryTableConfigurationInputBuilder {
+        bucket: Option<BucketName>,
+
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+
+        content_md5: Option<ContentMD5>,
+
+        expected_bucket_owner: Option<AccountId>,
+
+        inventory_table_configuration: Option<InventoryTableConfigurationUpdates>,
+    }
+
+    impl UpdateBucketMetadataInventoryTableConfigurationInputBuilder {
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_algorithm(&mut self, field: Option<ChecksumAlgorithm>) -> &mut Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        pub fn set_content_md5(&mut self, field: Option<ContentMD5>) -> &mut Self {
+            self.content_md5 = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn set_inventory_table_configuration(&mut self, field: InventoryTableConfigurationUpdates) -> &mut Self {
+            self.inventory_table_configuration = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_algorithm(mut self, field: Option<ChecksumAlgorithm>) -> Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        #[must_use]
+        pub fn content_md5(mut self, field: Option<ContentMD5>) -> Self {
+            self.content_md5 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn inventory_table_configuration(mut self, field: InventoryTableConfigurationUpdates) -> Self {
+            self.inventory_table_configuration = Some(field);
+            self
+        }
+
+        pub fn build(self) -> Result<UpdateBucketMetadataInventoryTableConfigurationInput, BuildError> {
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_algorithm = self.checksum_algorithm;
+            let content_md5 = self.content_md5;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            let inventory_table_configuration = self
+                .inventory_table_configuration
+                .ok_or_else(|| BuildError::missing_field("inventory_table_configuration"))?;
+            Ok(UpdateBucketMetadataInventoryTableConfigurationInput {
+                bucket,
+                checksum_algorithm,
+                content_md5,
+                expected_bucket_owner,
+                inventory_table_configuration,
+            })
+        }
+    }
+
+    /// A builder for [`UpdateBucketMetadataJournalTableConfigurationInput`]
+    #[derive(Default)]
+    pub struct UpdateBucketMetadataJournalTableConfigurationInputBuilder {
+        bucket: Option<BucketName>,
+
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+
+        content_md5: Option<ContentMD5>,
+
+        expected_bucket_owner: Option<AccountId>,
+
+        journal_table_configuration: Option<JournalTableConfigurationUpdates>,
+    }
+
+    impl UpdateBucketMetadataJournalTableConfigurationInputBuilder {
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_algorithm(&mut self, field: Option<ChecksumAlgorithm>) -> &mut Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        pub fn set_content_md5(&mut self, field: Option<ContentMD5>) -> &mut Self {
+            self.content_md5 = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn set_journal_table_configuration(&mut self, field: JournalTableConfigurationUpdates) -> &mut Self {
+            self.journal_table_configuration = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_algorithm(mut self, field: Option<ChecksumAlgorithm>) -> Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        #[must_use]
+        pub fn content_md5(mut self, field: Option<ContentMD5>) -> Self {
+            self.content_md5 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn journal_table_configuration(mut self, field: JournalTableConfigurationUpdates) -> Self {
+            self.journal_table_configuration = Some(field);
+            self
+        }
+
+        pub fn build(self) -> Result<UpdateBucketMetadataJournalTableConfigurationInput, BuildError> {
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_algorithm = self.checksum_algorithm;
+            let content_md5 = self.content_md5;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            let journal_table_configuration = self
+                .journal_table_configuration
+                .ok_or_else(|| BuildError::missing_field("journal_table_configuration"))?;
+            Ok(UpdateBucketMetadataJournalTableConfigurationInput {
+                bucket,
+                checksum_algorithm,
+                content_md5,
+                expected_bucket_owner,
+                journal_table_configuration,
+            })
+        }
+    }
+
     /// A builder for [`UploadPartInput`]
     #[derive(Default)]
     pub struct UploadPartInputBuilder {
@@ -35887,6 +37413,45 @@ impl DtoExt for AnalyticsS3BucketDestination {
         }
     }
 }
+impl DtoExt for AnnotationTableConfiguration {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.encryption_configuration {
+            val.ignore_empty_strings();
+        }
+        if self.role.as_deref() == Some("") {
+            self.role = None;
+        }
+    }
+}
+impl DtoExt for AnnotationTableConfigurationResult {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.error {
+            val.ignore_empty_strings();
+        }
+        if self.role.as_deref() == Some("") {
+            self.role = None;
+        }
+        if self.table_arn.as_deref() == Some("") {
+            self.table_arn = None;
+        }
+        if self.table_name.as_deref() == Some("") {
+            self.table_name = None;
+        }
+        if self.table_status.as_deref() == Some("") {
+            self.table_status = None;
+        }
+    }
+}
+impl DtoExt for AnnotationTableConfigurationUpdates {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.encryption_configuration {
+            val.ignore_empty_strings();
+        }
+        if self.role.as_deref() == Some("") {
+            self.role = None;
+        }
+    }
+}
 impl DtoExt for AssumeRoleOutput {
     fn ignore_empty_strings(&mut self) {
         if let Some(ref mut val) = self.assumed_role_user {
@@ -36486,6 +38051,22 @@ impl DtoExt for CreateBucketInput {
         }
     }
 }
+impl DtoExt for CreateBucketMetadataConfigurationInput {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref val) = self.checksum_algorithm
+            && val.as_str() == ""
+        {
+            self.checksum_algorithm = None;
+        }
+        if self.content_md5.as_deref() == Some("") {
+            self.content_md5 = None;
+        }
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+        self.metadata_configuration.ignore_empty_strings();
+    }
+}
 impl DtoExt for CreateBucketMetadataTableConfigurationInput {
     fn ignore_empty_strings(&mut self) {
         if let Some(ref val) = self.checksum_algorithm
@@ -36755,6 +38336,13 @@ impl DtoExt for DeleteBucketLifecycleInput {
         }
     }
 }
+impl DtoExt for DeleteBucketMetadataConfigurationInput {
+    fn ignore_empty_strings(&mut self) {
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+    }
+}
 impl DtoExt for DeleteBucketMetadataTableConfigurationInput {
     fn ignore_empty_strings(&mut self) {
         if self.expected_bucket_owner.as_deref() == Some("") {
@@ -36947,6 +38535,21 @@ impl DtoExt for Destination {
             && val.as_str() == ""
         {
             self.storage_class = None;
+        }
+    }
+}
+impl DtoExt for DestinationResult {
+    fn ignore_empty_strings(&mut self) {
+        if self.table_bucket_arn.as_deref() == Some("") {
+            self.table_bucket_arn = None;
+        }
+        if let Some(ref val) = self.table_bucket_type
+            && val.as_str() == ""
+        {
+            self.table_bucket_type = None;
+        }
+        if self.table_namespace.as_deref() == Some("") {
+            self.table_namespace = None;
         }
     }
 }
@@ -37182,6 +38785,25 @@ impl DtoExt for GetBucketLoggingOutput {
         if let Some(ref mut val) = self.logging_enabled {
             val.ignore_empty_strings();
         }
+    }
+}
+impl DtoExt for GetBucketMetadataConfigurationInput {
+    fn ignore_empty_strings(&mut self) {
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+    }
+}
+impl DtoExt for GetBucketMetadataConfigurationOutput {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.get_bucket_metadata_configuration_result {
+            val.ignore_empty_strings();
+        }
+    }
+}
+impl DtoExt for GetBucketMetadataConfigurationResult {
+    fn ignore_empty_strings(&mut self) {
+        self.metadata_configuration_result.ignore_empty_strings();
     }
 }
 impl DtoExt for GetBucketMetadataTableConfigurationInput {
@@ -38016,6 +39638,36 @@ impl DtoExt for InventoryS3BucketDestination {
 impl DtoExt for InventorySchedule {
     fn ignore_empty_strings(&mut self) {}
 }
+impl DtoExt for InventoryTableConfiguration {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.encryption_configuration {
+            val.ignore_empty_strings();
+        }
+    }
+}
+impl DtoExt for InventoryTableConfigurationResult {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.error {
+            val.ignore_empty_strings();
+        }
+        if self.table_arn.as_deref() == Some("") {
+            self.table_arn = None;
+        }
+        if self.table_name.as_deref() == Some("") {
+            self.table_name = None;
+        }
+        if self.table_status.as_deref() == Some("") {
+            self.table_status = None;
+        }
+    }
+}
+impl DtoExt for InventoryTableConfigurationUpdates {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.encryption_configuration {
+            val.ignore_empty_strings();
+        }
+    }
+}
 impl DtoExt for JSONInput {
     fn ignore_empty_strings(&mut self) {
         if let Some(ref val) = self.type_
@@ -38030,6 +39682,30 @@ impl DtoExt for JSONOutput {
         if self.record_delimiter.as_deref() == Some("") {
             self.record_delimiter = None;
         }
+    }
+}
+impl DtoExt for JournalTableConfiguration {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.encryption_configuration {
+            val.ignore_empty_strings();
+        }
+        self.record_expiration.ignore_empty_strings();
+    }
+}
+impl DtoExt for JournalTableConfigurationResult {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.error {
+            val.ignore_empty_strings();
+        }
+        self.record_expiration.ignore_empty_strings();
+        if self.table_arn.as_deref() == Some("") {
+            self.table_arn = None;
+        }
+    }
+}
+impl DtoExt for JournalTableConfigurationUpdates {
+    fn ignore_empty_strings(&mut self) {
+        self.record_expiration.ignore_empty_strings();
     }
 }
 impl DtoExt for LambdaFunctionConfiguration {
@@ -38536,6 +40212,31 @@ impl DtoExt for LoggingEnabled {
         }
     }
 }
+impl DtoExt for MetadataConfiguration {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.annotation_table_configuration {
+            val.ignore_empty_strings();
+        }
+        if let Some(ref mut val) = self.inventory_table_configuration {
+            val.ignore_empty_strings();
+        }
+        self.journal_table_configuration.ignore_empty_strings();
+    }
+}
+impl DtoExt for MetadataConfigurationResult {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref mut val) = self.annotation_table_configuration_result {
+            val.ignore_empty_strings();
+        }
+        self.destination_result.ignore_empty_strings();
+        if let Some(ref mut val) = self.inventory_table_configuration_result {
+            val.ignore_empty_strings();
+        }
+        if let Some(ref mut val) = self.journal_table_configuration_result {
+            val.ignore_empty_strings();
+        }
+    }
+}
 impl DtoExt for MetadataEntry {
     fn ignore_empty_strings(&mut self) {
         if self.name.as_deref() == Some("") {
@@ -38554,6 +40255,13 @@ impl DtoExt for MetadataTableConfiguration {
 impl DtoExt for MetadataTableConfigurationResult {
     fn ignore_empty_strings(&mut self) {
         self.s3_tables_destination_result.ignore_empty_strings();
+    }
+}
+impl DtoExt for MetadataTableEncryptionConfiguration {
+    fn ignore_empty_strings(&mut self) {
+        if self.kms_key_arn.as_deref() == Some("") {
+            self.kms_key_arn = None;
+        }
     }
 }
 impl DtoExt for Metrics {
@@ -39746,6 +41454,9 @@ impl DtoExt for QueueConfiguration {
         }
     }
 }
+impl DtoExt for RecordExpiration {
+    fn ignore_empty_strings(&mut self) {}
+}
 impl DtoExt for RecordsEvent {
     fn ignore_empty_strings(&mut self) {}
 }
@@ -40110,6 +41821,54 @@ impl DtoExt for Transition {
         {
             self.storage_class = None;
         }
+    }
+}
+impl DtoExt for UpdateBucketMetadataAnnotationTableConfigurationInput {
+    fn ignore_empty_strings(&mut self) {
+        self.annotation_table_configuration.ignore_empty_strings();
+        if let Some(ref val) = self.checksum_algorithm
+            && val.as_str() == ""
+        {
+            self.checksum_algorithm = None;
+        }
+        if self.content_md5.as_deref() == Some("") {
+            self.content_md5 = None;
+        }
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+    }
+}
+impl DtoExt for UpdateBucketMetadataInventoryTableConfigurationInput {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref val) = self.checksum_algorithm
+            && val.as_str() == ""
+        {
+            self.checksum_algorithm = None;
+        }
+        if self.content_md5.as_deref() == Some("") {
+            self.content_md5 = None;
+        }
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+        self.inventory_table_configuration.ignore_empty_strings();
+    }
+}
+impl DtoExt for UpdateBucketMetadataJournalTableConfigurationInput {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref val) = self.checksum_algorithm
+            && val.as_str() == ""
+        {
+            self.checksum_algorithm = None;
+        }
+        if self.content_md5.as_deref() == Some("") {
+            self.content_md5 = None;
+        }
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+        self.journal_table_configuration.ignore_empty_strings();
     }
 }
 impl DtoExt for UploadPartCopyInput {

--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -7,6 +7,7 @@
 // CompleteMultipartUpload
 // CopyObject
 // CreateBucket
+// CreateBucketMetadataConfiguration
 // CreateBucketMetadataTableConfiguration
 // CreateMultipartUpload
 // CreateSession
@@ -17,6 +18,7 @@
 // DeleteBucketIntelligentTieringConfiguration
 // DeleteBucketInventoryConfiguration
 // DeleteBucketLifecycle
+// DeleteBucketMetadataConfiguration
 // DeleteBucketMetadataTableConfiguration
 // DeleteBucketMetricsConfiguration
 // DeleteBucketOwnershipControls
@@ -39,6 +41,7 @@
 // GetBucketLifecycleConfiguration
 // GetBucketLocation
 // GetBucketLogging
+// GetBucketMetadataConfiguration
 // GetBucketMetadataTableConfiguration
 // GetBucketMetricsConfiguration
 // GetBucketNotificationConfiguration
@@ -102,6 +105,9 @@
 // RenameObject
 // RestoreObject
 // SelectObjectContent
+// UpdateBucketMetadataAnnotationTableConfiguration
+// UpdateBucketMetadataInventoryTableConfiguration
+// UpdateBucketMetadataJournalTableConfiguration
 // UploadPart
 // UploadPartCopy
 // WriteGetObjectResponse
@@ -960,6 +966,63 @@ impl super::Operation for CreateBucket {
     }
 }
 
+pub struct CreateBucketMetadataConfiguration;
+
+impl CreateBucketMetadataConfiguration {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<CreateBucketMetadataConfigurationInput> {
+        let bucket = http::unwrap_bucket(req);
+
+        let checksum_algorithm: Option<ChecksumAlgorithm> = http::parse_checksum_algorithm_header(req)?;
+
+        let content_md5: Option<ContentMD5> = http::parse_opt_header(req, &CONTENT_MD5)?;
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        let metadata_configuration: MetadataConfiguration = http::take_xml_body(req)?;
+
+        Ok(CreateBucketMetadataConfigurationInput {
+            bucket,
+            checksum_algorithm,
+            content_md5,
+            expected_bucket_owner,
+            metadata_configuration,
+        })
+    }
+
+    pub fn serialize_http(_: CreateBucketMetadataConfigurationOutput) -> S3Result<http::Response> {
+        Ok(http::Response::with_status(http::StatusCode::OK))
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for CreateBucketMetadataConfiguration {
+    fn name(&self) -> &'static str {
+        "CreateBucketMetadataConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.create_bucket_metadata_configuration(&mut s3_req).await?;
+        }
+        let result = s3.create_bucket_metadata_configuration(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
 pub struct CreateBucketMetadataTableConfiguration;
 
 impl CreateBucketMetadataTableConfiguration {
@@ -1572,6 +1635,54 @@ impl super::Operation for DeleteBucketLifecycle {
             access.delete_bucket_lifecycle(&mut s3_req).await?;
         }
         let result = s3.delete_bucket_lifecycle(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
+pub struct DeleteBucketMetadataConfiguration;
+
+impl DeleteBucketMetadataConfiguration {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<DeleteBucketMetadataConfigurationInput> {
+        let bucket = http::unwrap_bucket(req);
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        Ok(DeleteBucketMetadataConfigurationInput {
+            bucket,
+            expected_bucket_owner,
+        })
+    }
+
+    pub fn serialize_http(_: DeleteBucketMetadataConfigurationOutput) -> S3Result<http::Response> {
+        Ok(http::Response::with_status(http::StatusCode::NO_CONTENT))
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for DeleteBucketMetadataConfiguration {
+    fn name(&self) -> &'static str {
+        "DeleteBucketMetadataConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.delete_bucket_metadata_configuration(&mut s3_req).await?;
+        }
+        let result = s3.delete_bucket_metadata_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
             Err(err) => return super::serialize_error(err, false),
@@ -2734,6 +2845,58 @@ impl super::Operation for GetBucketLogging {
             access.get_bucket_logging(&mut s3_req).await?;
         }
         let result = s3.get_bucket_logging(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
+pub struct GetBucketMetadataConfiguration;
+
+impl GetBucketMetadataConfiguration {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<GetBucketMetadataConfigurationInput> {
+        let bucket = http::unwrap_bucket(req);
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        Ok(GetBucketMetadataConfigurationInput {
+            bucket,
+            expected_bucket_owner,
+        })
+    }
+
+    pub fn serialize_http(x: GetBucketMetadataConfigurationOutput) -> S3Result<http::Response> {
+        let mut res = http::Response::with_status(http::StatusCode::OK);
+        if let Some(ref val) = x.get_bucket_metadata_configuration_result {
+            http::set_xml_body(&mut res, val)?;
+        }
+        Ok(res)
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for GetBucketMetadataConfiguration {
+    fn name(&self) -> &'static str {
+        "GetBucketMetadataConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.get_bucket_metadata_configuration(&mut s3_req).await?;
+        }
+        let result = s3.get_bucket_metadata_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
             Err(err) => return super::serialize_error(err, false),
@@ -6969,6 +7132,181 @@ impl super::Operation for SelectObjectContent {
     }
 }
 
+pub struct UpdateBucketMetadataAnnotationTableConfiguration;
+
+impl UpdateBucketMetadataAnnotationTableConfiguration {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<UpdateBucketMetadataAnnotationTableConfigurationInput> {
+        let bucket = http::unwrap_bucket(req);
+
+        let annotation_table_configuration: AnnotationTableConfigurationUpdates = http::take_xml_body(req)?;
+
+        let checksum_algorithm: Option<ChecksumAlgorithm> = http::parse_checksum_algorithm_header(req)?;
+
+        let content_md5: Option<ContentMD5> = http::parse_opt_header(req, &CONTENT_MD5)?;
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        Ok(UpdateBucketMetadataAnnotationTableConfigurationInput {
+            annotation_table_configuration,
+            bucket,
+            checksum_algorithm,
+            content_md5,
+            expected_bucket_owner,
+        })
+    }
+
+    pub fn serialize_http(_: UpdateBucketMetadataAnnotationTableConfigurationOutput) -> S3Result<http::Response> {
+        Ok(http::Response::with_status(http::StatusCode::OK))
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for UpdateBucketMetadataAnnotationTableConfiguration {
+    fn name(&self) -> &'static str {
+        "UpdateBucketMetadataAnnotationTableConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access
+                .update_bucket_metadata_annotation_table_configuration(&mut s3_req)
+                .await?;
+        }
+        let result = s3.update_bucket_metadata_annotation_table_configuration(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
+pub struct UpdateBucketMetadataInventoryTableConfiguration;
+
+impl UpdateBucketMetadataInventoryTableConfiguration {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<UpdateBucketMetadataInventoryTableConfigurationInput> {
+        let bucket = http::unwrap_bucket(req);
+
+        let checksum_algorithm: Option<ChecksumAlgorithm> = http::parse_checksum_algorithm_header(req)?;
+
+        let content_md5: Option<ContentMD5> = http::parse_opt_header(req, &CONTENT_MD5)?;
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        let inventory_table_configuration: InventoryTableConfigurationUpdates = http::take_xml_body(req)?;
+
+        Ok(UpdateBucketMetadataInventoryTableConfigurationInput {
+            bucket,
+            checksum_algorithm,
+            content_md5,
+            expected_bucket_owner,
+            inventory_table_configuration,
+        })
+    }
+
+    pub fn serialize_http(_: UpdateBucketMetadataInventoryTableConfigurationOutput) -> S3Result<http::Response> {
+        Ok(http::Response::with_status(http::StatusCode::OK))
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for UpdateBucketMetadataInventoryTableConfiguration {
+    fn name(&self) -> &'static str {
+        "UpdateBucketMetadataInventoryTableConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access
+                .update_bucket_metadata_inventory_table_configuration(&mut s3_req)
+                .await?;
+        }
+        let result = s3.update_bucket_metadata_inventory_table_configuration(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
+pub struct UpdateBucketMetadataJournalTableConfiguration;
+
+impl UpdateBucketMetadataJournalTableConfiguration {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<UpdateBucketMetadataJournalTableConfigurationInput> {
+        let bucket = http::unwrap_bucket(req);
+
+        let checksum_algorithm: Option<ChecksumAlgorithm> = http::parse_checksum_algorithm_header(req)?;
+
+        let content_md5: Option<ContentMD5> = http::parse_opt_header(req, &CONTENT_MD5)?;
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        let journal_table_configuration: JournalTableConfigurationUpdates = http::take_xml_body(req)?;
+
+        Ok(UpdateBucketMetadataJournalTableConfigurationInput {
+            bucket,
+            checksum_algorithm,
+            content_md5,
+            expected_bucket_owner,
+            journal_table_configuration,
+        })
+    }
+
+    pub fn serialize_http(_: UpdateBucketMetadataJournalTableConfigurationOutput) -> S3Result<http::Response> {
+        Ok(http::Response::with_status(http::StatusCode::OK))
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for UpdateBucketMetadataJournalTableConfiguration {
+    fn name(&self) -> &'static str {
+        "UpdateBucketMetadataJournalTableConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.update_bucket_metadata_journal_table_configuration(&mut s3_req).await?;
+        }
+        let result = s3.update_bucket_metadata_journal_table_configuration(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
 pub struct UploadPart;
 
 impl UploadPart {
@@ -7601,6 +7939,9 @@ pub fn resolve_route(
                     if qs.has("logging") {
                         return Ok(&GetBucketLogging as &'static dyn super::Operation);
                     }
+                    if qs.has("metadataConfiguration") {
+                        return Ok(&GetBucketMetadataConfiguration as &'static dyn super::Operation);
+                    }
                     if qs.has("metadataTable") {
                         return Ok(&GetBucketMetadataTableConfiguration as &'static dyn super::Operation);
                     }
@@ -7694,6 +8035,9 @@ pub fn resolve_route(
             S3Path::Root => Err(super::unknown_operation()),
             S3Path::Bucket { .. } => {
                 if let Some(qs) = qs {
+                    if qs.has("metadataConfiguration") {
+                        return Ok(&CreateBucketMetadataConfiguration as &'static dyn super::Operation);
+                    }
                     if qs.has("metadataTable") {
                         return Ok(&CreateBucketMetadataTableConfiguration as &'static dyn super::Operation);
                     }
@@ -7793,6 +8137,15 @@ pub fn resolve_route(
                     if qs.has("publicAccessBlock") {
                         return Ok(&PutPublicAccessBlock as &'static dyn super::Operation);
                     }
+                    if qs.has("metadataAnnotationTable") {
+                        return Ok(&UpdateBucketMetadataAnnotationTableConfiguration as &'static dyn super::Operation);
+                    }
+                    if qs.has("metadataInventoryTable") {
+                        return Ok(&UpdateBucketMetadataInventoryTableConfiguration as &'static dyn super::Operation);
+                    }
+                    if qs.has("metadataJournalTable") {
+                        return Ok(&UpdateBucketMetadataJournalTableConfiguration as &'static dyn super::Operation);
+                    }
                 }
                 Ok(&CreateBucket as &'static dyn super::Operation)
             }
@@ -7857,6 +8210,9 @@ pub fn resolve_route(
                     }
                     if qs.has("lifecycle") {
                         return Ok(&DeleteBucketLifecycle as &'static dyn super::Operation);
+                    }
+                    if qs.has("metadataConfiguration") {
+                        return Ok(&DeleteBucketMetadataConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("metadataTable") {
                         return Ok(&DeleteBucketMetadataTableConfiguration as &'static dyn super::Operation);

--- a/crates/s3s/src/ops/generated_minio.rs
+++ b/crates/s3s/src/ops/generated_minio.rs
@@ -7,6 +7,7 @@
 // CompleteMultipartUpload
 // CopyObject
 // CreateBucket
+// CreateBucketMetadataConfiguration
 // CreateBucketMetadataTableConfiguration
 // CreateMultipartUpload
 // CreateSession
@@ -17,6 +18,7 @@
 // DeleteBucketIntelligentTieringConfiguration
 // DeleteBucketInventoryConfiguration
 // DeleteBucketLifecycle
+// DeleteBucketMetadataConfiguration
 // DeleteBucketMetadataTableConfiguration
 // DeleteBucketMetricsConfiguration
 // DeleteBucketOwnershipControls
@@ -39,6 +41,7 @@
 // GetBucketLifecycleConfiguration
 // GetBucketLocation
 // GetBucketLogging
+// GetBucketMetadataConfiguration
 // GetBucketMetadataTableConfiguration
 // GetBucketMetricsConfiguration
 // GetBucketNotificationConfiguration
@@ -102,6 +105,9 @@
 // RenameObject
 // RestoreObject
 // SelectObjectContent
+// UpdateBucketMetadataAnnotationTableConfiguration
+// UpdateBucketMetadataInventoryTableConfiguration
+// UpdateBucketMetadataJournalTableConfiguration
 // UploadPart
 // UploadPartCopy
 // WriteGetObjectResponse
@@ -963,6 +969,63 @@ impl super::Operation for CreateBucket {
     }
 }
 
+pub struct CreateBucketMetadataConfiguration;
+
+impl CreateBucketMetadataConfiguration {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<CreateBucketMetadataConfigurationInput> {
+        let bucket = http::unwrap_bucket(req);
+
+        let checksum_algorithm: Option<ChecksumAlgorithm> = http::parse_checksum_algorithm_header(req)?;
+
+        let content_md5: Option<ContentMD5> = http::parse_opt_header(req, &CONTENT_MD5)?;
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        let metadata_configuration: MetadataConfiguration = http::take_xml_body(req)?;
+
+        Ok(CreateBucketMetadataConfigurationInput {
+            bucket,
+            checksum_algorithm,
+            content_md5,
+            expected_bucket_owner,
+            metadata_configuration,
+        })
+    }
+
+    pub fn serialize_http(_: CreateBucketMetadataConfigurationOutput) -> S3Result<http::Response> {
+        Ok(http::Response::with_status(http::StatusCode::OK))
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for CreateBucketMetadataConfiguration {
+    fn name(&self) -> &'static str {
+        "CreateBucketMetadataConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.create_bucket_metadata_configuration(&mut s3_req).await?;
+        }
+        let result = s3.create_bucket_metadata_configuration(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
 pub struct CreateBucketMetadataTableConfiguration;
 
 impl CreateBucketMetadataTableConfiguration {
@@ -1581,6 +1644,54 @@ impl super::Operation for DeleteBucketLifecycle {
             access.delete_bucket_lifecycle(&mut s3_req).await?;
         }
         let result = s3.delete_bucket_lifecycle(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
+pub struct DeleteBucketMetadataConfiguration;
+
+impl DeleteBucketMetadataConfiguration {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<DeleteBucketMetadataConfigurationInput> {
+        let bucket = http::unwrap_bucket(req);
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        Ok(DeleteBucketMetadataConfigurationInput {
+            bucket,
+            expected_bucket_owner,
+        })
+    }
+
+    pub fn serialize_http(_: DeleteBucketMetadataConfigurationOutput) -> S3Result<http::Response> {
+        Ok(http::Response::with_status(http::StatusCode::NO_CONTENT))
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for DeleteBucketMetadataConfiguration {
+    fn name(&self) -> &'static str {
+        "DeleteBucketMetadataConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.delete_bucket_metadata_configuration(&mut s3_req).await?;
+        }
+        let result = s3.delete_bucket_metadata_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
             Err(err) => return super::serialize_error(err, false),
@@ -2743,6 +2854,58 @@ impl super::Operation for GetBucketLogging {
             access.get_bucket_logging(&mut s3_req).await?;
         }
         let result = s3.get_bucket_logging(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
+pub struct GetBucketMetadataConfiguration;
+
+impl GetBucketMetadataConfiguration {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<GetBucketMetadataConfigurationInput> {
+        let bucket = http::unwrap_bucket(req);
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        Ok(GetBucketMetadataConfigurationInput {
+            bucket,
+            expected_bucket_owner,
+        })
+    }
+
+    pub fn serialize_http(x: GetBucketMetadataConfigurationOutput) -> S3Result<http::Response> {
+        let mut res = http::Response::with_status(http::StatusCode::OK);
+        if let Some(ref val) = x.get_bucket_metadata_configuration_result {
+            http::set_xml_body(&mut res, val)?;
+        }
+        Ok(res)
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for GetBucketMetadataConfiguration {
+    fn name(&self) -> &'static str {
+        "GetBucketMetadataConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.get_bucket_metadata_configuration(&mut s3_req).await?;
+        }
+        let result = s3.get_bucket_metadata_configuration(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
             Err(err) => return super::serialize_error(err, false),
@@ -6986,6 +7149,181 @@ impl super::Operation for SelectObjectContent {
     }
 }
 
+pub struct UpdateBucketMetadataAnnotationTableConfiguration;
+
+impl UpdateBucketMetadataAnnotationTableConfiguration {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<UpdateBucketMetadataAnnotationTableConfigurationInput> {
+        let bucket = http::unwrap_bucket(req);
+
+        let annotation_table_configuration: AnnotationTableConfigurationUpdates = http::take_xml_body(req)?;
+
+        let checksum_algorithm: Option<ChecksumAlgorithm> = http::parse_checksum_algorithm_header(req)?;
+
+        let content_md5: Option<ContentMD5> = http::parse_opt_header(req, &CONTENT_MD5)?;
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        Ok(UpdateBucketMetadataAnnotationTableConfigurationInput {
+            annotation_table_configuration,
+            bucket,
+            checksum_algorithm,
+            content_md5,
+            expected_bucket_owner,
+        })
+    }
+
+    pub fn serialize_http(_: UpdateBucketMetadataAnnotationTableConfigurationOutput) -> S3Result<http::Response> {
+        Ok(http::Response::with_status(http::StatusCode::OK))
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for UpdateBucketMetadataAnnotationTableConfiguration {
+    fn name(&self) -> &'static str {
+        "UpdateBucketMetadataAnnotationTableConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access
+                .update_bucket_metadata_annotation_table_configuration(&mut s3_req)
+                .await?;
+        }
+        let result = s3.update_bucket_metadata_annotation_table_configuration(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
+pub struct UpdateBucketMetadataInventoryTableConfiguration;
+
+impl UpdateBucketMetadataInventoryTableConfiguration {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<UpdateBucketMetadataInventoryTableConfigurationInput> {
+        let bucket = http::unwrap_bucket(req);
+
+        let checksum_algorithm: Option<ChecksumAlgorithm> = http::parse_checksum_algorithm_header(req)?;
+
+        let content_md5: Option<ContentMD5> = http::parse_opt_header(req, &CONTENT_MD5)?;
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        let inventory_table_configuration: InventoryTableConfigurationUpdates = http::take_xml_body(req)?;
+
+        Ok(UpdateBucketMetadataInventoryTableConfigurationInput {
+            bucket,
+            checksum_algorithm,
+            content_md5,
+            expected_bucket_owner,
+            inventory_table_configuration,
+        })
+    }
+
+    pub fn serialize_http(_: UpdateBucketMetadataInventoryTableConfigurationOutput) -> S3Result<http::Response> {
+        Ok(http::Response::with_status(http::StatusCode::OK))
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for UpdateBucketMetadataInventoryTableConfiguration {
+    fn name(&self) -> &'static str {
+        "UpdateBucketMetadataInventoryTableConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access
+                .update_bucket_metadata_inventory_table_configuration(&mut s3_req)
+                .await?;
+        }
+        let result = s3.update_bucket_metadata_inventory_table_configuration(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
+pub struct UpdateBucketMetadataJournalTableConfiguration;
+
+impl UpdateBucketMetadataJournalTableConfiguration {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<UpdateBucketMetadataJournalTableConfigurationInput> {
+        let bucket = http::unwrap_bucket(req);
+
+        let checksum_algorithm: Option<ChecksumAlgorithm> = http::parse_checksum_algorithm_header(req)?;
+
+        let content_md5: Option<ContentMD5> = http::parse_opt_header(req, &CONTENT_MD5)?;
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        let journal_table_configuration: JournalTableConfigurationUpdates = http::take_xml_body(req)?;
+
+        Ok(UpdateBucketMetadataJournalTableConfigurationInput {
+            bucket,
+            checksum_algorithm,
+            content_md5,
+            expected_bucket_owner,
+            journal_table_configuration,
+        })
+    }
+
+    pub fn serialize_http(_: UpdateBucketMetadataJournalTableConfigurationOutput) -> S3Result<http::Response> {
+        Ok(http::Response::with_status(http::StatusCode::OK))
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for UpdateBucketMetadataJournalTableConfiguration {
+    fn name(&self) -> &'static str {
+        "UpdateBucketMetadataJournalTableConfiguration"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.update_bucket_metadata_journal_table_configuration(&mut s3_req).await?;
+        }
+        let result = s3.update_bucket_metadata_journal_table_configuration(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
 pub struct UploadPart;
 
 impl UploadPart {
@@ -7618,6 +7956,9 @@ pub fn resolve_route(
                     if qs.has("logging") {
                         return Ok(&GetBucketLogging as &'static dyn super::Operation);
                     }
+                    if qs.has("metadataConfiguration") {
+                        return Ok(&GetBucketMetadataConfiguration as &'static dyn super::Operation);
+                    }
                     if qs.has("metadataTable") {
                         return Ok(&GetBucketMetadataTableConfiguration as &'static dyn super::Operation);
                     }
@@ -7711,6 +8052,9 @@ pub fn resolve_route(
             S3Path::Root => Err(super::unknown_operation()),
             S3Path::Bucket { .. } => {
                 if let Some(qs) = qs {
+                    if qs.has("metadataConfiguration") {
+                        return Ok(&CreateBucketMetadataConfiguration as &'static dyn super::Operation);
+                    }
                     if qs.has("metadataTable") {
                         return Ok(&CreateBucketMetadataTableConfiguration as &'static dyn super::Operation);
                     }
@@ -7810,6 +8154,15 @@ pub fn resolve_route(
                     if qs.has("publicAccessBlock") {
                         return Ok(&PutPublicAccessBlock as &'static dyn super::Operation);
                     }
+                    if qs.has("metadataAnnotationTable") {
+                        return Ok(&UpdateBucketMetadataAnnotationTableConfiguration as &'static dyn super::Operation);
+                    }
+                    if qs.has("metadataInventoryTable") {
+                        return Ok(&UpdateBucketMetadataInventoryTableConfiguration as &'static dyn super::Operation);
+                    }
+                    if qs.has("metadataJournalTable") {
+                        return Ok(&UpdateBucketMetadataJournalTableConfiguration as &'static dyn super::Operation);
+                    }
                 }
                 Ok(&CreateBucket as &'static dyn super::Operation)
             }
@@ -7874,6 +8227,9 @@ pub fn resolve_route(
                     }
                     if qs.has("lifecycle") {
                         return Ok(&DeleteBucketLifecycle as &'static dyn super::Operation);
+                    }
+                    if qs.has("metadataConfiguration") {
+                        return Ok(&DeleteBucketMetadataConfiguration as &'static dyn super::Operation);
                     }
                     if qs.has("metadataTable") {
                         return Ok(&DeleteBucketMetadataTableConfiguration as &'static dyn super::Operation);

--- a/crates/s3s/src/ops/route_fixtures.json
+++ b/crates/s3s/src/ops/route_fixtures.json
@@ -3487,5 +3487,197 @@
     "zz"
    ]
   ]
+ },
+ {
+  "expect": "CreateBucketMetadataConfiguration",
+  "headers": {},
+  "method": "POST",
+  "nfb": true,
+  "note": "if:qs.has(\"metadataConfiguration\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataConfiguration",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "CreateBucketMetadataConfiguration",
+  "headers": {},
+  "method": "POST",
+  "nfb": true,
+  "note": "noise:qs.has(\"metadataConfiguration\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataConfiguration",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketMetadataConfiguration",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:qs.has(\"metadataConfiguration\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataConfiguration",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteBucketMetadataConfiguration",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:qs.has(\"metadataConfiguration\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataConfiguration",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketMetadataConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"metadataConfiguration\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataConfiguration",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "GetBucketMetadataConfiguration",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"metadataConfiguration\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataConfiguration",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "UpdateBucketMetadataAnnotationTableConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"metadataAnnotationTable\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataAnnotationTable",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "UpdateBucketMetadataAnnotationTableConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"metadataAnnotationTable\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataAnnotationTable",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "UpdateBucketMetadataInventoryTableConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"metadataInventoryTable\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataInventoryTable",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "UpdateBucketMetadataInventoryTableConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"metadataInventoryTable\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataInventoryTable",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "UpdateBucketMetadataJournalTableConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"metadataJournalTable\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataJournalTable",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "UpdateBucketMetadataJournalTableConfiguration",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"metadataJournalTable\")",
+  "path": "Bucket",
+  "qs": [
+   [
+    "metadataJournalTable",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
  }
 ]

--- a/crates/s3s/src/s3_trait.rs
+++ b/crates/s3s/src/s3_trait.rs
@@ -644,6 +644,126 @@ pub trait S3: Send + Sync + 'static {
         Err(s3_error!(NotImplemented, "CreateBucket is not implemented yet"))
     }
 
+    /// <p>Creates an S3 Metadata V2 metadata configuration for a general purpose bucket. For more information, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-overview.html">Accelerating
+    /// data discovery with S3 Metadata</a> in the <i>Amazon S3 User Guide</i>.</p>
+    /// <dl>
+    /// <dt>Permissions</dt>
+    /// <dd>
+    /// <p>To use this operation, you must have the following permissions. For more information, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-permissions.html">Setting up permissions for configuring metadata tables</a> in the
+    /// <i>Amazon S3 User Guide</i>.</p>
+    /// <p>If you want to encrypt your metadata tables with server-side encryption with Key Management Service
+    /// (KMS) keys (SSE-KMS), you need additional permissions in your KMS key policy. For more
+    /// information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-permissions.html">
+    /// Setting up permissions for configuring metadata tables</a> in the
+    /// <i>Amazon S3 User Guide</i>.</p>
+    /// <p>If you also want to integrate your table bucket with Amazon Web Services analytics services so that you can
+    /// query your metadata table, you need additional permissions. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-integrating-aws.html"> Integrating
+    /// Amazon S3 Tables with Amazon Web Services analytics services</a> in the
+    /// <i>Amazon S3 User Guide</i>.</p>
+    /// <p>To query your metadata tables, you need additional permissions. For more information, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-bucket-query-permissions.html">
+    /// Permissions for querying metadata tables</a> in the <i>Amazon S3 User Guide</i>.</p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <code>s3:CreateBucketMetadataTableConfiguration</code>
+    /// </p>
+    /// <note>
+    /// <p>The IAM policy action name is the same for the V1 and V2 API operations.</p>
+    /// </note>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>s3tables:CreateTableBucket</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>s3tables:CreateNamespace</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>s3tables:GetTable</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>s3tables:CreateTable</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>s3tables:PutTablePolicy</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>s3tables:PutTableBucketPolicy</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>s3tables:PutTableEncryption</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>kms:DescribeKey</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>iam:PassRole</code> - required if you include an
+    /// <code>AnnotationTableConfiguration</code> with an IAM role.</p>
+    /// </li>
+    /// </ul>
+    /// </dd>
+    /// </dl>
+    /// <p>The following operations are related to <code>CreateBucketMetadataConfiguration</code>:</p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetadataConfiguration.html">DeleteBucketMetadataConfiguration</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetadataConfiguration.html">GetBucketMetadataConfiguration</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataInventoryTableConfiguration.html">UpdateBucketMetadataInventoryTableConfiguration</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataJournalTableConfiguration.html">UpdateBucketMetadataJournalTableConfiguration</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataAnnotationTableConfiguration.html">UpdateBucketMetadataAnnotationTableConfiguration</a>
+    /// </p>
+    /// </li>
+    /// </ul>
+    /// <p>If you include an <code>AnnotationTableConfiguration</code> with an IAM role, the role must
+    /// have a trust policy that allows the Amazon S3 metadata service to assume it, and a permissions policy
+    /// that grants the actions needed to read annotations from your bucket. The following examples show
+    /// a trust policy and a permissions policy that you can adapt for your bucket and account.</p>
+    /// <important>
+    /// <p>You must URL encode any signed header values that contain spaces. For example, if your header value is <code>my  file.txt</code>, containing two spaces after <code>my</code>, you must URL encode this value to <code>my%20%20file.txt</code>.</p>
+    /// </important>
+    async fn create_bucket_metadata_configuration(
+        &self,
+        _req: S3Request<CreateBucketMetadataConfigurationInput>,
+    ) -> S3Result<S3Response<CreateBucketMetadataConfigurationOutput>> {
+        Err(s3_error!(NotImplemented, "CreateBucketMetadataConfiguration is not implemented yet"))
+    }
+
     /// <p>Creates a metadata table configuration for a general purpose bucket. For more
     /// information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-overview.html">Accelerating data
     /// discovery with S3 Metadata</a> in the <i>Amazon S3 User Guide</i>. </p>
@@ -1437,6 +1557,60 @@ pub trait S3: Send + Sync + 'static {
         _req: S3Request<DeleteBucketLifecycleInput>,
     ) -> S3Result<S3Response<DeleteBucketLifecycleOutput>> {
         Err(s3_error!(NotImplemented, "DeleteBucketLifecycle is not implemented yet"))
+    }
+
+    /// <p> Deletes an S3 Metadata configuration from a general purpose bucket. For more information, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-overview.html">Accelerating
+    /// data discovery with S3 Metadata</a> in the <i>Amazon S3 User Guide</i>. </p>
+    /// <note>
+    /// <p>You can use the V2 <code>DeleteBucketMetadataConfiguration</code> API operation with V1 or V2
+    /// metadata configurations. However, if you try to use the V1
+    /// <code>DeleteBucketMetadataTableConfiguration</code> API operation with V2 configurations, you
+    /// will receive an HTTP <code>405 Method Not Allowed</code> error.</p>
+    /// </note>
+    /// <dl>
+    /// <dt>Permissions</dt>
+    /// <dd>
+    /// <p>To use this operation, you must have the
+    /// <code>s3:DeleteBucketMetadataTableConfiguration</code> permission. For more information, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-permissions.html">Setting up permissions for configuring metadata tables</a> in the
+    /// <i>Amazon S3 User Guide</i>. </p>
+    /// <note>
+    /// <p>The IAM policy action name is the same for the V1 and V2 API operations.</p>
+    /// </note>
+    /// </dd>
+    /// </dl>
+    /// <p>The following operations are related to <code>DeleteBucketMetadataConfiguration</code>:</p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketMetadataConfiguration.html">CreateBucketMetadataConfiguration</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetadataConfiguration.html">GetBucketMetadataConfiguration</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataInventoryTableConfiguration.html">UpdateBucketMetadataInventoryTableConfiguration</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataJournalTableConfiguration.html">UpdateBucketMetadataJournalTableConfiguration</a>
+    /// </p>
+    /// </li>
+    /// </ul>
+    /// <important>
+    /// <p>You must URL encode any signed header values that contain spaces. For example, if your header value is <code>my  file.txt</code>, containing two spaces after <code>my</code>, you must URL encode this value to <code>my%20%20file.txt</code>.</p>
+    /// </important>
+    async fn delete_bucket_metadata_configuration(
+        &self,
+        _req: S3Request<DeleteBucketMetadataConfigurationInput>,
+    ) -> S3Result<S3Response<DeleteBucketMetadataConfigurationOutput>> {
+        Err(s3_error!(NotImplemented, "DeleteBucketMetadataConfiguration is not implemented yet"))
     }
 
     /// <p>
@@ -2479,6 +2653,59 @@ pub trait S3: Send + Sync + 'static {
     /// </ul>
     async fn get_bucket_logging(&self, _req: S3Request<GetBucketLoggingInput>) -> S3Result<S3Response<GetBucketLoggingOutput>> {
         Err(s3_error!(NotImplemented, "GetBucketLogging is not implemented yet"))
+    }
+
+    /// <p>Retrieves the S3 Metadata configuration for a general purpose bucket. For more information, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-overview.html">Accelerating
+    /// data discovery with S3 Metadata</a> in the <i>Amazon S3 User Guide</i>. </p>
+    /// <note>
+    /// <p>You can use the V2 <code>GetBucketMetadataConfiguration</code> API operation with V1 or V2
+    /// metadata configurations. However, if you try to use the V1
+    /// <code>GetBucketMetadataTableConfiguration</code> API operation with V2 configurations, you
+    /// will receive an HTTP <code>405 Method Not Allowed</code> error.</p>
+    /// </note>
+    /// <dl>
+    /// <dt>Permissions</dt>
+    /// <dd>
+    /// <p>To use this operation, you must have the <code>s3:GetBucketMetadataTableConfiguration</code>
+    /// permission. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-permissions.html">Setting up permissions for
+    /// configuring metadata tables</a> in the <i>Amazon S3 User Guide</i>. </p>
+    /// <note>
+    /// <p>The IAM policy action name is the same for the V1 and V2 API operations.</p>
+    /// </note>
+    /// </dd>
+    /// </dl>
+    /// <p>The following operations are related to <code>GetBucketMetadataConfiguration</code>:</p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketMetadataConfiguration.html">CreateBucketMetadataConfiguration</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetadataConfiguration.html">DeleteBucketMetadataConfiguration</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataInventoryTableConfiguration.html">UpdateBucketMetadataInventoryTableConfiguration</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataJournalTableConfiguration.html">UpdateBucketMetadataJournalTableConfiguration</a>
+    /// </p>
+    /// </li>
+    /// </ul>
+    /// <important>
+    /// <p>You must URL encode any signed header values that contain spaces. For example, if your header value is <code>my  file.txt</code>, containing two spaces after <code>my</code>, you must URL encode this value to <code>my%20%20file.txt</code>.</p>
+    /// </important>
+    async fn get_bucket_metadata_configuration(
+        &self,
+        _req: S3Request<GetBucketMetadataConfigurationInput>,
+    ) -> S3Result<S3Response<GetBucketMetadataConfigurationOutput>> {
+        Err(s3_error!(NotImplemented, "GetBucketMetadataConfiguration is not implemented yet"))
     }
 
     /// <p>
@@ -6910,6 +7137,185 @@ pub trait S3: Send + Sync + 'static {
         _req: S3Request<SelectObjectContentInput>,
     ) -> S3Result<S3Response<SelectObjectContentOutput>> {
         Err(s3_error!(NotImplemented, "SelectObjectContent is not implemented yet"))
+    }
+
+    /// <p>Updates the annotation table configuration for an Amazon S3 bucket's metadata configuration. Use this
+    /// operation to enable or disable the annotation table, or to update its associated IAM role.</p>
+    /// <p>An annotation table is a queryable Iceberg table that contains records of all annotations
+    /// attached to objects in the bucket. To use this operation, the bucket must have an existing Amazon S3
+    /// Metadata configuration.</p>
+    /// <p>To use this operation, you must have the
+    /// <code>s3:UpdateBucketMetadataAnnotationTableConfiguration</code> permission. If you are specifying
+    /// or changing the IAM role, you must also have <code>iam:PassRole</code> permission for the role.</p>
+    /// <p>The IAM role must have a trust policy that allows the Amazon S3 metadata service to assume it, and a
+    /// permissions policy that grants the actions needed to read annotations from your bucket. The
+    /// following examples show a trust policy and a permissions policy that you can adapt for your bucket
+    /// and account.</p>
+    /// <p>The following operations are related to
+    /// <code>UpdateBucketMetadataAnnotationTableConfiguration</code>:</p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketMetadataConfiguration.html">CreateBucketMetadataConfiguration</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetadataConfiguration.html">GetBucketMetadataConfiguration</a>
+    /// </p>
+    /// </li>
+    /// </ul>
+    async fn update_bucket_metadata_annotation_table_configuration(
+        &self,
+        _req: S3Request<UpdateBucketMetadataAnnotationTableConfigurationInput>,
+    ) -> S3Result<S3Response<UpdateBucketMetadataAnnotationTableConfigurationOutput>> {
+        Err(s3_error!(
+            NotImplemented,
+            "UpdateBucketMetadataAnnotationTableConfiguration is not implemented yet"
+        ))
+    }
+
+    /// <p>Enables or disables a live inventory table for an S3 Metadata configuration on a general
+    /// purpose bucket. For more information, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-overview.html">Accelerating
+    /// data discovery with S3 Metadata</a> in the <i>Amazon S3 User Guide</i>.</p>
+    /// <dl>
+    /// <dt>Permissions</dt>
+    /// <dd>
+    /// <p>To use this operation, you must have the following permissions. For more information, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-permissions.html">Setting up permissions for configuring metadata tables</a> in the
+    /// <i>Amazon S3 User Guide</i>.</p>
+    /// <p>If you want to encrypt your inventory table with server-side encryption with Key Management Service
+    /// (KMS) keys (SSE-KMS), you need additional permissions in your KMS key policy. For more
+    /// information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-permissions.html">
+    /// Setting up permissions for configuring metadata tables</a> in the
+    /// <i>Amazon S3 User Guide</i>.</p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <code>s3:UpdateBucketMetadataInventoryTableConfiguration</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>s3tables:CreateTableBucket</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>s3tables:CreateNamespace</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>s3tables:GetTable</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>s3tables:CreateTable</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>s3tables:PutTablePolicy</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>s3tables:PutTableEncryption</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>kms:DescribeKey</code>
+    /// </p>
+    /// </li>
+    /// </ul>
+    /// </dd>
+    /// </dl>
+    /// <p>The following operations are related to <code>UpdateBucketMetadataInventoryTableConfiguration</code>:</p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketMetadataConfiguration.html">CreateBucketMetadataConfiguration</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetadataConfiguration.html">DeleteBucketMetadataConfiguration</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetadataConfiguration.html">GetBucketMetadataConfiguration</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataJournalTableConfiguration.html">UpdateBucketMetadataJournalTableConfiguration</a>
+    /// </p>
+    /// </li>
+    /// </ul>
+    /// <important>
+    /// <p>You must URL encode any signed header values that contain spaces. For example, if your header value is <code>my  file.txt</code>, containing two spaces after <code>my</code>, you must URL encode this value to <code>my%20%20file.txt</code>.</p>
+    /// </important>
+    async fn update_bucket_metadata_inventory_table_configuration(
+        &self,
+        _req: S3Request<UpdateBucketMetadataInventoryTableConfigurationInput>,
+    ) -> S3Result<S3Response<UpdateBucketMetadataInventoryTableConfigurationOutput>> {
+        Err(s3_error!(
+            NotImplemented,
+            "UpdateBucketMetadataInventoryTableConfiguration is not implemented yet"
+        ))
+    }
+
+    /// <p>Enables or disables journal table record expiration for an S3 Metadata configuration on a general
+    /// purpose bucket. For more information, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-overview.html">Accelerating
+    /// data discovery with S3 Metadata</a> in the <i>Amazon S3 User Guide</i>.</p>
+    /// <dl>
+    /// <dt>Permissions</dt>
+    /// <dd>
+    /// <p>To use this operation, you must have the <code>s3:UpdateBucketMetadataJournalTableConfiguration</code>
+    /// permission. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-permissions.html">Setting up permissions for
+    /// configuring metadata tables</a> in the <i>Amazon S3 User Guide</i>. </p>
+    /// </dd>
+    /// </dl>
+    /// <p>The following operations are related to <code>UpdateBucketMetadataJournalTableConfiguration</code>:</p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketMetadataConfiguration.html">CreateBucketMetadataConfiguration</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetadataConfiguration.html">DeleteBucketMetadataConfiguration</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetadataConfiguration.html">GetBucketMetadataConfiguration</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataInventoryTableConfiguration.html">UpdateBucketMetadataInventoryTableConfiguration</a>
+    /// </p>
+    /// </li>
+    /// </ul>
+    /// <important>
+    /// <p>You must URL encode any signed header values that contain spaces. For example, if your header value is <code>my  file.txt</code>, containing two spaces after <code>my</code>, you must URL encode this value to <code>my%20%20file.txt</code>.</p>
+    /// </important>
+    async fn update_bucket_metadata_journal_table_configuration(
+        &self,
+        _req: S3Request<UpdateBucketMetadataJournalTableConfigurationInput>,
+    ) -> S3Result<S3Response<UpdateBucketMetadataJournalTableConfigurationOutput>> {
+        Err(s3_error!(
+            NotImplemented,
+            "UpdateBucketMetadataJournalTableConfiguration is not implemented yet"
+        ))
     }
 
     /// <p>Uploads a part in a multipart upload.</p>

--- a/crates/s3s/src/xml/generated.rs
+++ b/crates/s3s/src/xml/generated.rs
@@ -19,6 +19,8 @@ use std::io::Write;
 // Deserialize: AccessControlPolicy
 //   Serialize: AnalyticsConfiguration
 // Deserialize: AnalyticsConfiguration
+//   Serialize: AnnotationTableConfigurationUpdates "AnnotationTableConfiguration"
+// Deserialize: AnnotationTableConfigurationUpdates "AnnotationTableConfiguration"
 //   Serialize: BucketLifecycleConfiguration "LifecycleConfiguration"
 // Deserialize: BucketLifecycleConfiguration "LifecycleConfiguration"
 //   Serialize: BucketLoggingStatus
@@ -49,6 +51,8 @@ use std::io::Write;
 // Deserialize: GetBucketLocationOutput
 //   Serialize: GetBucketLoggingOutput
 // Deserialize: GetBucketLoggingOutput
+//   Serialize: GetBucketMetadataConfigurationResult
+// Deserialize: GetBucketMetadataConfigurationResult
 //   Serialize: GetBucketMetadataTableConfigurationResult
 // Deserialize: GetBucketMetadataTableConfigurationResult
 //   Serialize: GetBucketNotificationConfigurationOutput
@@ -68,6 +72,10 @@ use std::io::Write;
 // Deserialize: IntelligentTieringConfiguration
 //   Serialize: InventoryConfiguration
 // Deserialize: InventoryConfiguration
+//   Serialize: InventoryTableConfigurationUpdates "InventoryTableConfiguration"
+// Deserialize: InventoryTableConfigurationUpdates "InventoryTableConfiguration"
+//   Serialize: JournalTableConfigurationUpdates "JournalTableConfiguration"
+// Deserialize: JournalTableConfigurationUpdates "JournalTableConfiguration"
 //   Serialize: ListBucketAnalyticsConfigurationsOutput
 // Deserialize: ListBucketAnalyticsConfigurationsOutput
 //   Serialize: ListBucketIntelligentTieringConfigurationsOutput
@@ -85,6 +93,8 @@ use std::io::Write;
 //   Serialize: ListObjectsOutput
 //   Serialize: ListObjectsV2Output
 //   Serialize: ListPartsOutput
+//   Serialize: MetadataConfiguration
+// Deserialize: MetadataConfiguration
 //   Serialize: MetadataTableConfiguration
 // Deserialize: MetadataTableConfiguration
 //   Serialize: MetricsConfiguration
@@ -166,6 +176,14 @@ use std::io::Write;
 // DeserializeContent: AnalyticsS3BucketDestination
 //   SerializeContent: AnalyticsS3ExportFileFormat
 // DeserializeContent: AnalyticsS3ExportFileFormat
+//   SerializeContent: AnnotationConfigurationState
+// DeserializeContent: AnnotationConfigurationState
+//   SerializeContent: AnnotationTableConfiguration
+// DeserializeContent: AnnotationTableConfiguration
+//   SerializeContent: AnnotationTableConfigurationResult
+// DeserializeContent: AnnotationTableConfigurationResult
+//   SerializeContent: AnnotationTableConfigurationUpdates
+// DeserializeContent: AnnotationTableConfigurationUpdates
 //   SerializeContent: ArnType
 // DeserializeContent: ArnType
 //   SerializeContent: AssumeRoleOutput
@@ -300,6 +318,8 @@ use std::io::Write;
 // DeserializeContent: Description
 //   SerializeContent: Destination
 // DeserializeContent: Destination
+//   SerializeContent: DestinationResult
+// DeserializeContent: DestinationResult
 //   SerializeContent: DirectoryBucketToken
 // DeserializeContent: DirectoryBucketToken
 //   SerializeContent: DisplayName
@@ -336,6 +356,8 @@ use std::io::Write;
 // DeserializeContent: ExistingObjectReplication
 //   SerializeContent: ExistingObjectReplicationStatus
 // DeserializeContent: ExistingObjectReplicationStatus
+//   SerializeContent: ExpirationState
+// DeserializeContent: ExpirationState
 //   SerializeContent: ExpirationStatus
 // DeserializeContent: ExpirationStatus
 //   SerializeContent: ExpiredObjectDeleteMarker
@@ -366,6 +388,8 @@ use std::io::Write;
 // DeserializeContent: GetBucketLocationOutput
 //   SerializeContent: GetBucketLoggingOutput
 // DeserializeContent: GetBucketLoggingOutput
+//   SerializeContent: GetBucketMetadataConfigurationResult
+// DeserializeContent: GetBucketMetadataConfigurationResult
 //   SerializeContent: GetBucketMetadataTableConfigurationResult
 // DeserializeContent: GetBucketMetadataTableConfigurationResult
 //   SerializeContent: GetBucketNotificationConfigurationOutput
@@ -420,6 +444,8 @@ use std::io::Write;
 // DeserializeContent: IntelligentTieringStatus
 //   SerializeContent: InventoryConfiguration
 // DeserializeContent: InventoryConfiguration
+//   SerializeContent: InventoryConfigurationState
+// DeserializeContent: InventoryConfigurationState
 //   SerializeContent: InventoryDestination
 // DeserializeContent: InventoryDestination
 //   SerializeContent: InventoryEncryption
@@ -440,6 +466,12 @@ use std::io::Write;
 // DeserializeContent: InventoryS3BucketDestination
 //   SerializeContent: InventorySchedule
 // DeserializeContent: InventorySchedule
+//   SerializeContent: InventoryTableConfiguration
+// DeserializeContent: InventoryTableConfiguration
+//   SerializeContent: InventoryTableConfigurationResult
+// DeserializeContent: InventoryTableConfigurationResult
+//   SerializeContent: InventoryTableConfigurationUpdates
+// DeserializeContent: InventoryTableConfigurationUpdates
 //   SerializeContent: IsEnabled
 // DeserializeContent: IsEnabled
 //   SerializeContent: IsLatest
@@ -456,6 +488,12 @@ use std::io::Write;
 // DeserializeContent: JSONOutput
 //   SerializeContent: JSONType
 // DeserializeContent: JSONType
+//   SerializeContent: JournalTableConfiguration
+// DeserializeContent: JournalTableConfiguration
+//   SerializeContent: JournalTableConfigurationResult
+// DeserializeContent: JournalTableConfigurationResult
+//   SerializeContent: JournalTableConfigurationUpdates
+// DeserializeContent: JournalTableConfigurationUpdates
 //   SerializeContent: KMSContext
 // DeserializeContent: KMSContext
 //   SerializeContent: KeyCount
@@ -464,6 +502,8 @@ use std::io::Write;
 // DeserializeContent: KeyMarker
 //   SerializeContent: KeyPrefixEquals
 // DeserializeContent: KeyPrefixEquals
+//   SerializeContent: KmsKeyArn
+// DeserializeContent: KmsKeyArn
 //   SerializeContent: LambdaFunctionArn
 // DeserializeContent: LambdaFunctionArn
 //   SerializeContent: LambdaFunctionConfiguration
@@ -525,6 +565,10 @@ use std::io::Write;
 // DeserializeContent: MaxUploads
 //   SerializeContent: Message
 // DeserializeContent: Message
+//   SerializeContent: MetadataConfiguration
+// DeserializeContent: MetadataConfiguration
+//   SerializeContent: MetadataConfigurationResult
+// DeserializeContent: MetadataConfigurationResult
 //   SerializeContent: MetadataEntry
 // DeserializeContent: MetadataEntry
 //   SerializeContent: MetadataKey
@@ -533,6 +577,8 @@ use std::io::Write;
 // DeserializeContent: MetadataTableConfiguration
 //   SerializeContent: MetadataTableConfigurationResult
 // DeserializeContent: MetadataTableConfigurationResult
+//   SerializeContent: MetadataTableEncryptionConfiguration
+// DeserializeContent: MetadataTableEncryptionConfiguration
 //   SerializeContent: MetadataTableStatus
 // DeserializeContent: MetadataTableStatus
 //   SerializeContent: MetadataValue
@@ -675,6 +721,10 @@ use std::io::Write;
 // DeserializeContent: QuoteFields
 //   SerializeContent: RecordDelimiter
 // DeserializeContent: RecordDelimiter
+//   SerializeContent: RecordExpiration
+// DeserializeContent: RecordExpiration
+//   SerializeContent: RecordExpirationDays
+// DeserializeContent: RecordExpirationDays
 //   SerializeContent: Redirect
 // DeserializeContent: Redirect
 //   SerializeContent: RedirectAllRequestsTo
@@ -729,6 +779,8 @@ use std::io::Write;
 // DeserializeContent: S3TablesArn
 //   SerializeContent: S3TablesBucketArn
 // DeserializeContent: S3TablesBucketArn
+//   SerializeContent: S3TablesBucketType
+// DeserializeContent: S3TablesBucketType
 //   SerializeContent: S3TablesDestination
 // DeserializeContent: S3TablesDestination
 //   SerializeContent: S3TablesDestinationResult
@@ -793,6 +845,8 @@ use std::io::Write;
 // DeserializeContent: StorageClassAnalysisSchemaVersion
 //   SerializeContent: Suffix
 // DeserializeContent: Suffix
+//   SerializeContent: TableSseAlgorithm
+// DeserializeContent: TableSseAlgorithm
 //   SerializeContent: Tag
 // DeserializeContent: Tag
 //   SerializeContent: Tagging
@@ -887,6 +941,18 @@ impl Serialize for AnalyticsConfiguration {
 impl<'xml> Deserialize<'xml> for AnalyticsConfiguration {
     fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {
         d.named_element("AnalyticsConfiguration", Deserializer::content)
+    }
+}
+
+impl Serialize for AnnotationTableConfigurationUpdates {
+    fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("AnnotationTableConfiguration", self)
+    }
+}
+
+impl<'xml> Deserialize<'xml> for AnnotationTableConfigurationUpdates {
+    fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.named_element("AnnotationTableConfiguration", Deserializer::content)
     }
 }
 
@@ -1058,6 +1124,18 @@ impl<'xml> Deserialize<'xml> for GetBucketLoggingOutput {
     }
 }
 
+impl Serialize for GetBucketMetadataConfigurationResult {
+    fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("GetBucketMetadataConfigurationResult", self)
+    }
+}
+
+impl<'xml> Deserialize<'xml> for GetBucketMetadataConfigurationResult {
+    fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.named_element("GetBucketMetadataConfigurationResult", Deserializer::content)
+    }
+}
+
 impl Serialize for GetBucketMetadataTableConfigurationResult {
     fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         s.content("GetBucketMetadataTableConfigurationResult", self)
@@ -1172,6 +1250,30 @@ impl<'xml> Deserialize<'xml> for InventoryConfiguration {
     }
 }
 
+impl Serialize for InventoryTableConfigurationUpdates {
+    fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("InventoryTableConfiguration", self)
+    }
+}
+
+impl<'xml> Deserialize<'xml> for InventoryTableConfigurationUpdates {
+    fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.named_element("InventoryTableConfiguration", Deserializer::content)
+    }
+}
+
+impl Serialize for JournalTableConfigurationUpdates {
+    fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("JournalTableConfiguration", self)
+    }
+}
+
+impl<'xml> Deserialize<'xml> for JournalTableConfigurationUpdates {
+    fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.named_element("JournalTableConfiguration", Deserializer::content)
+    }
+}
+
 impl Serialize for ListBucketAnalyticsConfigurationsOutput {
     fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         s.content_with_ns("ListBucketAnalyticsConfigurationResult", XMLNS_S3, self)
@@ -1271,6 +1373,18 @@ impl Serialize for ListObjectsV2Output {
 impl Serialize for ListPartsOutput {
     fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         s.content_with_ns("ListPartsResult", XMLNS_S3, self)
+    }
+}
+
+impl Serialize for MetadataConfiguration {
+    fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("MetadataConfiguration", self)
+    }
+}
+
+impl<'xml> Deserialize<'xml> for MetadataConfiguration {
+    fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.named_element("MetadataConfiguration", Deserializer::content)
     }
 }
 
@@ -1844,6 +1958,206 @@ impl<'xml> DeserializeContent<'xml> for AnalyticsS3ExportFileFormat {
         d.text(|s| match s {
             "CSV" => Ok(Self::from_static(AnalyticsS3ExportFileFormat::CSV)),
             _ => Ok(Self::from(s.to_owned())),
+        })
+    }
+}
+impl SerializeContent for AnnotationConfigurationState {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        self.as_str().serialize_content(s)
+    }
+}
+impl<'xml> DeserializeContent<'xml> for AnnotationConfigurationState {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.text(|s| match s {
+            "DISABLED" => Ok(Self::from_static(AnnotationConfigurationState::DISABLED)),
+            "ENABLED" => Ok(Self::from_static(AnnotationConfigurationState::ENABLED)),
+            _ => Ok(Self::from(s.to_owned())),
+        })
+    }
+}
+impl SerializeContent for AnnotationTableConfiguration {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("ConfigurationState", &self.configuration_state)?;
+        if let Some(ref val) = self.encryption_configuration {
+            s.content("EncryptionConfiguration", val)?;
+        }
+        if let Some(ref val) = self.role {
+            s.content("Role", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for AnnotationTableConfiguration {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut configuration_state: Option<AnnotationConfigurationState> = None;
+        let mut encryption_configuration: Option<MetadataTableEncryptionConfiguration> = None;
+        let mut role: Option<Role> = None;
+        d.for_each_element(|d, x| match x {
+            b"ConfigurationState" => {
+                if configuration_state.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                configuration_state = Some(d.content()?);
+                Ok(())
+            }
+            b"EncryptionConfiguration" => {
+                if encryption_configuration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                encryption_configuration = Some(d.content()?);
+                Ok(())
+            }
+            b"Role" => {
+                if role.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                role = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            configuration_state: configuration_state.ok_or(DeError::MissingField)?,
+            encryption_configuration,
+            role,
+        })
+    }
+}
+impl SerializeContent for AnnotationTableConfigurationResult {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("ConfigurationState", &self.configuration_state)?;
+        if let Some(ref val) = self.error {
+            s.content("Error", val)?;
+        }
+        if let Some(ref val) = self.role {
+            s.content("Role", val)?;
+        }
+        if let Some(ref val) = self.table_arn {
+            s.content("TableArn", val)?;
+        }
+        if let Some(ref val) = self.table_name {
+            s.content("TableName", val)?;
+        }
+        if let Some(ref val) = self.table_status {
+            s.content("TableStatus", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for AnnotationTableConfigurationResult {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut configuration_state: Option<AnnotationConfigurationState> = None;
+        let mut error: Option<ErrorDetails> = None;
+        let mut role: Option<Role> = None;
+        let mut table_arn: Option<S3TablesArn> = None;
+        let mut table_name: Option<S3TablesName> = None;
+        let mut table_status: Option<MetadataTableStatus> = None;
+        d.for_each_element(|d, x| match x {
+            b"ConfigurationState" => {
+                if configuration_state.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                configuration_state = Some(d.content()?);
+                Ok(())
+            }
+            b"Error" => {
+                if error.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                error = Some(d.content()?);
+                Ok(())
+            }
+            b"Role" => {
+                if role.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                role = Some(d.content()?);
+                Ok(())
+            }
+            b"TableArn" => {
+                if table_arn.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_arn = Some(d.content()?);
+                Ok(())
+            }
+            b"TableName" => {
+                if table_name.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_name = Some(d.content()?);
+                Ok(())
+            }
+            b"TableStatus" => {
+                if table_status.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_status = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            configuration_state: configuration_state.ok_or(DeError::MissingField)?,
+            error,
+            role,
+            table_arn,
+            table_name,
+            table_status,
+        })
+    }
+}
+impl SerializeContent for AnnotationTableConfigurationUpdates {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("ConfigurationState", &self.configuration_state)?;
+        if let Some(ref val) = self.encryption_configuration {
+            s.content("EncryptionConfiguration", val)?;
+        }
+        if let Some(ref val) = self.role {
+            s.content("Role", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for AnnotationTableConfigurationUpdates {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut configuration_state: Option<AnnotationConfigurationState> = None;
+        let mut encryption_configuration: Option<MetadataTableEncryptionConfiguration> = None;
+        let mut role: Option<Role> = None;
+        d.for_each_element(|d, x| match x {
+            b"ConfigurationState" => {
+                if configuration_state.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                configuration_state = Some(d.content()?);
+                Ok(())
+            }
+            b"EncryptionConfiguration" => {
+                if encryption_configuration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                encryption_configuration = Some(d.content()?);
+                Ok(())
+            }
+            b"Role" => {
+                if role.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                role = Some(d.content()?);
+                Ok(())
+            }
+            _ => {
+                d.skip_element_content()?;
+                Ok(())
+            }
+        })?;
+        Ok(Self {
+            configuration_state: configuration_state.ok_or(DeError::MissingField)?,
+            encryption_configuration,
+            role,
         })
     }
 }
@@ -3840,6 +4154,57 @@ impl<'xml> DeserializeContent<'xml> for Destination {
         })
     }
 }
+impl SerializeContent for DestinationResult {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.table_bucket_arn {
+            s.content("TableBucketArn", val)?;
+        }
+        if let Some(ref val) = self.table_bucket_type {
+            s.content("TableBucketType", val)?;
+        }
+        if let Some(ref val) = self.table_namespace {
+            s.content("TableNamespace", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for DestinationResult {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut table_bucket_arn: Option<S3TablesBucketArn> = None;
+        let mut table_bucket_type: Option<S3TablesBucketType> = None;
+        let mut table_namespace: Option<S3TablesNamespace> = None;
+        d.for_each_element(|d, x| match x {
+            b"TableBucketArn" => {
+                if table_bucket_arn.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_bucket_arn = Some(d.content()?);
+                Ok(())
+            }
+            b"TableBucketType" => {
+                if table_bucket_type.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_bucket_type = Some(d.content()?);
+                Ok(())
+            }
+            b"TableNamespace" => {
+                if table_namespace.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_namespace = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            table_bucket_arn,
+            table_bucket_type,
+            table_namespace,
+        })
+    }
+}
 impl SerializeContent for EncodingType {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         self.as_str().serialize_content(s)
@@ -4104,6 +4469,20 @@ impl<'xml> DeserializeContent<'xml> for ExistingObjectReplicationStatus {
         })
     }
 }
+impl SerializeContent for ExpirationState {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        self.as_str().serialize_content(s)
+    }
+}
+impl<'xml> DeserializeContent<'xml> for ExpirationState {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.text(|s| match s {
+            "DISABLED" => Ok(Self::from_static(ExpirationState::DISABLED)),
+            "ENABLED" => Ok(Self::from_static(ExpirationState::ENABLED)),
+            _ => Ok(Self::from(s.to_owned())),
+        })
+    }
+}
 impl SerializeContent for ExpirationStatus {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         self.as_str().serialize_content(s)
@@ -4321,6 +4700,31 @@ impl<'xml> DeserializeContent<'xml> for GetBucketLoggingOutput {
             _ => Err(DeError::UnexpectedTagName),
         })?;
         Ok(Self { logging_enabled })
+    }
+}
+impl SerializeContent for GetBucketMetadataConfigurationResult {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("MetadataConfigurationResult", &self.metadata_configuration_result)?;
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for GetBucketMetadataConfigurationResult {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut metadata_configuration_result: Option<MetadataConfigurationResult> = None;
+        d.for_each_element(|d, x| match x {
+            b"MetadataConfigurationResult" => {
+                if metadata_configuration_result.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                metadata_configuration_result = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            metadata_configuration_result: metadata_configuration_result.ok_or(DeError::MissingField)?,
+        })
     }
 }
 impl SerializeContent for GetBucketMetadataTableConfigurationResult {
@@ -5229,6 +5633,20 @@ impl<'xml> DeserializeContent<'xml> for InventoryConfiguration {
         })
     }
 }
+impl SerializeContent for InventoryConfigurationState {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        self.as_str().serialize_content(s)
+    }
+}
+impl<'xml> DeserializeContent<'xml> for InventoryConfigurationState {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.text(|s| match s {
+            "DISABLED" => Ok(Self::from_static(InventoryConfigurationState::DISABLED)),
+            "ENABLED" => Ok(Self::from_static(InventoryConfigurationState::ENABLED)),
+            _ => Ok(Self::from(s.to_owned())),
+        })
+    }
+}
 impl SerializeContent for InventoryDestination {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         s.content("S3BucketDestination", &self.s3_bucket_destination)?;
@@ -5482,6 +5900,156 @@ impl<'xml> DeserializeContent<'xml> for InventorySchedule {
         })
     }
 }
+impl SerializeContent for InventoryTableConfiguration {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("ConfigurationState", &self.configuration_state)?;
+        if let Some(ref val) = self.encryption_configuration {
+            s.content("EncryptionConfiguration", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for InventoryTableConfiguration {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut configuration_state: Option<InventoryConfigurationState> = None;
+        let mut encryption_configuration: Option<MetadataTableEncryptionConfiguration> = None;
+        d.for_each_element(|d, x| match x {
+            b"ConfigurationState" => {
+                if configuration_state.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                configuration_state = Some(d.content()?);
+                Ok(())
+            }
+            b"EncryptionConfiguration" => {
+                if encryption_configuration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                encryption_configuration = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            configuration_state: configuration_state.ok_or(DeError::MissingField)?,
+            encryption_configuration,
+        })
+    }
+}
+impl SerializeContent for InventoryTableConfigurationResult {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("ConfigurationState", &self.configuration_state)?;
+        if let Some(ref val) = self.error {
+            s.content("Error", val)?;
+        }
+        if let Some(ref val) = self.table_arn {
+            s.content("TableArn", val)?;
+        }
+        if let Some(ref val) = self.table_name {
+            s.content("TableName", val)?;
+        }
+        if let Some(ref val) = self.table_status {
+            s.content("TableStatus", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for InventoryTableConfigurationResult {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut configuration_state: Option<InventoryConfigurationState> = None;
+        let mut error: Option<ErrorDetails> = None;
+        let mut table_arn: Option<S3TablesArn> = None;
+        let mut table_name: Option<S3TablesName> = None;
+        let mut table_status: Option<MetadataTableStatus> = None;
+        d.for_each_element(|d, x| match x {
+            b"ConfigurationState" => {
+                if configuration_state.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                configuration_state = Some(d.content()?);
+                Ok(())
+            }
+            b"Error" => {
+                if error.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                error = Some(d.content()?);
+                Ok(())
+            }
+            b"TableArn" => {
+                if table_arn.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_arn = Some(d.content()?);
+                Ok(())
+            }
+            b"TableName" => {
+                if table_name.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_name = Some(d.content()?);
+                Ok(())
+            }
+            b"TableStatus" => {
+                if table_status.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_status = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            configuration_state: configuration_state.ok_or(DeError::MissingField)?,
+            error,
+            table_arn,
+            table_name,
+            table_status,
+        })
+    }
+}
+impl SerializeContent for InventoryTableConfigurationUpdates {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("ConfigurationState", &self.configuration_state)?;
+        if let Some(ref val) = self.encryption_configuration {
+            s.content("EncryptionConfiguration", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for InventoryTableConfigurationUpdates {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut configuration_state: Option<InventoryConfigurationState> = None;
+        let mut encryption_configuration: Option<MetadataTableEncryptionConfiguration> = None;
+        d.for_each_element(|d, x| match x {
+            b"ConfigurationState" => {
+                if configuration_state.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                configuration_state = Some(d.content()?);
+                Ok(())
+            }
+            b"EncryptionConfiguration" => {
+                if encryption_configuration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                encryption_configuration = Some(d.content()?);
+                Ok(())
+            }
+            _ => {
+                d.skip_element_content()?;
+                Ok(())
+            }
+        })?;
+        Ok(Self {
+            configuration_state: configuration_state.ok_or(DeError::MissingField)?,
+            encryption_configuration,
+        })
+    }
+}
 impl SerializeContent for JSONInput {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         if let Some(ref val) = self.type_ {
@@ -5543,6 +6111,140 @@ impl<'xml> DeserializeContent<'xml> for JSONType {
             "DOCUMENT" => Ok(Self::from_static(JSONType::DOCUMENT)),
             "LINES" => Ok(Self::from_static(JSONType::LINES)),
             _ => Ok(Self::from(s.to_owned())),
+        })
+    }
+}
+impl SerializeContent for JournalTableConfiguration {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.encryption_configuration {
+            s.content("EncryptionConfiguration", val)?;
+        }
+        s.content("RecordExpiration", &self.record_expiration)?;
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for JournalTableConfiguration {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut encryption_configuration: Option<MetadataTableEncryptionConfiguration> = None;
+        let mut record_expiration: Option<RecordExpiration> = None;
+        d.for_each_element(|d, x| match x {
+            b"EncryptionConfiguration" => {
+                if encryption_configuration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                encryption_configuration = Some(d.content()?);
+                Ok(())
+            }
+            b"RecordExpiration" => {
+                if record_expiration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                record_expiration = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            encryption_configuration,
+            record_expiration: record_expiration.ok_or(DeError::MissingField)?,
+        })
+    }
+}
+impl SerializeContent for JournalTableConfigurationResult {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.error {
+            s.content("Error", val)?;
+        }
+        s.content("RecordExpiration", &self.record_expiration)?;
+        if let Some(ref val) = self.table_arn {
+            s.content("TableArn", val)?;
+        }
+        s.content("TableName", &self.table_name)?;
+        s.content("TableStatus", &self.table_status)?;
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for JournalTableConfigurationResult {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut error: Option<ErrorDetails> = None;
+        let mut record_expiration: Option<RecordExpiration> = None;
+        let mut table_arn: Option<S3TablesArn> = None;
+        let mut table_name: Option<S3TablesName> = None;
+        let mut table_status: Option<MetadataTableStatus> = None;
+        d.for_each_element(|d, x| match x {
+            b"Error" => {
+                if error.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                error = Some(d.content()?);
+                Ok(())
+            }
+            b"RecordExpiration" => {
+                if record_expiration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                record_expiration = Some(d.content()?);
+                Ok(())
+            }
+            b"TableArn" => {
+                if table_arn.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_arn = Some(d.content()?);
+                Ok(())
+            }
+            b"TableName" => {
+                if table_name.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_name = Some(d.content()?);
+                Ok(())
+            }
+            b"TableStatus" => {
+                if table_status.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_status = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            error,
+            record_expiration: record_expiration.ok_or(DeError::MissingField)?,
+            table_arn,
+            table_name: table_name.ok_or(DeError::MissingField)?,
+            table_status: table_status.ok_or(DeError::MissingField)?,
+        })
+    }
+}
+impl SerializeContent for JournalTableConfigurationUpdates {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("RecordExpiration", &self.record_expiration)?;
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for JournalTableConfigurationUpdates {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut record_expiration: Option<RecordExpiration> = None;
+        d.for_each_element(|d, x| match x {
+            b"RecordExpiration" => {
+                if record_expiration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                record_expiration = Some(d.content()?);
+                Ok(())
+            }
+            _ => {
+                d.skip_element_content()?;
+                Ok(())
+            }
+        })?;
+        Ok(Self {
+            record_expiration: record_expiration.ok_or(DeError::MissingField)?,
         })
     }
 }
@@ -6603,6 +7305,119 @@ impl<'xml> DeserializeContent<'xml> for MFADeleteStatus {
         })
     }
 }
+impl SerializeContent for MetadataConfiguration {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.annotation_table_configuration {
+            s.content("AnnotationTableConfiguration", val)?;
+        }
+        if let Some(ref val) = self.inventory_table_configuration {
+            s.content("InventoryTableConfiguration", val)?;
+        }
+        s.content("JournalTableConfiguration", &self.journal_table_configuration)?;
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for MetadataConfiguration {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut annotation_table_configuration: Option<AnnotationTableConfiguration> = None;
+        let mut inventory_table_configuration: Option<InventoryTableConfiguration> = None;
+        let mut journal_table_configuration: Option<JournalTableConfiguration> = None;
+        d.for_each_element(|d, x| match x {
+            b"AnnotationTableConfiguration" => {
+                if annotation_table_configuration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                annotation_table_configuration = Some(d.content()?);
+                Ok(())
+            }
+            b"InventoryTableConfiguration" => {
+                if inventory_table_configuration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                inventory_table_configuration = Some(d.content()?);
+                Ok(())
+            }
+            b"JournalTableConfiguration" => {
+                if journal_table_configuration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                journal_table_configuration = Some(d.content()?);
+                Ok(())
+            }
+            _ => {
+                d.skip_element_content()?;
+                Ok(())
+            }
+        })?;
+        Ok(Self {
+            annotation_table_configuration,
+            inventory_table_configuration,
+            journal_table_configuration: journal_table_configuration.ok_or(DeError::MissingField)?,
+        })
+    }
+}
+impl SerializeContent for MetadataConfigurationResult {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.annotation_table_configuration_result {
+            s.content("AnnotationTableConfigurationResult", val)?;
+        }
+        s.content("DestinationResult", &self.destination_result)?;
+        if let Some(ref val) = self.inventory_table_configuration_result {
+            s.content("InventoryTableConfigurationResult", val)?;
+        }
+        if let Some(ref val) = self.journal_table_configuration_result {
+            s.content("JournalTableConfigurationResult", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for MetadataConfigurationResult {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut annotation_table_configuration_result: Option<AnnotationTableConfigurationResult> = None;
+        let mut destination_result: Option<DestinationResult> = None;
+        let mut inventory_table_configuration_result: Option<InventoryTableConfigurationResult> = None;
+        let mut journal_table_configuration_result: Option<JournalTableConfigurationResult> = None;
+        d.for_each_element(|d, x| match x {
+            b"AnnotationTableConfigurationResult" => {
+                if annotation_table_configuration_result.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                annotation_table_configuration_result = Some(d.content()?);
+                Ok(())
+            }
+            b"DestinationResult" => {
+                if destination_result.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                destination_result = Some(d.content()?);
+                Ok(())
+            }
+            b"InventoryTableConfigurationResult" => {
+                if inventory_table_configuration_result.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                inventory_table_configuration_result = Some(d.content()?);
+                Ok(())
+            }
+            b"JournalTableConfigurationResult" => {
+                if journal_table_configuration_result.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                journal_table_configuration_result = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            annotation_table_configuration_result,
+            destination_result: destination_result.ok_or(DeError::MissingField)?,
+            inventory_table_configuration_result,
+            journal_table_configuration_result,
+        })
+    }
+}
 impl SerializeContent for MetadataEntry {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         if let Some(ref val) = self.name {
@@ -6689,6 +7504,43 @@ impl<'xml> DeserializeContent<'xml> for MetadataTableConfigurationResult {
         })?;
         Ok(Self {
             s3_tables_destination_result: s3_tables_destination_result.ok_or(DeError::MissingField)?,
+        })
+    }
+}
+impl SerializeContent for MetadataTableEncryptionConfiguration {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.kms_key_arn {
+            s.content("KmsKeyArn", val)?;
+        }
+        s.content("SseAlgorithm", &self.sse_algorithm)?;
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for MetadataTableEncryptionConfiguration {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut kms_key_arn: Option<KmsKeyArn> = None;
+        let mut sse_algorithm: Option<TableSseAlgorithm> = None;
+        d.for_each_element(|d, x| match x {
+            b"KmsKeyArn" => {
+                if kms_key_arn.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                kms_key_arn = Some(d.content()?);
+                Ok(())
+            }
+            b"SseAlgorithm" => {
+                if sse_algorithm.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                sse_algorithm = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            kms_key_arn,
+            sse_algorithm: sse_algorithm.ok_or(DeError::MissingField)?,
         })
     }
 }
@@ -8544,6 +9396,43 @@ impl<'xml> DeserializeContent<'xml> for QuoteFields {
         })
     }
 }
+impl SerializeContent for RecordExpiration {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.days {
+            s.content("Days", val)?;
+        }
+        s.content("Expiration", &self.expiration)?;
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for RecordExpiration {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut days: Option<RecordExpirationDays> = None;
+        let mut expiration: Option<ExpirationState> = None;
+        d.for_each_element(|d, x| match x {
+            b"Days" => {
+                if days.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                days = Some(d.content()?);
+                Ok(())
+            }
+            b"Expiration" => {
+                if expiration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                expiration = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            days,
+            expiration: expiration.ok_or(DeError::MissingField)?,
+        })
+    }
+}
 impl SerializeContent for Redirect {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         if let Some(ref val) = self.host_name {
@@ -9396,6 +10285,20 @@ impl<'xml> DeserializeContent<'xml> for S3Location {
         })
     }
 }
+impl SerializeContent for S3TablesBucketType {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        self.as_str().serialize_content(s)
+    }
+}
+impl<'xml> DeserializeContent<'xml> for S3TablesBucketType {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.text(|s| match s {
+            "aws" => Ok(Self::from_static(S3TablesBucketType::AWS)),
+            "customer" => Ok(Self::from_static(S3TablesBucketType::CUSTOMER)),
+            _ => Ok(Self::from(s.to_owned())),
+        })
+    }
+}
 impl SerializeContent for S3TablesDestination {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         s.content("TableBucketArn", &self.table_bucket_arn)?;
@@ -10106,6 +11009,20 @@ impl<'xml> DeserializeContent<'xml> for StorageClassAnalysisSchemaVersion {
     fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
         d.text(|s| match s {
             "V_1" => Ok(Self::from_static(StorageClassAnalysisSchemaVersion::V_1)),
+            _ => Ok(Self::from(s.to_owned())),
+        })
+    }
+}
+impl SerializeContent for TableSseAlgorithm {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        self.as_str().serialize_content(s)
+    }
+}
+impl<'xml> DeserializeContent<'xml> for TableSseAlgorithm {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.text(|s| match s {
+            "AES256" => Ok(Self::from_static(TableSseAlgorithm::AES256)),
+            "aws:kms" => Ok(Self::from_static(TableSseAlgorithm::AWS_KMS)),
             _ => Ok(Self::from(s.to_owned())),
         })
     }

--- a/crates/s3s/src/xml/generated_minio.rs
+++ b/crates/s3s/src/xml/generated_minio.rs
@@ -19,6 +19,8 @@ use std::io::Write;
 // Deserialize: AccessControlPolicy
 //   Serialize: AnalyticsConfiguration
 // Deserialize: AnalyticsConfiguration
+//   Serialize: AnnotationTableConfigurationUpdates "AnnotationTableConfiguration"
+// Deserialize: AnnotationTableConfigurationUpdates "AnnotationTableConfiguration"
 //   Serialize: BucketLifecycleConfiguration "LifecycleConfiguration"
 // Deserialize: BucketLifecycleConfiguration "LifecycleConfiguration"
 //   Serialize: BucketLoggingStatus
@@ -49,6 +51,8 @@ use std::io::Write;
 // Deserialize: GetBucketLocationOutput
 //   Serialize: GetBucketLoggingOutput
 // Deserialize: GetBucketLoggingOutput
+//   Serialize: GetBucketMetadataConfigurationResult
+// Deserialize: GetBucketMetadataConfigurationResult
 //   Serialize: GetBucketMetadataTableConfigurationResult
 // Deserialize: GetBucketMetadataTableConfigurationResult
 //   Serialize: GetBucketNotificationConfigurationOutput
@@ -68,6 +72,10 @@ use std::io::Write;
 // Deserialize: IntelligentTieringConfiguration
 //   Serialize: InventoryConfiguration
 // Deserialize: InventoryConfiguration
+//   Serialize: InventoryTableConfigurationUpdates "InventoryTableConfiguration"
+// Deserialize: InventoryTableConfigurationUpdates "InventoryTableConfiguration"
+//   Serialize: JournalTableConfigurationUpdates "JournalTableConfiguration"
+// Deserialize: JournalTableConfigurationUpdates "JournalTableConfiguration"
 //   Serialize: ListBucketAnalyticsConfigurationsOutput
 // Deserialize: ListBucketAnalyticsConfigurationsOutput
 //   Serialize: ListBucketIntelligentTieringConfigurationsOutput
@@ -85,6 +93,8 @@ use std::io::Write;
 //   Serialize: ListObjectsOutput
 //   Serialize: ListObjectsV2Output
 //   Serialize: ListPartsOutput
+//   Serialize: MetadataConfiguration
+// Deserialize: MetadataConfiguration
 //   Serialize: MetadataTableConfiguration
 // Deserialize: MetadataTableConfiguration
 //   Serialize: MetricsConfiguration
@@ -166,6 +176,14 @@ use std::io::Write;
 // DeserializeContent: AnalyticsS3BucketDestination
 //   SerializeContent: AnalyticsS3ExportFileFormat
 // DeserializeContent: AnalyticsS3ExportFileFormat
+//   SerializeContent: AnnotationConfigurationState
+// DeserializeContent: AnnotationConfigurationState
+//   SerializeContent: AnnotationTableConfiguration
+// DeserializeContent: AnnotationTableConfiguration
+//   SerializeContent: AnnotationTableConfigurationResult
+// DeserializeContent: AnnotationTableConfigurationResult
+//   SerializeContent: AnnotationTableConfigurationUpdates
+// DeserializeContent: AnnotationTableConfigurationUpdates
 //   SerializeContent: ArnType
 // DeserializeContent: ArnType
 //   SerializeContent: AssumeRoleOutput
@@ -306,6 +324,8 @@ use std::io::Write;
 // DeserializeContent: Description
 //   SerializeContent: Destination
 // DeserializeContent: Destination
+//   SerializeContent: DestinationResult
+// DeserializeContent: DestinationResult
 //   SerializeContent: DirectoryBucketToken
 // DeserializeContent: DirectoryBucketToken
 //   SerializeContent: DisplayName
@@ -346,6 +366,8 @@ use std::io::Write;
 // DeserializeContent: ExistingObjectReplication
 //   SerializeContent: ExistingObjectReplicationStatus
 // DeserializeContent: ExistingObjectReplicationStatus
+//   SerializeContent: ExpirationState
+// DeserializeContent: ExpirationState
 //   SerializeContent: ExpirationStatus
 // DeserializeContent: ExpirationStatus
 //   SerializeContent: ExpiredObjectAllVersions
@@ -378,6 +400,8 @@ use std::io::Write;
 // DeserializeContent: GetBucketLocationOutput
 //   SerializeContent: GetBucketLoggingOutput
 // DeserializeContent: GetBucketLoggingOutput
+//   SerializeContent: GetBucketMetadataConfigurationResult
+// DeserializeContent: GetBucketMetadataConfigurationResult
 //   SerializeContent: GetBucketMetadataTableConfigurationResult
 // DeserializeContent: GetBucketMetadataTableConfigurationResult
 //   SerializeContent: GetBucketNotificationConfigurationOutput
@@ -432,6 +456,8 @@ use std::io::Write;
 // DeserializeContent: IntelligentTieringStatus
 //   SerializeContent: InventoryConfiguration
 // DeserializeContent: InventoryConfiguration
+//   SerializeContent: InventoryConfigurationState
+// DeserializeContent: InventoryConfigurationState
 //   SerializeContent: InventoryDestination
 // DeserializeContent: InventoryDestination
 //   SerializeContent: InventoryEncryption
@@ -452,6 +478,12 @@ use std::io::Write;
 // DeserializeContent: InventoryS3BucketDestination
 //   SerializeContent: InventorySchedule
 // DeserializeContent: InventorySchedule
+//   SerializeContent: InventoryTableConfiguration
+// DeserializeContent: InventoryTableConfiguration
+//   SerializeContent: InventoryTableConfigurationResult
+// DeserializeContent: InventoryTableConfigurationResult
+//   SerializeContent: InventoryTableConfigurationUpdates
+// DeserializeContent: InventoryTableConfigurationUpdates
 //   SerializeContent: IsEnabled
 // DeserializeContent: IsEnabled
 //   SerializeContent: IsLatest
@@ -468,6 +500,12 @@ use std::io::Write;
 // DeserializeContent: JSONOutput
 //   SerializeContent: JSONType
 // DeserializeContent: JSONType
+//   SerializeContent: JournalTableConfiguration
+// DeserializeContent: JournalTableConfiguration
+//   SerializeContent: JournalTableConfigurationResult
+// DeserializeContent: JournalTableConfigurationResult
+//   SerializeContent: JournalTableConfigurationUpdates
+// DeserializeContent: JournalTableConfigurationUpdates
 //   SerializeContent: KMSContext
 // DeserializeContent: KMSContext
 //   SerializeContent: KeyCount
@@ -476,6 +514,8 @@ use std::io::Write;
 // DeserializeContent: KeyMarker
 //   SerializeContent: KeyPrefixEquals
 // DeserializeContent: KeyPrefixEquals
+//   SerializeContent: KmsKeyArn
+// DeserializeContent: KmsKeyArn
 //   SerializeContent: LambdaFunctionArn
 // DeserializeContent: LambdaFunctionArn
 //   SerializeContent: LambdaFunctionConfiguration
@@ -537,6 +577,10 @@ use std::io::Write;
 // DeserializeContent: MaxUploads
 //   SerializeContent: Message
 // DeserializeContent: Message
+//   SerializeContent: MetadataConfiguration
+// DeserializeContent: MetadataConfiguration
+//   SerializeContent: MetadataConfigurationResult
+// DeserializeContent: MetadataConfigurationResult
 //   SerializeContent: MetadataEntry
 // DeserializeContent: MetadataEntry
 //   SerializeContent: MetadataKey
@@ -545,6 +589,8 @@ use std::io::Write;
 // DeserializeContent: MetadataTableConfiguration
 //   SerializeContent: MetadataTableConfigurationResult
 // DeserializeContent: MetadataTableConfigurationResult
+//   SerializeContent: MetadataTableEncryptionConfiguration
+// DeserializeContent: MetadataTableEncryptionConfiguration
 //   SerializeContent: MetadataTableStatus
 // DeserializeContent: MetadataTableStatus
 //   SerializeContent: MetadataValue
@@ -687,6 +733,10 @@ use std::io::Write;
 // DeserializeContent: QuoteFields
 //   SerializeContent: RecordDelimiter
 // DeserializeContent: RecordDelimiter
+//   SerializeContent: RecordExpiration
+// DeserializeContent: RecordExpiration
+//   SerializeContent: RecordExpirationDays
+// DeserializeContent: RecordExpirationDays
 //   SerializeContent: Redirect
 // DeserializeContent: Redirect
 //   SerializeContent: RedirectAllRequestsTo
@@ -741,6 +791,8 @@ use std::io::Write;
 // DeserializeContent: S3TablesArn
 //   SerializeContent: S3TablesBucketArn
 // DeserializeContent: S3TablesBucketArn
+//   SerializeContent: S3TablesBucketType
+// DeserializeContent: S3TablesBucketType
 //   SerializeContent: S3TablesDestination
 // DeserializeContent: S3TablesDestination
 //   SerializeContent: S3TablesDestinationResult
@@ -805,6 +857,8 @@ use std::io::Write;
 // DeserializeContent: StorageClassAnalysisSchemaVersion
 //   SerializeContent: Suffix
 // DeserializeContent: Suffix
+//   SerializeContent: TableSseAlgorithm
+// DeserializeContent: TableSseAlgorithm
 //   SerializeContent: Tag
 // DeserializeContent: Tag
 //   SerializeContent: Tagging
@@ -899,6 +953,18 @@ impl Serialize for AnalyticsConfiguration {
 impl<'xml> Deserialize<'xml> for AnalyticsConfiguration {
     fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {
         d.named_element("AnalyticsConfiguration", Deserializer::content)
+    }
+}
+
+impl Serialize for AnnotationTableConfigurationUpdates {
+    fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("AnnotationTableConfiguration", self)
+    }
+}
+
+impl<'xml> Deserialize<'xml> for AnnotationTableConfigurationUpdates {
+    fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.named_element("AnnotationTableConfiguration", Deserializer::content)
     }
 }
 
@@ -1070,6 +1136,18 @@ impl<'xml> Deserialize<'xml> for GetBucketLoggingOutput {
     }
 }
 
+impl Serialize for GetBucketMetadataConfigurationResult {
+    fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("GetBucketMetadataConfigurationResult", self)
+    }
+}
+
+impl<'xml> Deserialize<'xml> for GetBucketMetadataConfigurationResult {
+    fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.named_element("GetBucketMetadataConfigurationResult", Deserializer::content)
+    }
+}
+
 impl Serialize for GetBucketMetadataTableConfigurationResult {
     fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         s.content("GetBucketMetadataTableConfigurationResult", self)
@@ -1184,6 +1262,30 @@ impl<'xml> Deserialize<'xml> for InventoryConfiguration {
     }
 }
 
+impl Serialize for InventoryTableConfigurationUpdates {
+    fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("InventoryTableConfiguration", self)
+    }
+}
+
+impl<'xml> Deserialize<'xml> for InventoryTableConfigurationUpdates {
+    fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.named_element("InventoryTableConfiguration", Deserializer::content)
+    }
+}
+
+impl Serialize for JournalTableConfigurationUpdates {
+    fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("JournalTableConfiguration", self)
+    }
+}
+
+impl<'xml> Deserialize<'xml> for JournalTableConfigurationUpdates {
+    fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.named_element("JournalTableConfiguration", Deserializer::content)
+    }
+}
+
 impl Serialize for ListBucketAnalyticsConfigurationsOutput {
     fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         s.content_with_ns("ListBucketAnalyticsConfigurationResult", XMLNS_S3, self)
@@ -1283,6 +1385,18 @@ impl Serialize for ListObjectsV2Output {
 impl Serialize for ListPartsOutput {
     fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         s.content_with_ns("ListPartsResult", XMLNS_S3, self)
+    }
+}
+
+impl Serialize for MetadataConfiguration {
+    fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("MetadataConfiguration", self)
+    }
+}
+
+impl<'xml> Deserialize<'xml> for MetadataConfiguration {
+    fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.named_element("MetadataConfiguration", Deserializer::content)
     }
 }
 
@@ -1856,6 +1970,206 @@ impl<'xml> DeserializeContent<'xml> for AnalyticsS3ExportFileFormat {
         d.text(|s| match s {
             "CSV" => Ok(Self::from_static(AnalyticsS3ExportFileFormat::CSV)),
             _ => Ok(Self::from(s.to_owned())),
+        })
+    }
+}
+impl SerializeContent for AnnotationConfigurationState {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        self.as_str().serialize_content(s)
+    }
+}
+impl<'xml> DeserializeContent<'xml> for AnnotationConfigurationState {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.text(|s| match s {
+            "DISABLED" => Ok(Self::from_static(AnnotationConfigurationState::DISABLED)),
+            "ENABLED" => Ok(Self::from_static(AnnotationConfigurationState::ENABLED)),
+            _ => Ok(Self::from(s.to_owned())),
+        })
+    }
+}
+impl SerializeContent for AnnotationTableConfiguration {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("ConfigurationState", &self.configuration_state)?;
+        if let Some(ref val) = self.encryption_configuration {
+            s.content("EncryptionConfiguration", val)?;
+        }
+        if let Some(ref val) = self.role {
+            s.content("Role", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for AnnotationTableConfiguration {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut configuration_state: Option<AnnotationConfigurationState> = None;
+        let mut encryption_configuration: Option<MetadataTableEncryptionConfiguration> = None;
+        let mut role: Option<Role> = None;
+        d.for_each_element(|d, x| match x {
+            b"ConfigurationState" => {
+                if configuration_state.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                configuration_state = Some(d.content()?);
+                Ok(())
+            }
+            b"EncryptionConfiguration" => {
+                if encryption_configuration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                encryption_configuration = Some(d.content()?);
+                Ok(())
+            }
+            b"Role" => {
+                if role.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                role = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            configuration_state: configuration_state.ok_or(DeError::MissingField)?,
+            encryption_configuration,
+            role,
+        })
+    }
+}
+impl SerializeContent for AnnotationTableConfigurationResult {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("ConfigurationState", &self.configuration_state)?;
+        if let Some(ref val) = self.error {
+            s.content("Error", val)?;
+        }
+        if let Some(ref val) = self.role {
+            s.content("Role", val)?;
+        }
+        if let Some(ref val) = self.table_arn {
+            s.content("TableArn", val)?;
+        }
+        if let Some(ref val) = self.table_name {
+            s.content("TableName", val)?;
+        }
+        if let Some(ref val) = self.table_status {
+            s.content("TableStatus", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for AnnotationTableConfigurationResult {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut configuration_state: Option<AnnotationConfigurationState> = None;
+        let mut error: Option<ErrorDetails> = None;
+        let mut role: Option<Role> = None;
+        let mut table_arn: Option<S3TablesArn> = None;
+        let mut table_name: Option<S3TablesName> = None;
+        let mut table_status: Option<MetadataTableStatus> = None;
+        d.for_each_element(|d, x| match x {
+            b"ConfigurationState" => {
+                if configuration_state.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                configuration_state = Some(d.content()?);
+                Ok(())
+            }
+            b"Error" => {
+                if error.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                error = Some(d.content()?);
+                Ok(())
+            }
+            b"Role" => {
+                if role.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                role = Some(d.content()?);
+                Ok(())
+            }
+            b"TableArn" => {
+                if table_arn.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_arn = Some(d.content()?);
+                Ok(())
+            }
+            b"TableName" => {
+                if table_name.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_name = Some(d.content()?);
+                Ok(())
+            }
+            b"TableStatus" => {
+                if table_status.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_status = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            configuration_state: configuration_state.ok_or(DeError::MissingField)?,
+            error,
+            role,
+            table_arn,
+            table_name,
+            table_status,
+        })
+    }
+}
+impl SerializeContent for AnnotationTableConfigurationUpdates {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("ConfigurationState", &self.configuration_state)?;
+        if let Some(ref val) = self.encryption_configuration {
+            s.content("EncryptionConfiguration", val)?;
+        }
+        if let Some(ref val) = self.role {
+            s.content("Role", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for AnnotationTableConfigurationUpdates {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut configuration_state: Option<AnnotationConfigurationState> = None;
+        let mut encryption_configuration: Option<MetadataTableEncryptionConfiguration> = None;
+        let mut role: Option<Role> = None;
+        d.for_each_element(|d, x| match x {
+            b"ConfigurationState" => {
+                if configuration_state.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                configuration_state = Some(d.content()?);
+                Ok(())
+            }
+            b"EncryptionConfiguration" => {
+                if encryption_configuration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                encryption_configuration = Some(d.content()?);
+                Ok(())
+            }
+            b"Role" => {
+                if role.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                role = Some(d.content()?);
+                Ok(())
+            }
+            _ => {
+                d.skip_element_content()?;
+                Ok(())
+            }
+        })?;
+        Ok(Self {
+            configuration_state: configuration_state.ok_or(DeError::MissingField)?,
+            encryption_configuration,
+            role,
         })
     }
 }
@@ -3928,6 +4242,57 @@ impl<'xml> DeserializeContent<'xml> for Destination {
         })
     }
 }
+impl SerializeContent for DestinationResult {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.table_bucket_arn {
+            s.content("TableBucketArn", val)?;
+        }
+        if let Some(ref val) = self.table_bucket_type {
+            s.content("TableBucketType", val)?;
+        }
+        if let Some(ref val) = self.table_namespace {
+            s.content("TableNamespace", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for DestinationResult {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut table_bucket_arn: Option<S3TablesBucketArn> = None;
+        let mut table_bucket_type: Option<S3TablesBucketType> = None;
+        let mut table_namespace: Option<S3TablesNamespace> = None;
+        d.for_each_element(|d, x| match x {
+            b"TableBucketArn" => {
+                if table_bucket_arn.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_bucket_arn = Some(d.content()?);
+                Ok(())
+            }
+            b"TableBucketType" => {
+                if table_bucket_type.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_bucket_type = Some(d.content()?);
+                Ok(())
+            }
+            b"TableNamespace" => {
+                if table_namespace.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_namespace = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            table_bucket_arn,
+            table_bucket_type,
+            table_namespace,
+        })
+    }
+}
 impl SerializeContent for EncodingType {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         self.as_str().serialize_content(s)
@@ -4217,6 +4582,20 @@ impl<'xml> DeserializeContent<'xml> for ExistingObjectReplicationStatus {
         })
     }
 }
+impl SerializeContent for ExpirationState {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        self.as_str().serialize_content(s)
+    }
+}
+impl<'xml> DeserializeContent<'xml> for ExpirationState {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.text(|s| match s {
+            "DISABLED" => Ok(Self::from_static(ExpirationState::DISABLED)),
+            "ENABLED" => Ok(Self::from_static(ExpirationState::ENABLED)),
+            _ => Ok(Self::from(s.to_owned())),
+        })
+    }
+}
 impl SerializeContent for ExpirationStatus {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         self.as_str().serialize_content(s)
@@ -4434,6 +4813,31 @@ impl<'xml> DeserializeContent<'xml> for GetBucketLoggingOutput {
             _ => Err(DeError::UnexpectedTagName),
         })?;
         Ok(Self { logging_enabled })
+    }
+}
+impl SerializeContent for GetBucketMetadataConfigurationResult {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("MetadataConfigurationResult", &self.metadata_configuration_result)?;
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for GetBucketMetadataConfigurationResult {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut metadata_configuration_result: Option<MetadataConfigurationResult> = None;
+        d.for_each_element(|d, x| match x {
+            b"MetadataConfigurationResult" => {
+                if metadata_configuration_result.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                metadata_configuration_result = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            metadata_configuration_result: metadata_configuration_result.ok_or(DeError::MissingField)?,
+        })
     }
 }
 impl SerializeContent for GetBucketMetadataTableConfigurationResult {
@@ -5342,6 +5746,20 @@ impl<'xml> DeserializeContent<'xml> for InventoryConfiguration {
         })
     }
 }
+impl SerializeContent for InventoryConfigurationState {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        self.as_str().serialize_content(s)
+    }
+}
+impl<'xml> DeserializeContent<'xml> for InventoryConfigurationState {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.text(|s| match s {
+            "DISABLED" => Ok(Self::from_static(InventoryConfigurationState::DISABLED)),
+            "ENABLED" => Ok(Self::from_static(InventoryConfigurationState::ENABLED)),
+            _ => Ok(Self::from(s.to_owned())),
+        })
+    }
+}
 impl SerializeContent for InventoryDestination {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         s.content("S3BucketDestination", &self.s3_bucket_destination)?;
@@ -5595,6 +6013,156 @@ impl<'xml> DeserializeContent<'xml> for InventorySchedule {
         })
     }
 }
+impl SerializeContent for InventoryTableConfiguration {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("ConfigurationState", &self.configuration_state)?;
+        if let Some(ref val) = self.encryption_configuration {
+            s.content("EncryptionConfiguration", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for InventoryTableConfiguration {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut configuration_state: Option<InventoryConfigurationState> = None;
+        let mut encryption_configuration: Option<MetadataTableEncryptionConfiguration> = None;
+        d.for_each_element(|d, x| match x {
+            b"ConfigurationState" => {
+                if configuration_state.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                configuration_state = Some(d.content()?);
+                Ok(())
+            }
+            b"EncryptionConfiguration" => {
+                if encryption_configuration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                encryption_configuration = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            configuration_state: configuration_state.ok_or(DeError::MissingField)?,
+            encryption_configuration,
+        })
+    }
+}
+impl SerializeContent for InventoryTableConfigurationResult {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("ConfigurationState", &self.configuration_state)?;
+        if let Some(ref val) = self.error {
+            s.content("Error", val)?;
+        }
+        if let Some(ref val) = self.table_arn {
+            s.content("TableArn", val)?;
+        }
+        if let Some(ref val) = self.table_name {
+            s.content("TableName", val)?;
+        }
+        if let Some(ref val) = self.table_status {
+            s.content("TableStatus", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for InventoryTableConfigurationResult {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut configuration_state: Option<InventoryConfigurationState> = None;
+        let mut error: Option<ErrorDetails> = None;
+        let mut table_arn: Option<S3TablesArn> = None;
+        let mut table_name: Option<S3TablesName> = None;
+        let mut table_status: Option<MetadataTableStatus> = None;
+        d.for_each_element(|d, x| match x {
+            b"ConfigurationState" => {
+                if configuration_state.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                configuration_state = Some(d.content()?);
+                Ok(())
+            }
+            b"Error" => {
+                if error.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                error = Some(d.content()?);
+                Ok(())
+            }
+            b"TableArn" => {
+                if table_arn.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_arn = Some(d.content()?);
+                Ok(())
+            }
+            b"TableName" => {
+                if table_name.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_name = Some(d.content()?);
+                Ok(())
+            }
+            b"TableStatus" => {
+                if table_status.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_status = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            configuration_state: configuration_state.ok_or(DeError::MissingField)?,
+            error,
+            table_arn,
+            table_name,
+            table_status,
+        })
+    }
+}
+impl SerializeContent for InventoryTableConfigurationUpdates {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("ConfigurationState", &self.configuration_state)?;
+        if let Some(ref val) = self.encryption_configuration {
+            s.content("EncryptionConfiguration", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for InventoryTableConfigurationUpdates {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut configuration_state: Option<InventoryConfigurationState> = None;
+        let mut encryption_configuration: Option<MetadataTableEncryptionConfiguration> = None;
+        d.for_each_element(|d, x| match x {
+            b"ConfigurationState" => {
+                if configuration_state.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                configuration_state = Some(d.content()?);
+                Ok(())
+            }
+            b"EncryptionConfiguration" => {
+                if encryption_configuration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                encryption_configuration = Some(d.content()?);
+                Ok(())
+            }
+            _ => {
+                d.skip_element_content()?;
+                Ok(())
+            }
+        })?;
+        Ok(Self {
+            configuration_state: configuration_state.ok_or(DeError::MissingField)?,
+            encryption_configuration,
+        })
+    }
+}
 impl SerializeContent for JSONInput {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         if let Some(ref val) = self.type_ {
@@ -5656,6 +6224,140 @@ impl<'xml> DeserializeContent<'xml> for JSONType {
             "DOCUMENT" => Ok(Self::from_static(JSONType::DOCUMENT)),
             "LINES" => Ok(Self::from_static(JSONType::LINES)),
             _ => Ok(Self::from(s.to_owned())),
+        })
+    }
+}
+impl SerializeContent for JournalTableConfiguration {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.encryption_configuration {
+            s.content("EncryptionConfiguration", val)?;
+        }
+        s.content("RecordExpiration", &self.record_expiration)?;
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for JournalTableConfiguration {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut encryption_configuration: Option<MetadataTableEncryptionConfiguration> = None;
+        let mut record_expiration: Option<RecordExpiration> = None;
+        d.for_each_element(|d, x| match x {
+            b"EncryptionConfiguration" => {
+                if encryption_configuration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                encryption_configuration = Some(d.content()?);
+                Ok(())
+            }
+            b"RecordExpiration" => {
+                if record_expiration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                record_expiration = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            encryption_configuration,
+            record_expiration: record_expiration.ok_or(DeError::MissingField)?,
+        })
+    }
+}
+impl SerializeContent for JournalTableConfigurationResult {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.error {
+            s.content("Error", val)?;
+        }
+        s.content("RecordExpiration", &self.record_expiration)?;
+        if let Some(ref val) = self.table_arn {
+            s.content("TableArn", val)?;
+        }
+        s.content("TableName", &self.table_name)?;
+        s.content("TableStatus", &self.table_status)?;
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for JournalTableConfigurationResult {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut error: Option<ErrorDetails> = None;
+        let mut record_expiration: Option<RecordExpiration> = None;
+        let mut table_arn: Option<S3TablesArn> = None;
+        let mut table_name: Option<S3TablesName> = None;
+        let mut table_status: Option<MetadataTableStatus> = None;
+        d.for_each_element(|d, x| match x {
+            b"Error" => {
+                if error.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                error = Some(d.content()?);
+                Ok(())
+            }
+            b"RecordExpiration" => {
+                if record_expiration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                record_expiration = Some(d.content()?);
+                Ok(())
+            }
+            b"TableArn" => {
+                if table_arn.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_arn = Some(d.content()?);
+                Ok(())
+            }
+            b"TableName" => {
+                if table_name.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_name = Some(d.content()?);
+                Ok(())
+            }
+            b"TableStatus" => {
+                if table_status.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                table_status = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            error,
+            record_expiration: record_expiration.ok_or(DeError::MissingField)?,
+            table_arn,
+            table_name: table_name.ok_or(DeError::MissingField)?,
+            table_status: table_status.ok_or(DeError::MissingField)?,
+        })
+    }
+}
+impl SerializeContent for JournalTableConfigurationUpdates {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("RecordExpiration", &self.record_expiration)?;
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for JournalTableConfigurationUpdates {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut record_expiration: Option<RecordExpiration> = None;
+        d.for_each_element(|d, x| match x {
+            b"RecordExpiration" => {
+                if record_expiration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                record_expiration = Some(d.content()?);
+                Ok(())
+            }
+            _ => {
+                d.skip_element_content()?;
+                Ok(())
+            }
+        })?;
+        Ok(Self {
+            record_expiration: record_expiration.ok_or(DeError::MissingField)?,
         })
     }
 }
@@ -6741,6 +7443,119 @@ impl<'xml> DeserializeContent<'xml> for MFADeleteStatus {
         })
     }
 }
+impl SerializeContent for MetadataConfiguration {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.annotation_table_configuration {
+            s.content("AnnotationTableConfiguration", val)?;
+        }
+        if let Some(ref val) = self.inventory_table_configuration {
+            s.content("InventoryTableConfiguration", val)?;
+        }
+        s.content("JournalTableConfiguration", &self.journal_table_configuration)?;
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for MetadataConfiguration {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut annotation_table_configuration: Option<AnnotationTableConfiguration> = None;
+        let mut inventory_table_configuration: Option<InventoryTableConfiguration> = None;
+        let mut journal_table_configuration: Option<JournalTableConfiguration> = None;
+        d.for_each_element(|d, x| match x {
+            b"AnnotationTableConfiguration" => {
+                if annotation_table_configuration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                annotation_table_configuration = Some(d.content()?);
+                Ok(())
+            }
+            b"InventoryTableConfiguration" => {
+                if inventory_table_configuration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                inventory_table_configuration = Some(d.content()?);
+                Ok(())
+            }
+            b"JournalTableConfiguration" => {
+                if journal_table_configuration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                journal_table_configuration = Some(d.content()?);
+                Ok(())
+            }
+            _ => {
+                d.skip_element_content()?;
+                Ok(())
+            }
+        })?;
+        Ok(Self {
+            annotation_table_configuration,
+            inventory_table_configuration,
+            journal_table_configuration: journal_table_configuration.ok_or(DeError::MissingField)?,
+        })
+    }
+}
+impl SerializeContent for MetadataConfigurationResult {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.annotation_table_configuration_result {
+            s.content("AnnotationTableConfigurationResult", val)?;
+        }
+        s.content("DestinationResult", &self.destination_result)?;
+        if let Some(ref val) = self.inventory_table_configuration_result {
+            s.content("InventoryTableConfigurationResult", val)?;
+        }
+        if let Some(ref val) = self.journal_table_configuration_result {
+            s.content("JournalTableConfigurationResult", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for MetadataConfigurationResult {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut annotation_table_configuration_result: Option<AnnotationTableConfigurationResult> = None;
+        let mut destination_result: Option<DestinationResult> = None;
+        let mut inventory_table_configuration_result: Option<InventoryTableConfigurationResult> = None;
+        let mut journal_table_configuration_result: Option<JournalTableConfigurationResult> = None;
+        d.for_each_element(|d, x| match x {
+            b"AnnotationTableConfigurationResult" => {
+                if annotation_table_configuration_result.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                annotation_table_configuration_result = Some(d.content()?);
+                Ok(())
+            }
+            b"DestinationResult" => {
+                if destination_result.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                destination_result = Some(d.content()?);
+                Ok(())
+            }
+            b"InventoryTableConfigurationResult" => {
+                if inventory_table_configuration_result.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                inventory_table_configuration_result = Some(d.content()?);
+                Ok(())
+            }
+            b"JournalTableConfigurationResult" => {
+                if journal_table_configuration_result.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                journal_table_configuration_result = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            annotation_table_configuration_result,
+            destination_result: destination_result.ok_or(DeError::MissingField)?,
+            inventory_table_configuration_result,
+            journal_table_configuration_result,
+        })
+    }
+}
 impl SerializeContent for MetadataEntry {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         if let Some(ref val) = self.name {
@@ -6827,6 +7642,43 @@ impl<'xml> DeserializeContent<'xml> for MetadataTableConfigurationResult {
         })?;
         Ok(Self {
             s3_tables_destination_result: s3_tables_destination_result.ok_or(DeError::MissingField)?,
+        })
+    }
+}
+impl SerializeContent for MetadataTableEncryptionConfiguration {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.kms_key_arn {
+            s.content("KmsKeyArn", val)?;
+        }
+        s.content("SseAlgorithm", &self.sse_algorithm)?;
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for MetadataTableEncryptionConfiguration {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut kms_key_arn: Option<KmsKeyArn> = None;
+        let mut sse_algorithm: Option<TableSseAlgorithm> = None;
+        d.for_each_element(|d, x| match x {
+            b"KmsKeyArn" => {
+                if kms_key_arn.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                kms_key_arn = Some(d.content()?);
+                Ok(())
+            }
+            b"SseAlgorithm" => {
+                if sse_algorithm.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                sse_algorithm = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            kms_key_arn,
+            sse_algorithm: sse_algorithm.ok_or(DeError::MissingField)?,
         })
     }
 }
@@ -8682,6 +9534,43 @@ impl<'xml> DeserializeContent<'xml> for QuoteFields {
         })
     }
 }
+impl SerializeContent for RecordExpiration {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.days {
+            s.content("Days", val)?;
+        }
+        s.content("Expiration", &self.expiration)?;
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for RecordExpiration {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut days: Option<RecordExpirationDays> = None;
+        let mut expiration: Option<ExpirationState> = None;
+        d.for_each_element(|d, x| match x {
+            b"Days" => {
+                if days.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                days = Some(d.content()?);
+                Ok(())
+            }
+            b"Expiration" => {
+                if expiration.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                expiration = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            days,
+            expiration: expiration.ok_or(DeError::MissingField)?,
+        })
+    }
+}
 impl SerializeContent for Redirect {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         if let Some(ref val) = self.host_name {
@@ -9551,6 +10440,20 @@ impl<'xml> DeserializeContent<'xml> for S3Location {
         })
     }
 }
+impl SerializeContent for S3TablesBucketType {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        self.as_str().serialize_content(s)
+    }
+}
+impl<'xml> DeserializeContent<'xml> for S3TablesBucketType {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.text(|s| match s {
+            "aws" => Ok(Self::from_static(S3TablesBucketType::AWS)),
+            "customer" => Ok(Self::from_static(S3TablesBucketType::CUSTOMER)),
+            _ => Ok(Self::from(s.to_owned())),
+        })
+    }
+}
 impl SerializeContent for S3TablesDestination {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         s.content("TableBucketArn", &self.table_bucket_arn)?;
@@ -10261,6 +11164,20 @@ impl<'xml> DeserializeContent<'xml> for StorageClassAnalysisSchemaVersion {
     fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
         d.text(|s| match s {
             "V_1" => Ok(Self::from_static(StorageClassAnalysisSchemaVersion::V_1)),
+            _ => Ok(Self::from(s.to_owned())),
+        })
+    }
+}
+impl SerializeContent for TableSseAlgorithm {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        self.as_str().serialize_content(s)
+    }
+}
+impl<'xml> DeserializeContent<'xml> for TableSseAlgorithm {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.text(|s| match s {
+            "AES256" => Ok(Self::from_static(TableSseAlgorithm::AES256)),
+            "aws:kms" => Ok(Self::from_static(TableSseAlgorithm::AWS_KMS)),
             _ => Ok(Self::from(s.to_owned())),
         })
     }

--- a/data/s3.json
+++ b/data/s3.json
@@ -27269,6 +27269,113 @@
                 }
             }
         },
+        "com.amazonaws.s3#AnnotationConfigurationState": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3#AnnotationTableConfiguration": {
+            "type": "structure",
+            "members": {
+                "ConfigurationState": {
+                    "target": "com.amazonaws.s3#AnnotationConfigurationState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The state of the annotation table. Valid values are <code>ENABLED</code> and <code>DISABLED</code>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "EncryptionConfiguration": {
+                    "target": "com.amazonaws.s3#MetadataTableEncryptionConfiguration"
+                },
+                "Role": {
+                    "target": "com.amazonaws.s3#Role",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM role used to manage the annotation table.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies the configuration for the annotation table associated with a bucket's Amazon S3 Metadata\n      configuration. The annotation table is an Iceberg table that records annotation events for objects\n      in the bucket.</p>"
+            }
+        },
+        "com.amazonaws.s3#AnnotationTableConfigurationResult": {
+            "type": "structure",
+            "members": {
+                "ConfigurationState": {
+                    "target": "com.amazonaws.s3#AnnotationConfigurationState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current configuration state of the annotation table.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TableStatus": {
+                    "target": "com.amazonaws.s3#MetadataTableStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The provisioning status of the annotation table. Possible values: <code>CREATING</code>, <code>BACKFILLING</code>, <code>ACTIVE</code>, <code>FAILED</code>.</p>"
+                    }
+                },
+                "Error": {
+                    "target": "com.amazonaws.s3#ErrorDetails"
+                },
+                "TableName": {
+                    "target": "com.amazonaws.s3#S3TablesName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the annotation table.</p>"
+                    }
+                },
+                "TableArn": {
+                    "target": "com.amazonaws.s3#S3TablesArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the annotation table.</p>"
+                    }
+                },
+                "Role": {
+                    "target": "com.amazonaws.s3#Role",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the IAM role associated with the annotation table.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains the current state of the annotation table associated with a bucket's Amazon S3 Metadata\n      configuration, including its provisioning status and identifiers.</p>"
+            }
+        },
+        "com.amazonaws.s3#AnnotationTableConfigurationUpdates": {
+            "type": "structure",
+            "members": {
+                "ConfigurationState": {
+                    "target": "com.amazonaws.s3#AnnotationConfigurationState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The new configuration state to apply.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "EncryptionConfiguration": {
+                    "target": "com.amazonaws.s3#MetadataTableEncryptionConfiguration"
+                },
+                "Role": {
+                    "target": "com.amazonaws.s3#Role",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The new IAM role ARN to apply.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies updates to apply to the annotation table configuration. Used as the request body for\n      <code>UpdateBucketMetadataAnnotationTableConfiguration</code>.</p>"
+            }
+        },
         "com.amazonaws.s3#ArchiveStatus": {
             "type": "enum",
             "members": {
@@ -29438,6 +29545,81 @@
                 "smithy.api#documentation": "<p>The configuration information for the bucket.</p>"
             }
         },
+        "com.amazonaws.s3#CreateBucketMetadataConfiguration": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.s3#CreateBucketMetadataConfigurationRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "traits": {
+                "aws.protocols#httpChecksum": {
+                    "requestAlgorithmMember": "ChecksumAlgorithm",
+                    "requestChecksumRequired": true
+                },
+                "smithy.api#documentation": "<p>Creates an S3 Metadata V2 metadata configuration for a general purpose bucket. For more information, see\n      <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-overview.html\">Accelerating\n        data discovery with S3 Metadata</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <dl>\n            <dt>Permissions</dt>\n            <dd>\n               <p>To use this operation, you must have the following permissions. For more information, see\n            <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-permissions.html\">Setting up permissions for configuring metadata tables</a> in the\n            <i>Amazon S3 User Guide</i>.</p>\n               <p>If you want to encrypt your metadata tables with server-side encryption with Key Management Service\n            (KMS) keys (SSE-KMS), you need additional permissions in your KMS key policy. For more\n            information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-permissions.html\">\n              Setting up permissions for configuring metadata tables</a> in the\n            <i>Amazon S3 User Guide</i>.</p>\n               <p>If you also want to integrate your table bucket with Amazon Web Services analytics services so that you can\n            query your metadata table, you need additional permissions. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-integrating-aws.html\"> Integrating\n              Amazon S3 Tables with Amazon Web Services analytics services</a> in the\n            <i>Amazon S3 User Guide</i>.</p>\n               <p>To query your metadata tables, you need additional permissions. For more information, see \n            <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-bucket-query-permissions.html\">\n              Permissions for querying metadata tables</a> in the <i>Amazon S3 User Guide</i>.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>s3:CreateBucketMetadataTableConfiguration</code>\n                     </p>\n                     <note>\n                        <p>The IAM policy action name is the same for the V1 and V2 API operations.</p>\n                     </note>\n                  </li>\n                  <li>\n                     <p>\n                        <code>s3tables:CreateTableBucket</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>s3tables:CreateNamespace</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>s3tables:GetTable</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>s3tables:CreateTable</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>s3tables:PutTablePolicy</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>s3tables:PutTableBucketPolicy</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>s3tables:PutTableEncryption</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>kms:DescribeKey</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>iam:PassRole</code> - required if you include an\n                <code>AnnotationTableConfiguration</code> with an IAM role.</p>\n                  </li>\n               </ul>\n            </dd>\n         </dl>\n         <p>The following operations are related to <code>CreateBucketMetadataConfiguration</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetadataConfiguration.html\">DeleteBucketMetadataConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetadataConfiguration.html\">GetBucketMetadataConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataInventoryTableConfiguration.html\">UpdateBucketMetadataInventoryTableConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataJournalTableConfiguration.html\">UpdateBucketMetadataJournalTableConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataAnnotationTableConfiguration.html\">UpdateBucketMetadataAnnotationTableConfiguration</a>\n               </p>\n            </li>\n         </ul>\n         <p>If you include an <code>AnnotationTableConfiguration</code> with an IAM role, the role must\n      have a trust policy that allows the Amazon S3 metadata service to assume it, and a permissions policy\n      that grants the actions needed to read annotations from your bucket. The following examples show\n      a trust policy and a permissions policy that you can adapt for your bucket and account.</p>\n         <important>\n            <p>You must URL encode any signed header values that contain spaces. For example, if your header value is <code>my  file.txt</code>, containing two spaces after <code>my</code>, you must URL encode this value to <code>my%20%20file.txt</code>.</p>\n         </important>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/{Bucket}?metadataConfiguration",
+                    "code": 200
+                },
+                "smithy.rules#staticContextParams": {
+                    "UseS3ExpressControlEndpoint": {
+                        "value": true
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3#CreateBucketMetadataConfigurationRequest": {
+            "type": "structure",
+            "members": {
+                "Bucket": {
+                    "target": "com.amazonaws.s3#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The general purpose bucket that you want to create the metadata configuration for.\n    </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Bucket"
+                        }
+                    }
+                },
+                "ContentMD5": {
+                    "target": "com.amazonaws.s3#ContentMD5",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The <code>Content-MD5</code> header for the metadata configuration.\n    </p>",
+                        "smithy.api#httpHeader": "Content-MD5"
+                    }
+                },
+                "ChecksumAlgorithm": {
+                    "target": "com.amazonaws.s3#ChecksumAlgorithm",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The checksum algorithm to use with your metadata configuration.\n    </p>",
+                        "smithy.api#httpHeader": "x-amz-sdk-checksum-algorithm"
+                    }
+                },
+                "MetadataConfiguration": {
+                    "target": "com.amazonaws.s3#MetadataConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The contents of your metadata configuration.\n    </p>",
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {},
+                        "smithy.api#xmlName": "MetadataConfiguration"
+                    }
+                },
+                "ExpectedBucketOwner": {
+                    "target": "com.amazonaws.s3#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The expected owner of the general purpose bucket that corresponds to your metadata configuration.\n    </p>",
+                        "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
         "com.amazonaws.s3#CreateBucketMetadataTableConfiguration": {
             "type": "operation",
             "input": {
@@ -30553,6 +30735,54 @@
                 "smithy.api#input": {}
             }
         },
+        "com.amazonaws.s3#DeleteBucketMetadataConfiguration": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.s3#DeleteBucketMetadataConfigurationRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> Deletes an S3 Metadata configuration from a general purpose bucket. For more information, see\n      <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-overview.html\">Accelerating\n        data discovery with S3 Metadata</a> in the <i>Amazon S3 User Guide</i>. </p>\n         <note>\n            <p>You can use the V2 <code>DeleteBucketMetadataConfiguration</code> API operation with V1 or V2 \n            metadata configurations. However, if you try to use the V1 \n            <code>DeleteBucketMetadataTableConfiguration</code> API operation with V2 configurations, you\n            will receive an HTTP <code>405 Method Not Allowed</code> error.</p>\n         </note>\n         <dl>\n            <dt>Permissions</dt>\n            <dd>\n               <p>To use this operation, you must have the\n            <code>s3:DeleteBucketMetadataTableConfiguration</code> permission. For more information, see\n            <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-permissions.html\">Setting up permissions for configuring metadata tables</a> in the\n            <i>Amazon S3 User Guide</i>. </p>\n               <note>\n                  <p>The IAM policy action name is the same for the V1 and V2 API operations.</p>\n               </note>\n            </dd>\n         </dl>\n         <p>The following operations are related to <code>DeleteBucketMetadataConfiguration</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketMetadataConfiguration.html\">CreateBucketMetadataConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetadataConfiguration.html\">GetBucketMetadataConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataInventoryTableConfiguration.html\">UpdateBucketMetadataInventoryTableConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataJournalTableConfiguration.html\">UpdateBucketMetadataJournalTableConfiguration</a>\n               </p>\n            </li>\n         </ul>\n         <important>\n            <p>You must URL encode any signed header values that contain spaces. For example, if your header value is <code>my  file.txt</code>, containing two spaces after <code>my</code>, you must URL encode this value to <code>my%20%20file.txt</code>.</p>\n         </important>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/{Bucket}?metadataConfiguration",
+                    "code": 204
+                },
+                "smithy.rules#staticContextParams": {
+                    "UseS3ExpressControlEndpoint": {
+                        "value": true
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3#DeleteBucketMetadataConfigurationRequest": {
+            "type": "structure",
+            "members": {
+                "Bucket": {
+                    "target": "com.amazonaws.s3#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The general purpose bucket that you want to remove the metadata configuration from.\n    </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Bucket"
+                        }
+                    }
+                },
+                "ExpectedBucketOwner": {
+                    "target": "com.amazonaws.s3#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The expected bucket owner of the general purpose bucket that you want to remove the metadata table\n      configuration from.\n    </p>",
+                        "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
         "com.amazonaws.s3#DeleteBucketMetadataTableConfiguration": {
             "type": "operation",
             "input": {
@@ -31609,6 +31839,32 @@
                 "smithy.api#documentation": "<p>Specifies information about where to publish analysis or configuration results for an\n         Amazon S3 bucket and S3 Replication Time Control (S3 RTC).</p>"
             }
         },
+        "com.amazonaws.s3#DestinationResult": {
+            "type": "structure",
+            "members": {
+                "TableBucketType": {
+                    "target": "com.amazonaws.s3#S3TablesBucketType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The type of the table bucket where the metadata configuration is stored. The <code>aws</code> \n      value indicates an Amazon Web Services managed table bucket, and the <code>customer</code> value indicates a \n      customer-managed table bucket. V2 metadata configurations are stored in Amazon Web Services managed table \n      buckets, and V1 metadata configurations are stored in customer-managed table buckets. \n    </p>"
+                    }
+                },
+                "TableBucketArn": {
+                    "target": "com.amazonaws.s3#S3TablesBucketArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The Amazon Resource Name (ARN) of the table bucket where the metadata configuration is stored.\n    </p>"
+                    }
+                },
+                "TableNamespace": {
+                    "target": "com.amazonaws.s3#S3TablesNamespace",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The namespace in the table bucket where the metadata tables for a metadata configuration are \n      stored.\n    </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n      The destination information for the S3 Metadata configuration.\n    </p>"
+            }
+        },
         "com.amazonaws.s3#DirectoryBucketToken": {
             "type": "string",
             "traits": {
@@ -32000,6 +32256,23 @@
         },
         "com.amazonaws.s3#Expiration": {
             "type": "string"
+        },
+        "com.amazonaws.s3#ExpirationState": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                }
+            }
         },
         "com.amazonaws.s3#ExpirationStatus": {
             "type": "enum",
@@ -32923,6 +33196,84 @@
             },
             "traits": {
                 "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.s3#GetBucketMetadataConfiguration": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.s3#GetBucketMetadataConfigurationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.s3#GetBucketMetadataConfigurationOutput"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Retrieves the S3 Metadata configuration for a general purpose bucket. For more information, see\n      <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-overview.html\">Accelerating\n        data discovery with S3 Metadata</a> in the <i>Amazon S3 User Guide</i>. </p>\n         <note>\n            <p>You can use the V2 <code>GetBucketMetadataConfiguration</code> API operation with V1 or V2 \n            metadata configurations. However, if you try to use the V1 \n            <code>GetBucketMetadataTableConfiguration</code> API operation with V2 configurations, you\n            will receive an HTTP <code>405 Method Not Allowed</code> error.</p>\n         </note>\n         <dl>\n            <dt>Permissions</dt>\n            <dd>\n               <p>To use this operation, you must have the <code>s3:GetBucketMetadataTableConfiguration</code>\n            permission. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-permissions.html\">Setting up permissions for\n              configuring metadata tables</a> in the <i>Amazon S3 User Guide</i>. </p>\n               <note>\n                  <p>The IAM policy action name is the same for the V1 and V2 API operations.</p>\n               </note>\n            </dd>\n         </dl>\n         <p>The following operations are related to <code>GetBucketMetadataConfiguration</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketMetadataConfiguration.html\">CreateBucketMetadataConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetadataConfiguration.html\">DeleteBucketMetadataConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataInventoryTableConfiguration.html\">UpdateBucketMetadataInventoryTableConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataJournalTableConfiguration.html\">UpdateBucketMetadataJournalTableConfiguration</a>\n               </p>\n            </li>\n         </ul>\n         <important>\n            <p>You must URL encode any signed header values that contain spaces. For example, if your header value is <code>my  file.txt</code>, containing two spaces after <code>my</code>, you must URL encode this value to <code>my%20%20file.txt</code>.</p>\n         </important>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/{Bucket}?metadataConfiguration",
+                    "code": 200
+                },
+                "smithy.rules#staticContextParams": {
+                    "UseS3ExpressControlEndpoint": {
+                        "value": true
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3#GetBucketMetadataConfigurationOutput": {
+            "type": "structure",
+            "members": {
+                "GetBucketMetadataConfigurationResult": {
+                    "target": "com.amazonaws.s3#GetBucketMetadataConfigurationResult",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The metadata configuration for the general purpose bucket.\n    </p>",
+                        "smithy.api#httpPayload": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.s3#GetBucketMetadataConfigurationRequest": {
+            "type": "structure",
+            "members": {
+                "Bucket": {
+                    "target": "com.amazonaws.s3#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The general purpose bucket that corresponds to the metadata configuration that you want to\n      retrieve.\n    </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Bucket"
+                        }
+                    }
+                },
+                "ExpectedBucketOwner": {
+                    "target": "com.amazonaws.s3#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The expected owner of the general purpose bucket that you want to retrieve the metadata table\n      configuration for.\n    </p>",
+                        "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.s3#GetBucketMetadataConfigurationResult": {
+            "type": "structure",
+            "members": {
+                "MetadataConfigurationResult": {
+                    "target": "com.amazonaws.s3#MetadataConfigurationResult",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The metadata configuration for a general purpose bucket.\n    </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n      The S3 Metadata configuration for a general purpose bucket.\n    </p>"
             }
         },
         "com.amazonaws.s3#GetBucketMetadataTableConfiguration": {
@@ -36287,6 +36638,23 @@
                 "target": "com.amazonaws.s3#InventoryConfiguration"
             }
         },
+        "com.amazonaws.s3#InventoryConfigurationState": {
+            "type": "enum",
+            "members": {
+                "ENABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ENABLED"
+                    }
+                },
+                "DISABLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DISABLED"
+                    }
+                }
+            }
+        },
         "com.amazonaws.s3#InventoryDestination": {
             "type": "structure",
             "members": {
@@ -36564,6 +36932,84 @@
                 "smithy.api#documentation": "<p>Specifies the schedule for generating inventory results.</p>"
             }
         },
+        "com.amazonaws.s3#InventoryTableConfiguration": {
+            "type": "structure",
+            "members": {
+                "ConfigurationState": {
+                    "target": "com.amazonaws.s3#InventoryConfigurationState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The configuration state of the inventory table, indicating whether the inventory table is enabled \n      or disabled.\n    </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "EncryptionConfiguration": {
+                    "target": "com.amazonaws.s3#MetadataTableEncryptionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The encryption configuration for the inventory table.\n    </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n      The inventory table configuration for an S3 Metadata configuration.\n    </p>"
+            }
+        },
+        "com.amazonaws.s3#InventoryTableConfigurationResult": {
+            "type": "structure",
+            "members": {
+                "ConfigurationState": {
+                    "target": "com.amazonaws.s3#InventoryConfigurationState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The configuration state of the inventory table, indicating whether the inventory table is enabled \n      or disabled.\n    </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TableStatus": {
+                    "target": "com.amazonaws.s3#MetadataTableStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The status of the inventory table. The status values are: </p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> - The inventory table is in the process of being created in the specified\n          Amazon Web Services managed table bucket.</p>\n            </li>\n            <li>\n               <p>\n                  <code>BACKFILLING</code> - The inventory table is in the process of being backfilled. When \n          you enable the inventory table for your metadata configuration, the table goes through a \n          process known as backfilling, during which Amazon S3 scans your general purpose bucket to retrieve \n          the initial metadata for all objects in the bucket. Depending on the number of objects in your \n          bucket, this process can take several hours. When the backfilling process is finished, the \n          status of your inventory table changes from <code>BACKFILLING</code> to <code>ACTIVE</code>. \n          After backfilling is completed, updates to your objects are reflected in the inventory table \n          within one hour.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - The inventory table has been created successfully, and records are being\n          delivered to the table. </p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> - Amazon S3 is unable to create the inventory table, or Amazon S3 is unable to deliver\n          records.</p>\n            </li>\n         </ul>"
+                    }
+                },
+                "Error": {
+                    "target": "com.amazonaws.s3#ErrorDetails"
+                },
+                "TableName": {
+                    "target": "com.amazonaws.s3#S3TablesName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The name of the inventory table.\n    </p>"
+                    }
+                },
+                "TableArn": {
+                    "target": "com.amazonaws.s3#S3TablesArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The Amazon Resource Name (ARN) for the inventory table.\n    </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n      The inventory table configuration for an S3 Metadata configuration.\n    </p>"
+            }
+        },
+        "com.amazonaws.s3#InventoryTableConfigurationUpdates": {
+            "type": "structure",
+            "members": {
+                "ConfigurationState": {
+                    "target": "com.amazonaws.s3#InventoryConfigurationState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The configuration state of the inventory table, indicating whether the inventory table is enabled \n      or disabled.\n    </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "EncryptionConfiguration": {
+                    "target": "com.amazonaws.s3#MetadataTableEncryptionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The encryption configuration for the inventory table.\n    </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n      The specified updates to the S3 Metadata inventory table configuration.\n    </p>"
+            }
+        },
         "com.amazonaws.s3#IsEnabled": {
             "type": "boolean"
         },
@@ -36624,6 +37070,80 @@
                 }
             }
         },
+        "com.amazonaws.s3#JournalTableConfiguration": {
+            "type": "structure",
+            "members": {
+                "RecordExpiration": {
+                    "target": "com.amazonaws.s3#RecordExpiration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The journal table record expiration settings for the journal table.\n    </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "EncryptionConfiguration": {
+                    "target": "com.amazonaws.s3#MetadataTableEncryptionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The encryption configuration for the journal table.\n    </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n      The journal table configuration for an S3 Metadata configuration.\n    </p>"
+            }
+        },
+        "com.amazonaws.s3#JournalTableConfigurationResult": {
+            "type": "structure",
+            "members": {
+                "TableStatus": {
+                    "target": "com.amazonaws.s3#MetadataTableStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The status of the journal table. The status values are: </p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> - The journal table is in the process of being created in the specified\n          table bucket.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - The journal table has been created successfully, and records are being\n          delivered to the table. </p>\n            </li>\n            <li>\n               <p>\n                  <code>FAILED</code> - Amazon S3 is unable to create the journal table, or Amazon S3 is unable to deliver\n          records.</p>\n            </li>\n         </ul>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Error": {
+                    "target": "com.amazonaws.s3#ErrorDetails"
+                },
+                "TableName": {
+                    "target": "com.amazonaws.s3#S3TablesName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The name of the journal table.\n    </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TableArn": {
+                    "target": "com.amazonaws.s3#S3TablesArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The Amazon Resource Name (ARN) for the journal table.\n    </p>"
+                    }
+                },
+                "RecordExpiration": {
+                    "target": "com.amazonaws.s3#RecordExpiration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The journal table record expiration settings for the journal table.\n    </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n      The journal table configuration for the S3 Metadata configuration.\n    </p>"
+            }
+        },
+        "com.amazonaws.s3#JournalTableConfigurationUpdates": {
+            "type": "structure",
+            "members": {
+                "RecordExpiration": {
+                    "target": "com.amazonaws.s3#RecordExpiration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The journal table record expiration settings for the journal table.\n    </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n      The specified updates to the S3 Metadata journal table configuration.\n    </p>"
+            }
+        },
         "com.amazonaws.s3#KMSContext": {
             "type": "string"
         },
@@ -36634,6 +37154,9 @@
             "type": "string"
         },
         "com.amazonaws.s3#KeyPrefixEquals": {
+            "type": "string"
+        },
+        "com.amazonaws.s3#KmsKeyArn": {
             "type": "string"
         },
         "com.amazonaws.s3#LambdaFunctionArn": {
@@ -38778,6 +39301,66 @@
                 "target": "com.amazonaws.s3#MetadataValue"
             }
         },
+        "com.amazonaws.s3#MetadataConfiguration": {
+            "type": "structure",
+            "members": {
+                "JournalTableConfiguration": {
+                    "target": "com.amazonaws.s3#JournalTableConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The journal table configuration for a metadata configuration.\n    </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "InventoryTableConfiguration": {
+                    "target": "com.amazonaws.s3#InventoryTableConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The inventory table configuration for a metadata configuration.\n    </p>"
+                    }
+                },
+                "AnnotationTableConfiguration": {
+                    "target": "com.amazonaws.s3#AnnotationTableConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Optional annotation table configuration to include with the metadata configuration.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n      The S3 Metadata configuration for a general purpose bucket.\n    </p>"
+            }
+        },
+        "com.amazonaws.s3#MetadataConfigurationResult": {
+            "type": "structure",
+            "members": {
+                "DestinationResult": {
+                    "target": "com.amazonaws.s3#DestinationResult",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The destination settings for a metadata configuration.\n    </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "JournalTableConfigurationResult": {
+                    "target": "com.amazonaws.s3#JournalTableConfigurationResult",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The journal table configuration for a metadata configuration.\n    </p>"
+                    }
+                },
+                "InventoryTableConfigurationResult": {
+                    "target": "com.amazonaws.s3#InventoryTableConfigurationResult",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The inventory table configuration for a metadata configuration.\n    </p>"
+                    }
+                },
+                "AnnotationTableConfigurationResult": {
+                    "target": "com.amazonaws.s3#AnnotationTableConfigurationResult",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The annotation table configuration result, if an annotation table is configured.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n      The S3 Metadata configuration for a general purpose bucket.\n    </p>"
+            }
+        },
         "com.amazonaws.s3#MetadataDirective": {
             "type": "enum",
             "members": {
@@ -38846,6 +39429,27 @@
             },
             "traits": {
                 "smithy.api#documentation": "<p>\n         The metadata table configuration for a general purpose bucket. The destination table bucket\n         must be in the same Region and Amazon Web Services account as the general purpose bucket. The specified metadata\n         table name must be unique within the <code>aws_s3_metadata</code> namespace in the destination \n         table bucket. \n      </p>"
+            }
+        },
+        "com.amazonaws.s3#MetadataTableEncryptionConfiguration": {
+            "type": "structure",
+            "members": {
+                "SseAlgorithm": {
+                    "target": "com.amazonaws.s3#TableSseAlgorithm",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The encryption type specified for a metadata table. To specify server-side encryption with \n      Key Management Service (KMS) keys (SSE-KMS), use the <code>aws:kms</code> value. To specify server-side \n      encryption with Amazon S3 managed keys (SSE-S3), use the <code>AES256</code> value. \n    </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "KmsKeyArn": {
+                    "target": "com.amazonaws.s3#KmsKeyArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      If server-side encryption with Key Management Service (KMS) keys (SSE-KMS) is specified, you must also\n      specify the KMS key Amazon Resource Name (ARN). You must specify a customer-managed KMS key \n      that's located in the same Region as the general purpose bucket that corresponds to the metadata \n      table configuration.\n    </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n      The encryption settings for an S3 Metadata journal table or inventory table configuration.\n    </p>"
             }
         },
         "com.amazonaws.s3#MetadataTableStatus": {
@@ -43384,6 +43988,30 @@
         "com.amazonaws.s3#RecordDelimiter": {
             "type": "string"
         },
+        "com.amazonaws.s3#RecordExpiration": {
+            "type": "structure",
+            "members": {
+                "Expiration": {
+                    "target": "com.amazonaws.s3#ExpirationState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      Specifies whether journal table record expiration is enabled or disabled.\n    </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Days": {
+                    "target": "com.amazonaws.s3#RecordExpirationDays",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      If you enable journal table record expiration, you can set the number of days to retain your \n      journal table records. Journal table records must be retained for a minimum of 7 days. To set \n      this value, specify any whole number from <code>7</code> to <code>2147483647</code>. For example, \n      to retain your journal table records for one year, set this value to <code>365</code>.\n    </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n      The journal table record expiration settings for a journal table in an S3 Metadata configuration.\n    </p>"
+            }
+        },
+        "com.amazonaws.s3#RecordExpirationDays": {
+            "type": "integer"
+        },
         "com.amazonaws.s3#RecordsEvent": {
             "type": "structure",
             "members": {
@@ -44312,6 +44940,23 @@
         "com.amazonaws.s3#S3TablesBucketArn": {
             "type": "string"
         },
+        "com.amazonaws.s3#S3TablesBucketType": {
+            "type": "enum",
+            "members": {
+                "aws": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "aws"
+                    }
+                },
+                "customer": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "customer"
+                    }
+                }
+            }
+        },
         "com.amazonaws.s3#S3TablesDestination": {
             "type": "structure",
             "members": {
@@ -45067,6 +45712,23 @@
         "com.amazonaws.s3#Suffix": {
             "type": "string"
         },
+        "com.amazonaws.s3#TableSseAlgorithm": {
+            "type": "enum",
+            "members": {
+                "aws_kms": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "aws:kms"
+                    }
+                },
+                "AES256": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AES256"
+                    }
+                }
+            }
+        },
         "com.amazonaws.s3#Tag": {
             "type": "structure",
             "members": {
@@ -45415,6 +46077,231 @@
         },
         "com.amazonaws.s3#URI": {
             "type": "string"
+        },
+        "com.amazonaws.s3#UpdateBucketMetadataAnnotationTableConfiguration": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.s3#UpdateBucketMetadataAnnotationTableConfigurationRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "traits": {
+                "aws.protocols#httpChecksum": {
+                    "requestAlgorithmMember": "ChecksumAlgorithm",
+                    "requestChecksumRequired": true
+                },
+                "smithy.api#documentation": "<p>Updates the annotation table configuration for an Amazon S3 bucket's metadata configuration. Use this\n      operation to enable or disable the annotation table, or to update its associated IAM role.</p>\n         <p>An annotation table is a queryable Iceberg table that contains records of all annotations\n      attached to objects in the bucket. To use this operation, the bucket must have an existing Amazon S3\n      Metadata configuration.</p>\n         <p>To use this operation, you must have the\n      <code>s3:UpdateBucketMetadataAnnotationTableConfiguration</code> permission. If you are specifying\n      or changing the IAM role, you must also have <code>iam:PassRole</code> permission for the role.</p>\n         <p>The IAM role must have a trust policy that allows the Amazon S3 metadata service to assume it, and a\n      permissions policy that grants the actions needed to read annotations from your bucket. The\n      following examples show a trust policy and a permissions policy that you can adapt for your bucket\n      and account.</p>\n         <p>The following operations are related to\n      <code>UpdateBucketMetadataAnnotationTableConfiguration</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketMetadataConfiguration.html\">CreateBucketMetadataConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetadataConfiguration.html\">GetBucketMetadataConfiguration</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/{Bucket}?metadataAnnotationTable",
+                    "code": 200
+                },
+                "smithy.rules#staticContextParams": {
+                    "UseS3ExpressControlEndpoint": {
+                        "value": true
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3#UpdateBucketMetadataAnnotationTableConfigurationRequest": {
+            "type": "structure",
+            "members": {
+                "Bucket": {
+                    "target": "com.amazonaws.s3#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the bucket whose annotation table configuration to update.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Bucket"
+                        }
+                    }
+                },
+                "ContentMD5": {
+                    "target": "com.amazonaws.s3#ContentMD5",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Base64-encoded MD5 digest of the message body.</p>",
+                        "smithy.api#httpHeader": "Content-MD5"
+                    }
+                },
+                "ChecksumAlgorithm": {
+                    "target": "com.amazonaws.s3#ChecksumAlgorithm",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Checksum algorithm for the request payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-sdk-checksum-algorithm"
+                    }
+                },
+                "AnnotationTableConfiguration": {
+                    "target": "com.amazonaws.s3#AnnotationTableConfigurationUpdates",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The annotation table configuration updates to apply.</p>",
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {},
+                        "smithy.api#xmlName": "AnnotationTableConfiguration"
+                    }
+                },
+                "ExpectedBucketOwner": {
+                    "target": "com.amazonaws.s3#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The account ID of the expected bucket owner.</p>",
+                        "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.s3#UpdateBucketMetadataInventoryTableConfiguration": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.s3#UpdateBucketMetadataInventoryTableConfigurationRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "traits": {
+                "aws.protocols#httpChecksum": {
+                    "requestAlgorithmMember": "ChecksumAlgorithm",
+                    "requestChecksumRequired": true
+                },
+                "smithy.api#documentation": "<p>Enables or disables a live inventory table for an S3 Metadata configuration on a general \n      purpose bucket. For more information, see\n      <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-overview.html\">Accelerating\n        data discovery with S3 Metadata</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <dl>\n            <dt>Permissions</dt>\n            <dd>\n               <p>To use this operation, you must have the following permissions. For more information, see\n            <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-permissions.html\">Setting up permissions for configuring metadata tables</a> in the\n            <i>Amazon S3 User Guide</i>.</p>\n               <p>If you want to encrypt your inventory table with server-side encryption with Key Management Service\n            (KMS) keys (SSE-KMS), you need additional permissions in your KMS key policy. For more\n            information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-permissions.html\">\n              Setting up permissions for configuring metadata tables</a> in the\n            <i>Amazon S3 User Guide</i>.</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>s3:UpdateBucketMetadataInventoryTableConfiguration</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>s3tables:CreateTableBucket</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>s3tables:CreateNamespace</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>s3tables:GetTable</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>s3tables:CreateTable</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>s3tables:PutTablePolicy</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>s3tables:PutTableEncryption</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>kms:DescribeKey</code>\n                     </p>\n                  </li>\n               </ul>\n            </dd>\n         </dl>\n         <p>The following operations are related to <code>UpdateBucketMetadataInventoryTableConfiguration</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketMetadataConfiguration.html\">CreateBucketMetadataConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetadataConfiguration.html\">DeleteBucketMetadataConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetadataConfiguration.html\">GetBucketMetadataConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataJournalTableConfiguration.html\">UpdateBucketMetadataJournalTableConfiguration</a>\n               </p>\n            </li>\n         </ul>\n         <important>\n            <p>You must URL encode any signed header values that contain spaces. For example, if your header value is <code>my  file.txt</code>, containing two spaces after <code>my</code>, you must URL encode this value to <code>my%20%20file.txt</code>.</p>\n         </important>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/{Bucket}?metadataInventoryTable",
+                    "code": 200
+                },
+                "smithy.rules#staticContextParams": {
+                    "UseS3ExpressControlEndpoint": {
+                        "value": true
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3#UpdateBucketMetadataInventoryTableConfigurationRequest": {
+            "type": "structure",
+            "members": {
+                "Bucket": {
+                    "target": "com.amazonaws.s3#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The general purpose bucket that corresponds to the metadata configuration that you want to \n      enable or disable an inventory table for.\n    </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Bucket"
+                        }
+                    }
+                },
+                "ContentMD5": {
+                    "target": "com.amazonaws.s3#ContentMD5",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The <code>Content-MD5</code> header for the inventory table configuration.\n    </p>",
+                        "smithy.api#httpHeader": "Content-MD5"
+                    }
+                },
+                "ChecksumAlgorithm": {
+                    "target": "com.amazonaws.s3#ChecksumAlgorithm",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The checksum algorithm to use with your inventory table configuration.\n    </p>",
+                        "smithy.api#httpHeader": "x-amz-sdk-checksum-algorithm"
+                    }
+                },
+                "InventoryTableConfiguration": {
+                    "target": "com.amazonaws.s3#InventoryTableConfigurationUpdates",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The contents of your inventory table configuration.      \n    </p>",
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {},
+                        "smithy.api#xmlName": "InventoryTableConfiguration"
+                    }
+                },
+                "ExpectedBucketOwner": {
+                    "target": "com.amazonaws.s3#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The expected owner of the general purpose bucket that corresponds to the metadata table \n      configuration that you want to enable or disable an inventory table for.\n    </p>",
+                        "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.s3#UpdateBucketMetadataJournalTableConfiguration": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.s3#UpdateBucketMetadataJournalTableConfigurationRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "traits": {
+                "aws.protocols#httpChecksum": {
+                    "requestAlgorithmMember": "ChecksumAlgorithm",
+                    "requestChecksumRequired": true
+                },
+                "smithy.api#documentation": "<p>Enables or disables journal table record expiration for an S3 Metadata configuration on a general \n      purpose bucket. For more information, see\n      <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-overview.html\">Accelerating\n        data discovery with S3 Metadata</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <dl>\n            <dt>Permissions</dt>\n            <dd>\n               <p>To use this operation, you must have the <code>s3:UpdateBucketMetadataJournalTableConfiguration</code>\n            permission. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-permissions.html\">Setting up permissions for\n              configuring metadata tables</a> in the <i>Amazon S3 User Guide</i>. </p>\n            </dd>\n         </dl>\n         <p>The following operations are related to <code>UpdateBucketMetadataJournalTableConfiguration</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketMetadataConfiguration.html\">CreateBucketMetadataConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetadataConfiguration.html\">DeleteBucketMetadataConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetadataConfiguration.html\">GetBucketMetadataConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_UpdateBucketMetadataInventoryTableConfiguration.html\">UpdateBucketMetadataInventoryTableConfiguration</a>\n               </p>\n            </li>\n         </ul>\n         <important>\n            <p>You must URL encode any signed header values that contain spaces. For example, if your header value is <code>my  file.txt</code>, containing two spaces after <code>my</code>, you must URL encode this value to <code>my%20%20file.txt</code>.</p>\n         </important>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/{Bucket}?metadataJournalTable",
+                    "code": 200
+                },
+                "smithy.rules#staticContextParams": {
+                    "UseS3ExpressControlEndpoint": {
+                        "value": true
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3#UpdateBucketMetadataJournalTableConfigurationRequest": {
+            "type": "structure",
+            "members": {
+                "Bucket": {
+                    "target": "com.amazonaws.s3#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The general purpose bucket that corresponds to the metadata configuration that you want to \n      enable or disable journal table record expiration for.\n    </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Bucket"
+                        }
+                    }
+                },
+                "ContentMD5": {
+                    "target": "com.amazonaws.s3#ContentMD5",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The <code>Content-MD5</code> header for the journal table configuration.\n    </p>",
+                        "smithy.api#httpHeader": "Content-MD5"
+                    }
+                },
+                "ChecksumAlgorithm": {
+                    "target": "com.amazonaws.s3#ChecksumAlgorithm",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The checksum algorithm to use with your journal table configuration.\n    </p>",
+                        "smithy.api#httpHeader": "x-amz-sdk-checksum-algorithm"
+                    }
+                },
+                "JournalTableConfiguration": {
+                    "target": "com.amazonaws.s3#JournalTableConfigurationUpdates",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The contents of your journal table configuration.\n    </p>",
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {},
+                        "smithy.api#xmlName": "JournalTableConfiguration"
+                    }
+                },
+                "ExpectedBucketOwner": {
+                    "target": "com.amazonaws.s3#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The expected owner of the general purpose bucket that corresponds to the metadata table \n      configuration that you want to enable or disable journal table record expiration for.      \n    </p>",
+                        "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
         },
         "com.amazonaws.s3#UploadIdMarker": {
             "type": "string"


### PR DESCRIPTION
## Summary

Add the six bucket metadata configuration operations to the S3 model, following up on the model refresh merged in #698. All operations get default stubs on the `S3Service` trait that return `NotImplemented` like the other operations.

## Changes

### `data/s3.json`

- +6 operations:
  - `CreateBucketMetadataConfiguration` (`POST /{Bucket}?metadataConfiguration`)
  - `DeleteBucketMetadataConfiguration` (`DELETE /{Bucket}?metadataConfiguration`)
  - `GetBucketMetadataConfiguration` (`GET /{Bucket}?metadataConfiguration`)
  - `UpdateBucketMetadataAnnotationTableConfiguration` (`PUT /{Bucket}?metadataAnnotationTable`)
  - `UpdateBucketMetadataInventoryTableConfiguration` (`PUT /{Bucket}?metadataInventoryTable`)
  - `UpdateBucketMetadataJournalTableConfiguration` (`PUT /{Bucket}?metadataJournalTable`)
- +29 shapes: request/response types, `MetadataConfiguration` and per-table configuration families (`AnnotationTableConfiguration`, `InventoryTableConfiguration`, `JournalTableConfiguration`), `MetadataTableEncryptionConfiguration`, `RecordExpiration`, `DestinationResult`, and supporting enums
- All changed shapes are byte-identical to upstream `db89911`

### Generated code (`just codegen`, aws + minio variants)

- dto: new input/output types and builders
- ops: HTTP deserialization, XML payload handling, router rules for the six new subresources
- s3_trait: six methods with `NotImplemented` stubs
- access: access hooks for each new operation
- s3s-aws conv/proxy: field wiring to `aws_sdk_s3`

### Codegen

- Extend the `has_unconditional_builder` list with the five new structs whose AWS SDK builders return the struct directly (`GetBucketMetadataConfigurationResult`, `JournalTableConfiguration`, `JournalTableConfigurationUpdates`, `MetadataConfiguration`, `MetadataConfigurationResult`)

### Route fixtures

- +12 entries for the six new router rules

## Verification

- `just codegen` idempotent (second run produces no diff)
- `just lint` clean
- `just test` 923 passed
- changed model shapes verified byte-identical to upstream `db89911`