### PR TITLE
ci(fuzz): add PR fmt/lint gate

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -22,6 +22,9 @@ jobs:
   # malformed fuzz target could land without any CI signal.
   fuzz-check:
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      actions: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -52,7 +55,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          components: llvm-tools, clippy
+          components: llvm-tools, clippy, rustfmt
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,6 +1,13 @@
 name: Fuzz
 
 on:
+  pull_request:
+    branches:
+      - main
+      - 'feat/**'
+    paths:
+      - 'fuzz/**'
+      - '.github/workflows/fuzz.yml'
   schedule:
     - cron: '0 0 * * 0' # weekly at 00:00 UTC on Sunday
   workflow_dispatch:
@@ -10,7 +17,32 @@ permissions:
   actions: write
 
 jobs:
-  fuzz:
+  # Lightweight fmt + clippy gate for PRs that touch fuzz/. The fuzz/ tree is a
+  # separate cargo workspace not covered by the root ci.yml, so without this a
+  # malformed fuzz target could land without any CI signal.
+  fuzz-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: taiki-e/install-action@just
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: fuzz
+
+      - name: Format and lint
+        run: just -f fuzz/justfile ci-check
+
+  # Weekly actual fuzzing (schedule / manual dispatch only).
+  fuzz-run:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -20,7 +52,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          components: llvm-tools
+          components: llvm-tools, clippy
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
The `fuzz/` tree is a separate cargo workspace not covered by the root `ci.yml`. The existing `fuzz.yml` only runs `just ci-check` (formatting + clippy) plus a 30-minute actual fuzzing run on the weekly schedule / manual dispatch, so a PR that touches `fuzz/` has no CI signal at all — a broken fuzz target could merge unnoticed.

This adds a lightweight `fuzz-check` job gated to `pull_request` (with a `paths` filter on `fuzz/**`), which runs `just -f fuzz/justfile ci-check` only. The existing weekly fuzzing job is kept but now restricted to non-PR events so PRs don't trigger the heavy run. fmt and clippy both use nightly (cargo-fuzz requires it); the `fuzz/justfile` stays the single source of truth for the lint commands. As a drive-by fix, the weekly job's toolchain now also installs the `clippy` component, which its own `just ci-check` step already required.

Refs #730
