### PR TITLE
fix(s3s/utils): rewrite digit() to reject non-digits safely

### DIFF
--- a/crates/s3s/src/sig_v4/authorization_v4.rs
+++ b/crates/s3s/src/sig_v4/authorization_v4.rs
@@ -205,6 +205,20 @@ mod tests {
     }
 
     #[test]
+    fn credential_with_non_digit_date_does_not_panic() {
+        // Regression for the fuzz-discovered panic in `utils::parser::digit`:
+        // a non-digit byte in the credential date used to underflow below
+        // `b'0'` in overflow-checked builds.
+        let auth = concat!(
+            "AWS4-HMAC-SHA256 ",
+            "Credential=AKIAIOSFODNN7EXAMPLE/201%0524/us-east-1/s3/aws4_request,",
+            "SignedHeaders=host,",
+            "Signature=fe5f80f77d5fa3beca038a248ff027d0445342fe2855ddc963176630326f1024",
+        );
+        assert!(AuthorizationV4::parse(auth).is_err());
+    }
+
+    #[test]
     fn special_20200921() {
         let auth = concat!(
             "AWS4-HMAC-SHA256 ",

--- a/crates/s3s/src/utils/parser.rs
+++ b/crates/s3s/src/utils/parser.rs
@@ -5,7 +5,10 @@ pub struct Error;
 
 #[inline(always)]
 fn digit(c: u8) -> Result<u8, Error> {
-    c.is_ascii_digit().then_some(c - b'0').ok_or(Error)
+    match c {
+        b'0'..=b'9' => Ok(c - b'0'),
+        _ => Err(Error),
+    }
 }
 
 #[inline(always)]
@@ -30,4 +33,33 @@ where
     let (remaining, output) = f(*input)?;
     *input = remaining;
     Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digit_accepts_ascii_digits() {
+        for c in b'0'..=b'9' {
+            assert!(matches!(digit(c), Ok(v) if v == c - b'0'));
+        }
+    }
+
+    #[test]
+    fn digit_rejects_non_digit_without_overflow() {
+        // Regression for the fuzz-discovered panic: the subtraction used to
+        // be eager, so bytes below b'0' underflowed in overflow-checked
+        // builds.
+        for c in [b'%', 0x01, 0x00, 0x2f, 0x3a, 0x7f, 0xff, b'a'] {
+            assert!(digit(c).is_err(), "byte {c:#04x} must be rejected");
+        }
+    }
+
+    #[test]
+    fn digit2_digit4_reject_non_digit() {
+        assert!(digit2(*b"1%").is_err());
+        assert!(digit4(*b"201%").is_err());
+        assert!(digit4(*b"20\x014").is_err());
+    }
 }


### PR DESCRIPTION
## Summary

`utils::parser::digit` converts a single ASCII digit byte into its numeric value. It previously used `is_ascii_digit().then_some(c - b'0')`, which evaluates the subtraction eagerly: for any non-digit byte below `b'0'` the `u8` subtraction underflows and panics in overflow-checked builds (and silently wraps otherwise).

Rewrite `digit` as an explicit `match` over `b'0'..=b'9'`. The subtraction now runs only inside the matched arm for genuine digits, so non-digit bytes are rejected outright with no arithmetic involved.

## Background

Found by the `syntax_parsers` fuzz target: a SigV4 `Authorization` header carrying a non-digit byte in the credential date field (for example `Credential=AKIAIOSFODNN7EXAMPLE/201%0524/...`) triggered the panic while parsing the date.

## Changes

- `crates/s3s/src/utils/parser.rs`: rewrite `digit` as an explicit match; add unit tests for `digit`, `digit2`, and `digit4`.
- `crates/s3s/src/sig_v4/authorization_v4.rs`: add a regression test reproducing the exact fuzz crash shape.

## Validation

Run on `fix/utils-digit-lazy` (head `6b3dec1`):

- `cargo test -p s3s --lib utils::parser` → 3 passed: `digit_accepts_ascii_digits`, `digit_rejects_non_digit_without_overflow`, `digit2_digit4_reject_non_digit`.
- `cargo test -p s3s --lib sig_v4::authorization_v4` → 4 passed, including the new regression `credential_with_non_digit_date_does_not_panic` plus `auth_header`, `special_20200921`, `special_20230204`.
- `just codegen` → idempotent, no generated diff.
- `just lint` → clean, zero warnings (including `--all-targets` test code).
- `just test` → full workspace, 962 passed, 0 failed.
- `just dev` (fetch/fmt/codegen/lint/test) → exit 0, end to end.

All new and existing parser and SigV4 authorization tests pass.
