### PR TITLE
ci: split MSRV into a standalone test-only rust-msrv job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,19 @@ jobs:
       - run: just ci-python
       - run: just spdx-check
 
+  rust-msrv:
+    needs: skip-check
+    if: needs.skip-check.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: taiki-e/install-action@just
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.96.0 # MSRV
+      - uses: Swatinem/rust-cache@v2
+      - run: just test
+
   rust:
     needs: skip-check
     if: needs.skip-check.outputs.should_skip != 'true'
@@ -46,7 +59,6 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-          - 1.96.0 # MSRV
           - stable
           - nightly
     steps:
@@ -250,6 +262,7 @@ jobs:
     if: always()
     needs:
       - python
+      - rust-msrv
       - rust
       - cross-test
       - wasm-test


### PR DESCRIPTION
## Summary

The `rust` job currently runs the full `just ci-rust` (fmt + clippy + test + codegen) on all three toolchains (MSRV 1.96.0, stable, nightly). The MSRV leg only needs to verify that the crate compiles and tests pass on the minimum supported Rust version — fmt/clippy/codegen are stable-toolchain concerns. This extracts the MSRV leg into its own `rust-msrv` job that runs `just test` directly, narrowing the `rust` matrix to `stable` + `nightly`.

## Background

From issue #679 Finding 14, the three-toolchain matrix multiplies the expensive CI validation redundantly. The MSRV leg's fmt/clippy/codegen are pure redundancy: MSRV is a compile+test release promise (`rust-version = 1.96.0` in Cargo.toml). Splitting it out removes that redundancy while keeping merge-gate coverage intact. This PR deliberately extracts only the MSRV job; the full three-way split (explicit `rust-stable` / `rust-nightly` jobs with codegen folded into stable) is out of scope here.

## Changes

- `.github/workflows/ci.yml`: add a standalone `rust-msrv` job (toolchain `1.96.0`, `# MSRV`) that runs `just test`; narrow the `rust` matrix to `stable` + `nightly`; add `rust-msrv` to the `status-check` needs list.
- `justfile`: no new recipe; `rust-msrv` invokes `just test` directly (the `ci-rust-msrv` recipe was dropped per review).

## Validation

- `actionlint .github/workflows/ci.yml` passes with exit 0 (no errors/warnings) — this is the real GitHub Actions semantic check (job references, `needs`, step fields, shells), not just a YAML syntax parse.
- Merge-gate coverage preserved: fmt `--check` and clippy `-D warnings` still run once on `rust-stable`; workspace test still runs on `rust-msrv` + `rust-stable` (and nightly as a non-blocking canary); codegen idempotence still runs on `rust-stable` via `just ci-rust`; MSRV compile+test is preserved; nightly `continue-on-error` is preserved; `status-check` aggregates `rust-msrv` and `rust`.
- No change to the e2e jobs, cross-test, wasm-test, or coverage gates.

Refs #679
