### PR TITLE
fix(s3s): cap aws-chunked signed chunk size

### DIFF
--- a/crates/s3s/src/config.rs
+++ b/crates/s3s/src/config.rs
@@ -51,6 +51,9 @@ use crate::region::Region;
 // AWS-compatible default: https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html#PresignedUrl-Expiration
 pub(crate) const DEFAULT_PRESIGNED_URL_MAX_EXPIRES_SECS: u32 = 7 * 24 * 60 * 60;
 
+// Aligned with MinIO: https://github.com/minio/minio/blob/master/cmd/streaming-signature-v4.go
+pub(crate) const DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE: usize = 256 * 1024 * 1024;
+
 /// S3 Service Configuration Provider trait.
 ///
 /// This trait provides a `snapshot` method that returns an `Arc<S3Config>`.
@@ -112,6 +115,15 @@ pub struct S3Config {
     ///
     /// Default: 5 GB (5 * 1024 * 1024 * 1024)
     pub post_object_max_file_size: u64,
+
+    /// Maximum chunk data size for aws-chunked streaming uploads in bytes.
+    ///
+    /// Signed chunks must be buffered in full before their signature can be verified,
+    /// so this limit bounds the memory retained per chunk. Unsigned chunks are streamed
+    /// without buffering and are not subject to this limit.
+    ///
+    /// Default: 256 MB (256 * 1024 * 1024)
+    pub aws_chunked_stream_max_chunk_size: usize,
 
     /// Maximum size per form field in bytes.
     ///
@@ -194,8 +206,9 @@ impl Default for S3Config {
         Self {
             xml_max_body_size: 20 * 1024 * 1024,               // 20 MB
             post_object_max_file_size: 5 * 1024 * 1024 * 1024, // 5 GB
-            form_max_field_size: 1024 * 1024,                  // 1 MB
-            form_max_fields_size: 20 * 1024 * 1024,            // 20 MB
+            aws_chunked_stream_max_chunk_size: DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
+            form_max_field_size: 1024 * 1024,       // 1 MB
+            form_max_fields_size: 20 * 1024 * 1024, // 20 MB
             form_max_parts: 1000,
             presigned_url_max_skew_time_secs: 900, // 15 minutes
             expected_region: None,
@@ -405,6 +418,7 @@ mod tests {
         let config = S3Config {
             xml_max_body_size: 10 * 1024 * 1024,
             post_object_max_file_size: 1024 * 1024 * 1024,
+            aws_chunked_stream_max_chunk_size: DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
             form_max_field_size: 512 * 1024,
             form_max_fields_size: 5 * 1024 * 1024,
             form_max_parts: 500,

--- a/crates/s3s/src/http/aws_chunked_stream.rs
+++ b/crates/s3s/src/http/aws_chunked_stream.rs
@@ -105,6 +105,9 @@ pub enum AwsChunkedStreamError {
     /// Chunk metadata too large
     #[error("AwsChunkedStreamError: ChunkMetaTooLarge: size {0} exceeds limit {1}")]
     ChunkMetaTooLarge(usize, usize),
+    /// Chunk data too large
+    #[error("AwsChunkedStreamError: ChunkDataTooLarge: size {0} exceeds limit {1}")]
+    ChunkDataTooLarge(usize, usize),
     /// Trailers too large
     #[error("AwsChunkedStreamError: TrailersTooLarge: size {0} exceeds limit {1}")]
     TrailersTooLarge(usize, usize),
@@ -178,6 +181,7 @@ impl AwsChunkedStream {
         secret_key: SecretKey,
         decoded_content_length: usize,
         unsigned: bool,
+        max_chunk_size: usize,
     ) -> Self
     where
         S: Stream<Item = Result<Bytes, StdError>> + Send + Sync + 'static,
@@ -219,6 +223,10 @@ impl AwsChunkedStream {
                     };
 
                     tracing::trace!(?meta);
+
+                    if meta.signature.is_some() && meta.size > max_chunk_size {
+                        return Err(AwsChunkedStreamError::ChunkDataTooLarge(meta.size, max_chunk_size));
+                    }
 
                     let remaining_after_data = if let Some(expected_sig) = meta.signature {
                         let (data, remaining_bytes): (Vec<Bytes>, Bytes) = {
@@ -724,6 +732,7 @@ mod tests {
             "test-key".into(),
             6,
             true, // unsigned
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         tx.send(Ok(Bytes::from_static(b"6\r\nabc"))).await.unwrap();
@@ -757,6 +766,7 @@ mod tests {
             "test-key".into(),
             6,
             true, // unsigned
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         tx.send(Ok(Bytes::from_static(b"6\r\nabcdef"))).await.unwrap();
@@ -784,6 +794,7 @@ mod tests {
                 "test-key".into(),
                 6,
                 true, // unsigned
+                crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
             )
         };
 
@@ -853,10 +864,61 @@ mod tests {
             "test-key".into(),
             256,
             false, // signed
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         let result = chunked_stream.next().await;
         assert!(matches!(result, Some(Err(AwsChunkedStreamError::Underlying(_)))));
+    }
+
+    #[tokio::test]
+    async fn signed_chunk_rejects_oversized_declaration() {
+        // Declares 16 bytes but the limit is 8; the signed path buffers whole
+        // chunks, so the declaration is rejected before any data is read.
+        let chunk_meta = b"10;chunk-signature=0000000000000000000000000000000000000000000000000000000000000000\r\n";
+        let chunk_data = b"short";
+        let chunk1 = join(&[chunk_meta, chunk_data]);
+        let chunk_results = vec![Ok(chunk1)];
+
+        let stream = futures::stream::iter(chunk_results);
+        let mut chunked_stream = AwsChunkedStream::new(
+            stream,
+            Sha256Sum::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+            AmzDate::parse("20130524T000000Z").unwrap(),
+            "us-east-1".into(),
+            "s3".into(),
+            "test-key".into(),
+            16,
+            false,
+            8,
+        );
+
+        let result = chunked_stream.next().await;
+        assert!(matches!(result, Some(Err(AwsChunkedStreamError::ChunkDataTooLarge(16, 8)))));
+    }
+
+    #[tokio::test]
+    async fn unsigned_chunk_accepts_oversized_declaration() {
+        // Unsigned chunks are streamed without buffering and are not subject to the limit.
+        let chunk1 = join(&[b"10\r\n", b"0123456789abcdef\r\n", b"0\r\n\r\n"]);
+        let chunk_results = vec![Ok(chunk1)];
+
+        let stream = futures::stream::iter(chunk_results);
+        let mut chunked_stream = AwsChunkedStream::new(
+            stream,
+            Sha256Sum::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+            AmzDate::parse("20130524T000000Z").unwrap(),
+            "us-east-1".into(),
+            "s3".into(),
+            "test-key".into(),
+            16,
+            true, // unsigned
+            8,
+        );
+
+        let data = chunked_stream.next().await.unwrap().unwrap();
+        assert_eq!(data.as_ref(), b"0123456789abcdef");
+        assert!(chunked_stream.next().await.is_none());
     }
 
     fn join(bytes: &[&[u8]]) -> Bytes {
@@ -902,6 +964,7 @@ mod tests {
             secret_access_key.into(),
             decoded_content_length,
             false,
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         let ans1 = chunked_stream.next().await.unwrap();
@@ -956,6 +1019,7 @@ mod tests {
             secret_access_key.into(),
             decoded_content_length,
             false,
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         let ans1 = chunked_stream.next().await.unwrap();
@@ -1020,6 +1084,7 @@ mod tests {
             secret_access_key.into(),
             decoded_content_length,
             true, // unsigned
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         let ans1 = chunked_stream.next().await.unwrap();
@@ -1072,6 +1137,7 @@ mod tests {
             secret_access_key.into(),
             decoded_content_length,
             true, // unsigned
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         let ans1 = chunked_stream.next().await.unwrap();
@@ -1107,6 +1173,7 @@ mod tests {
             "test-key".into(),
             0,
             true, // unsigned
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         let result = chunked_stream.next().await.unwrap();
@@ -1133,6 +1200,7 @@ mod tests {
             "test-key".into(),
             16,
             true,
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         // Stream ends without proper chunk metadata
@@ -1162,6 +1230,7 @@ mod tests {
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
             5,
             false, // signed mode
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         let result = chunked_stream.next().await.unwrap();
@@ -1191,6 +1260,7 @@ mod tests {
             "test-key".into(),
             256,
             true,
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         let result = chunked_stream.next().await;
@@ -1225,6 +1295,7 @@ mod tests {
             "test-key".into(),
             256,
             false,
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         let result = chunked_stream.next().await;
@@ -1254,6 +1325,7 @@ mod tests {
             "test-key".into(),
             0,
             true,
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         let result = chunked_stream.next().await.unwrap();
@@ -1292,6 +1364,7 @@ mod tests {
             "test-key".into(),
             5,
             false, // signed mode - should require signatures
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         let result = chunked_stream.next().await.unwrap();
@@ -1325,6 +1398,7 @@ mod tests {
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
             3,
             true, // unsigned chunks but signed trailer
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         let ans1 = chunked_stream.next().await.unwrap();
@@ -1362,6 +1436,7 @@ mod tests {
             "test-key".into(),
             3,
             true,
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         let ans1 = chunked_stream.next().await.unwrap();
@@ -1421,6 +1496,7 @@ mod tests {
             secret_access_key.into(),
             decoded_content_length,
             true, // unsigned
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         let ans1 = chunked_stream.next().await.unwrap();
@@ -1463,6 +1539,7 @@ mod tests {
             secret_access_key.into(),
             0,
             true, // unsigned
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         // Should get an error due to meta size limit
@@ -1522,6 +1599,7 @@ mod tests {
             secret_access_key.into(),
             decoded_content_length,
             true, // unsigned
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         // Read the chunk data
@@ -1607,6 +1685,7 @@ mod tests {
             secret_access_key.into(),
             decoded_content_length,
             true, // unsigned
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
         // Read the chunk data

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -639,6 +639,7 @@ impl SignatureContext<'_> {
                 secret_key.clone(),
                 decoded_content_length,
                 unsigned,
+                self.config.snapshot().aws_chunked_stream_max_chunk_size,
             );
 
             debug!(len=?stream.exact_remaining_length(), "aws-chunked");


### PR DESCRIPTION
## Summary

For aws-chunked uploads, the chunk size is declared by the client with no upper bound (parsed as a u32 hex, up to ~4 GiB). Signed chunks must be buffered in full before their signature can be verified, so a malicious or misconfigured client can force the server to retain gigabytes per chunk. This PR adds a configurable cap (`S3Config::aws_chunked_stream_max_chunk_size`, default 256 MiB, aligned with MinIO) and rejects oversized signed chunk declarations with a dedicated error before any payload is read.

Unsigned chunks are not subject to the limit: they carry nothing to verify and are streamed without buffering, so capping them would only break SDKs that send the whole payload as a single unsigned chunk for trailing checksums — the exact problem MinIO hit when it capped all chunks at 16 MiB.

## Changes

- `config.rs`: add `S3Config::aws_chunked_stream_max_chunk_size` backed by the `pub(crate)` constant `DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE` (256 MiB, aligned with MinIO); the struct is `#[serde(default)]` + `#[non_exhaustive]`, so this is additive.
- `http/aws_chunked_stream.rs`
  - `AwsChunkedStream::new` takes `max_chunk_size`; after parsing the chunk meta and before reading any payload, a chunk that carries a signature and declares a size above the limit fails with the new `AwsChunkedStreamError::ChunkDataTooLarge { size, limit }`.
  - Unsigned chunks keep the existing behavior and are not rejected.
- `ops/signature.rs`: the call site passes `config.aws_chunked_stream_max_chunk_size` from the config snapshot.

## Impact

- Memory DoS hardening: the retained memory per signed chunk is now bounded by the configured limit instead of the client-declared u32.
- Behavioral: oversized signed chunks now fail with `ChunkDataTooLarge` (clear message, mirrors MinIO's `errChunkTooBig`) instead of being buffered; nothing is yielded before the rejection.
- Compatibility: default 256 MiB accommodates large signed chunks while blocking absurd ones; unsigned payloads (e.g. SDK trailing-checksum uploads) are unaffected.
- Public API: `S3Config` gains one additive field; `AwsChunkedStreamError` gains one variant (crate-private module).

## Verification

- `just dev` (fetch → fmt → codegen → lint → test) — passes end-to-end, working tree clean after codegen.
- `cargo fmt --all --check` — clean.
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean.
- New tests: `signed_chunk_rejects_oversized_declaration` (16-byte declaration against an 8-byte limit errors before any yield) and `unsigned_chunk_accepts_oversized_declaration` (same declaration streams through); all existing AWS-doc chunk/trailer signature vectors still pass.
- `just semver-checks` — pending (requires published crates.io baselines).
- E2E — handled by CI; not run locally (per repo policy).
