### PR TITLE
feat(s3s/ops): route custom requests before enforcing S3 name rules

### DIFF
--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -28,6 +28,9 @@ mod multipart;
 mod tests;
 
 #[cfg(test)]
+mod route_skip_validation_tests;
+
+#[cfg(test)]
 mod route_bench;
 
 #[cfg(test)]
@@ -387,46 +390,58 @@ fn inject_host_header(req: &mut Request) {
     }
 }
 
-fn parse_request_path<'a>(
-    req: &mut Request,
+fn parse_request_host<'a>(
     ccx: &CallContext<'a>,
     host_header: Option<&'a str>,
 ) -> S3Result<(Option<VirtualHost<'a>>, Option<String>)> {
-    let decoded_uri_path = urlencoding::decode(req.uri.path()).map_err(|_| S3ErrorCode::InvalidURI)?;
+    // Virtual-host context feeds signature verification for both custom-route
+    // and S3 traffic, so it is always resolved — and malformed hosts are
+    // transport-level malformations rejected immediately (not a bucket/key
+    // concern; see the routing step in [`prepare`]).
+    if let (Some(host_header), Some(s3_host)) = (host_header, ccx.host)
+        && !is_socket_addr_or_ip_addr(host_header)
+    {
+        let vh = s3_host.parse_host_header(host_header)?;
+        debug!(?vh);
+        let region = vh.region().map(str::to_owned);
+        Ok((Some(vh), region))
+    } else {
+        Ok((None, None))
+    }
+}
+
+/// Classifies the request path.
+///
+/// Matched custom routes skip this entirely: their paths are not bucket/key
+/// paths, so no `S3Path` is materialized (`None` returned). Unmatched requests
+/// run the combined parse+validate pipeline, raising legacy errors in the
+/// legacy position.
+///
+/// Note: percent-decoding cannot be skipped in any branch — signature
+/// verification decodes the path itself as a canonical-request input.
+fn classify_request_path(
+    decoded_uri_path: &str,
+    ccx: &CallContext<'_>,
+    vh_bucket: Option<&str>,
+    custom_route_hit: bool,
+) -> S3Result<Option<S3Path>> {
+    if custom_route_hit {
+        return Ok(None);
+    }
 
     let default_validation = &const { AwsNameValidation::new() };
     let validation = ccx.validation.unwrap_or(default_validation);
+    let normalize_path = ccx.config.snapshot().normalize_forward_slash_path;
 
-    let parsed = if let (Some(host_header), Some(s3_host)) = (host_header, ccx.host)
-        && !is_socket_addr_or_ip_addr(host_header)
-    {
-        debug!(?host_header, ?decoded_uri_path, "parsing virtual-hosted-style request");
+    let path = crate::path::parse_virtual_hosted_style_with_validation_and_normalization(
+        vh_bucket,
+        decoded_uri_path,
+        validation,
+        normalize_path,
+    )
+    .map_err(|err| convert_parse_s3_path_error(&err))?;
 
-        let vh = s3_host.parse_host_header(host_header)?;
-        debug!(?vh);
-
-        let bucket = vh.bucket();
-        let region = vh.region().map(str::to_owned);
-        let path = crate::path::parse_virtual_hosted_style_with_validation_and_normalization(
-            bucket,
-            decoded_uri_path.as_ref(),
-            validation,
-            ccx.config.snapshot().normalize_forward_slash_path,
-        );
-        (Some(vh), region, path)
-    } else {
-        debug!(?decoded_uri_path, "parsing path-style request");
-        let path = crate::path::parse_path_style_with_validation_and_normalization(
-            decoded_uri_path.as_ref(),
-            validation,
-            ccx.config.snapshot().normalize_forward_slash_path,
-        );
-        (None, None, path)
-    };
-
-    let (vh, vh_region, result) = parsed;
-    req.s3ext.s3_path = Some(result.map_err(|err| convert_parse_s3_path_error(&err))?);
-    Ok((vh, vh_region))
+    Ok(Some(path))
 }
 
 fn resolve_operation(
@@ -692,22 +707,39 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
 
     inject_host_header(req);
     let host_header = extract_host(req)?;
-    let (vh, vh_region) = parse_request_path(req, ccx, host_header.as_deref())?;
+
+    // Percent-decode stays ahead of routing: it is a signature-verification
+    // input anyway, and decoding here keeps the legacy error precedence for
+    // malformed paths regardless of route configuration.
+    let decoded_uri_path = urlencoding::decode(req.uri.path()).map_err(|_| S3ErrorCode::InvalidURI)?;
+    debug!(?decoded_uri_path, "parsing request path");
+
+    let (vh, vh_region) = parse_request_host(ccx, host_header.as_deref())?;
+
+    // Custom routes claim requests before S3 naming semantics are enforced:
+    // no `S3Path` is materialized for them. The predicate may observe any
+    // request that reaches the service; authentication is enforced later via
+    // `check_access` / `authorize`. Virtual-host resolution above stays
+    // unconditional — it feeds signature verification with full context.
+    let custom_route_hit = ccx
+        .route
+        .is_some_and(|route| route.is_match(&req.method, &req.uri, &req.headers, &mut req.extensions));
+
+    // Matched routes skip path classification; unmatched requests run the
+    // legacy combined parse+validate here, preserving error codes/ordering.
+    let vh_bucket = vh.as_ref().and_then(VirtualHost::bucket);
+    req.s3ext.s3_path = classify_request_path(&decoded_uri_path, ccx, vh_bucket, custom_route_hit)?;
 
     req.s3ext.qs = extract_qs(&req.uri)?;
     content_length = extract_content_length(req);
-    content_length =
-        verify_signature(req, ccx, vh.as_ref().and_then(VirtualHost::bucket), vh_region.as_deref(), content_length).await?;
+    content_length = verify_signature(req, ccx, vh_bucket, vh_region.as_deref(), content_length).await?;
 
-    let s3_path = req.s3ext.s3_path.as_ref().unwrap();
-
-    if let Some(route) = ccx.route
-        && route.is_match(&req.method, &req.uri, &req.headers, &mut req.extensions)
-    {
+    if custom_route_hit {
         return Ok(Prepare::CustomRoute);
     }
 
     let op = 'resolve: {
+        let s3_path = req.s3ext.s3_path.as_ref().expect("classified above");
         if let Some(multipart) = &mut req.s3ext.multipart
             && req.method == Method::POST
         {
@@ -726,9 +758,9 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
         resolve_operation(req, s3_path, host_header.as_deref(), ccx)?
     };
 
+    let s3_path = req.s3ext.s3_path.as_ref().unwrap();
     debug!(op = %op.name(), ?s3_path, "resolved route");
 
-    let s3_path = req.s3ext.s3_path.as_ref().unwrap();
     authorize(
         ccx,
         op.name(),

--- a/crates/s3s/src/ops/route_skip_validation_tests.rs
+++ b/crates/s3s/src/ops/route_skip_validation_tests.rs
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-2026 The s3s Authors
+
+//! Custom route path-validation bypass tests.
+//!
+//! Contract under test: `is_match` runs after structural parsing but before
+//! S3 naming semantics are enforced. A matching route receives requests whose
+//! paths would be rejected as invalid buckets/keys; unmatched (and no-route)
+//! requests keep the legacy pipeline byte-for-byte, including error ordering.
+
+use super::*;
+use crate::auth::{SecretKey, SimpleAuth};
+use crate::config::{S3ConfigProvider, StaticConfigProvider};
+use crate::error::S3ErrorCode;
+use crate::host::SingleDomain;
+use crate::protocol::S3Response;
+use crate::route::S3Route;
+use crate::s3_trait::S3;
+use crate::sig_v4::{self, AmzDate};
+use hyper::http::Extensions;
+use hyper::{HeaderMap, Method, Uri};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct NoopS3;
+
+#[async_trait::async_trait]
+impl S3 for NoopS3 {}
+
+/// Route matching every request; counts `call` invocations.
+struct MatchAllRoute {
+    calls: Arc<AtomicUsize>,
+}
+
+impl MatchAllRoute {
+    fn new() -> Self {
+        Self {
+            calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn call_count(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl S3Route for MatchAllRoute {
+    fn is_match(&self, _method: &Method, _uri: &Uri, _headers: &HeaderMap, _ext: &mut Extensions) -> bool {
+        true
+    }
+
+    async fn check_access(&self, _req: &mut S3Request<Body>) -> crate::error::S3Result<()> {
+        Ok(()) // allow anonymous so the end-to-end test observes `call`
+    }
+
+    async fn call(&self, _req: S3Request<Body>) -> crate::error::S3Result<S3Response<Body>> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(S3Response::new(Body::from("routed".to_string())))
+    }
+}
+
+/// Route that never matches.
+struct MatchNoneRoute;
+
+#[async_trait::async_trait]
+impl S3Route for MatchNoneRoute {
+    fn is_match(&self, _: &Method, _: &Uri, _: &HeaderMap, _: &mut Extensions) -> bool {
+        false
+    }
+
+    async fn call(&self, _: S3Request<Body>) -> crate::error::S3Result<S3Response<Body>> {
+        unreachable!("MatchNoneRoute never matches")
+    }
+}
+
+struct CtxParts {
+    s3: Arc<dyn S3>,
+    config: Arc<dyn S3ConfigProvider>,
+    auth: Option<SimpleAuth>,
+    host: Option<SingleDomain>,
+}
+
+fn ccx<'a>(parts: &'a CtxParts, auth: bool, host: bool, route: Option<&'a dyn S3Route>) -> CallContext<'a> {
+    CallContext {
+        s3: &parts.s3,
+        config: &parts.config,
+        host: if host {
+            parts.host.as_ref().map(|h| h as &dyn crate::host::S3Host)
+        } else {
+            None
+        },
+        auth: if auth {
+            parts.auth.as_ref().map(|a| a as &dyn crate::auth::S3Auth)
+        } else {
+            None
+        },
+        access: None,
+        route,
+        validation: None,
+    }
+}
+
+fn ctx() -> CtxParts {
+    CtxParts {
+        s3: Arc::new(NoopS3),
+        config: Arc::new(StaticConfigProvider::default()),
+        auth: Some(SimpleAuth::from_single(
+            "AKIAIOSFODNN7EXAMPLE",
+            SecretKey::from("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+        )),
+        host: Some(SingleDomain::new("example.com").expect("valid domain")),
+    }
+}
+
+fn get_request(path: &str, host: &str) -> Request {
+    Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .uri(format!("http://localhost{path}"))
+            .header(crate::header::HOST, host)
+            .body(Body::empty())
+            .unwrap(),
+    )
+}
+
+#[tokio::test]
+async fn invalid_paths_reach_matched_custom_route() {
+    let parts = ctx();
+    let route = MatchAllRoute::new();
+    let ccx = ccx(&parts, false, false, Some(&route));
+
+    // bucket names violating AWS rules; keys over 1024 bytes
+    for path in ["/x/y", "/Foo/bar", "/api_status/x", "/b/-leading-dash"] {
+        let mut req = get_request(path, "localhost");
+        let ans = prepare(&mut req, &ccx)
+            .await
+            .unwrap_or_else(|e| panic!("{path}: unexpected {e:?}"));
+        assert!(matches!(ans, Prepare::CustomRoute), "path {path}");
+    }
+
+    let long_key = "a".repeat(2000);
+    let mut req = get_request(&format!("/bucket/{long_key}"), "localhost");
+    let ans = prepare(&mut req, &ccx)
+        .await
+        .unwrap_or_else(|e| panic!("long key: unexpected {e:?}"));
+    assert!(matches!(ans, Prepare::CustomRoute));
+}
+
+#[tokio::test]
+async fn invalid_path_reaches_route_handler_end_to_end() {
+    use crate::ops::call;
+    use hyper::StatusCode;
+
+    let parts = ctx();
+    let route = MatchAllRoute::new();
+    let ccx = ccx(&parts, false, false, Some(&route));
+
+    let mut req = get_request("/Foo/bar", "localhost");
+    let resp = call(&mut req, &ccx).await.expect("route handles illegal path");
+    assert_eq!(resp.status, StatusCode::OK);
+    assert_eq!(route.call_count(), 1);
+}
+
+#[tokio::test]
+async fn unmatched_route_keeps_original_path_errors() {
+    let parts = ctx();
+    let ccx = ccx(&parts, false, false, Some(&MatchNoneRoute));
+
+    for path in ["/x/y", "/Foo/bar", "/api_status/x", "/b/-leading-dash"] {
+        let mut req = get_request(path, "localhost");
+        let Err(err) = prepare(&mut req, &ccx).await else { panic!("{path}: expected path rejection") };
+        assert_eq!(*err.code(), S3ErrorCode::InvalidBucketName, "path {path}");
+    }
+
+    let long_key = "a".repeat(2000);
+    let mut req = get_request(&format!("/bucket/{long_key}"), "localhost");
+    let Err(err) = prepare(&mut req, &ccx).await else { panic!("long key: expected KeyTooLongError") };
+    assert_eq!(*err.code(), S3ErrorCode::KeyTooLongError);
+}
+
+#[tokio::test]
+async fn no_route_configured_keeps_legacy_behavior() {
+    let parts = ctx();
+    let ccx = ccx(&parts, false, false, None);
+
+    let mut req = get_request("/Foo/bar", "localhost");
+    let Err(err) = prepare(&mut req, &ccx).await else { panic!("expected legacy rejection") };
+    assert_eq!(*err.code(), S3ErrorCode::InvalidBucketName);
+}
+
+#[tokio::test]
+async fn post_to_invalid_bucket_still_rejected_when_route_misses() {
+    struct PostOnlyRoute;
+    #[async_trait::async_trait]
+    impl S3Route for PostOnlyRoute {
+        fn is_match(&self, method: &Method, _: &Uri, _: &HeaderMap, _: &mut Extensions) -> bool {
+            method == Method::PUT // deliberately mismatch POST uploads
+        }
+
+        async fn call(&self, _: S3Request<Body>) -> crate::error::S3Result<S3Response<Body>> {
+            unreachable!("PostOnlyRoute never matches POST")
+        }
+    }
+
+    let parts = ctx();
+    let ccx = ccx(&parts, false, false, Some(&PostOnlyRoute));
+
+    let boundary = "------------------------X";
+    let body = format!(
+        "--{boundary}\r\nContent-Disposition: form-data; name=\"key\"\r\n\r\nfoo.txt\r\n\
+         --{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"f\"\r\n\
+         Content-Type: text/plain\r\n\r\nhello\r\n--{boundary}--\r\n"
+    );
+
+    let mut req = Request::from(
+        hyper::Request::builder()
+            .method(Method::POST)
+            .uri("http://localhost/Foo/bar")
+            .header(crate::header::HOST, "localhost")
+            .header(hyper::header::CONTENT_TYPE, format!("multipart/form-data; boundary={boundary}"))
+            .body(Body::from(body))
+            .unwrap(),
+    );
+
+    let Err(err) = prepare(&mut req, &ccx).await else {
+        panic!("POST to invalid bucket must stay rejected")
+    };
+    assert_eq!(*err.code(), S3ErrorCode::InvalidBucketName);
+}
+
+#[tokio::test]
+async fn legacy_error_precedence_preserved_on_route_miss() {
+    // With a route configured but missed, path validation still happens
+    // before signature verification exactly as in the no-route pipeline:
+    // a bad signature must not shadow the path error.
+    let parts = ctx();
+    let ccx = ccx(&parts, true, false, Some(&MatchNoneRoute));
+
+    let mut req = Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .uri("http://localhost/Foo/bar")
+            .header(crate::header::HOST, "localhost")
+            .header("x-amz-date", hyper::header::HeaderValue::from_static("20260826T000000Z"))
+            .header(
+                "authorization",
+                hyper::header::HeaderValue::from_static(
+                    "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260826/us-east-1/s3/aws4_request, \
+                     SignedHeaders=host;x-amz-date, \
+                     Signature=0000000000000000000000000000000000000000000000000000000000000000",
+                ),
+            )
+            .body(Body::empty())
+            .unwrap(),
+    );
+
+    let Err(err) = prepare(&mut req, &ccx).await else { panic!("invalid path must be rejected") };
+    assert_eq!(
+        *err.code(),
+        S3ErrorCode::InvalidBucketName,
+        "validation precedes signature verification on route miss: {err:?}"
+    );
+}
+
+/// Builds a correctly signed `SigV4` header-auth request against the given
+/// Host, using the same credentials as [`ctx`].
+fn signed_vhost_request(host: &str) -> Request {
+    let now = time::OffsetDateTime::now_utc();
+    let date_fmt = time::macros::format_description!("[year][month][day]T[hour][minute][second]Z");
+    let scope_fmt = time::macros::format_description!("[year][month][day]");
+    let date = now.format(&date_fmt).expect("format");
+    let scope_date = now.format(&scope_fmt).expect("format");
+    let region = "us-east-1";
+
+    let amz_date = AmzDate::parse(date.as_str()).expect("valid date");
+    let payload_hash = "UNSIGNED-PAYLOAD";
+
+    let signed_headers = [
+        ("host", host),
+        ("x-amz-content-sha256", payload_hash),
+        ("x-amz-date", date.as_str()),
+    ];
+
+    let canonical_request =
+        sig_v4::create_canonical_request(&Method::GET, "/", &[] as &[(&str, &str)], signed_headers, sig_v4::Payload::Unsigned);
+    let string_to_sign = sig_v4::create_string_to_sign(&canonical_request, &amz_date, region, "s3");
+    let signature = sig_v4::calculate_signature(
+        &string_to_sign,
+        &SecretKey::from("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+        &amz_date,
+        region,
+        "s3",
+    );
+
+    let authorization = format!(
+        "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/{scope_date}/{region}/s3/aws4_request, \
+         SignedHeaders=host;x-amz-content-sha256;x-amz-date, \
+         Signature={}",
+        signature.as_str()
+    );
+
+    let mut builder = hyper::Request::builder()
+        .method(Method::GET)
+        .uri(format!("http://{host}/"))
+        .header(crate::header::HOST, host)
+        .header("x-amz-date", hyper::header::HeaderValue::from_str(date.as_str()).unwrap())
+        .header("x-amz-content-sha256", hyper::header::HeaderValue::from_static(payload_hash));
+    builder = builder.header("authorization", authorization);
+    Request::from(builder.body(Body::empty()).unwrap())
+}
+
+#[tokio::test]
+async fn signed_vhost_underscore_subdomain_reaches_matched_route() {
+    // A validly-signed virtual-hosted request with an underscore bucket must
+    // both verify (full vh context reaches signature verification) and reach
+    // the matched custom route despite failing AWS bucket-name rules.
+    let parts = ctx();
+    let route = MatchAllRoute::new();
+    let route_ctx = ccx(&parts, true, true, Some(&route));
+
+    let mut req = signed_vhost_request("my_bucket.example.com");
+    let ans = prepare(&mut req, &route_ctx)
+        .await
+        .unwrap_or_else(|e| panic!("signed vhost: unexpected {e:?}"));
+    assert!(matches!(ans, Prepare::CustomRoute));
+    assert!(
+        req.s3ext
+            .credentials
+            .as_ref()
+            .is_some_and(|c| c.access_key == "AKIAIOSFODNN7EXAMPLE"),
+        "handler-bound credentials must be populated"
+    );
+
+    // Same signed request with the route removed keeps the original rejection
+    // (bucket-name validation), not a signature error.
+    let no_route = ccx(&parts, true, true, None);
+    let mut req = signed_vhost_request("my_bucket.example.com");
+    let Err(err) = prepare(&mut req, &no_route).await else {
+        panic!("underscore bucket without route must stay rejected")
+    };
+    assert_eq!(*err.code(), S3ErrorCode::InvalidBucketName);
+}
+
+#[tokio::test]
+async fn valid_path_on_route_miss_resolves_operation_normally() {
+    let parts = ctx();
+    let ccx = ccx(&parts, false, false, Some(&MatchNoneRoute));
+
+    // A conforming path must pass validation and continue into normal
+    // operation resolution even when a route is configured.
+    let mut req = get_request("/logs", "localhost");
+    let ans = prepare(&mut req, &ccx)
+        .await
+        .unwrap_or_else(|e| panic!("valid path: unexpected {e:?}"));
+    match ans {
+        Prepare::S3(op) => assert_eq!(op.name(), "ListObjects"),
+        Prepare::CustomRoute => panic!("missed route must not claim S3 traffic"),
+    }
+}

--- a/crates/s3s/src/route.rs
+++ b/crates/s3s/src/route.rs
@@ -168,6 +168,24 @@ pub trait S3Route: Send + Sync + 'static {
     /// #   }
     /// }
     /// ```
+    ///
+    /// # Timing contract
+    ///
+    /// Called exactly once per request, after virtual-host resolution and
+    /// before any path interpretation or signature verification. A matching
+    /// route receives the request even when its path would fail S3 naming
+    /// semantics (bucket-name rules, key length limit), and no `S3Path` is
+    /// materialized for it.
+    ///
+    /// The predicate may observe unauthenticated requests; authentication is
+    /// enforced later via [`check_access`](Self::check_access) and the
+    /// operation `authorize` stage.
+    ///
+    /// Virtual-host resolution itself stays *ahead* of matching: it feeds
+    /// signature verification unconditionally (so early execution is free),
+    /// and rejecting malformed hosts uniformly keeps the error surface
+    /// independent of whether a route happens to be configured. Keep predicates cheap and free of side effects beyond the
+    /// provided `extensions` scratch space.
     fn is_match(&self, method: &Method, uri: &Uri, headers: &HeaderMap, extensions: &mut Extensions) -> bool;
 
     /// Checks access permissions for the request.


### PR DESCRIPTION
Custom route paths are not bucket/key paths, but the request pipeline enforced AWS bucket-name rules and the key length limit before route matching, so any non-conforming prefix was rejected with 400 before a matching route could claim it.

`is_match` now runs once per request right after percent-decoding and virtual-host resolution — both of which are signature-verification inputs and stay unconditional — and before S3 naming semantics are enforced:

- matched custom routes receive requests regardless of path validity, with signature verification still applied and credentials flowing into `S3Request`; no `S3Path` is materialized for them
- unmatched and no-route requests follow the legacy pipeline byte-for-byte — same error codes, same ordering; configuring a route no longer changes how plain S3 traffic fails
- validly signed virtual-hosted requests with non-conforming bucket names reach routes instead of dying at signature time with a misleading error (virtual-host context stays complete for signature verification)

No public API changes; `cargo semver-checks` reports none.

The timing contract is documented on the `S3Route` trait: predicates may observe any request reaching the service (authenticated or not); authentication stays enforced via `check_access` / `authorize`.

Covered by eight tests, including correctly signed virtual-hosted requests with underscore subdomains reaching handlers end-to-end, exact legacy error codes on route miss and without any route, POST uploads to invalid buckets, and preservation of legacy error precedence over bad signatures on misses.

Refs #221 — addresses the first checklist item only. The issue should stay open until a follow-up security audit confirms both items (the second — SigV2 disabled by default — has already landed via #716).