### PR TITLE
ci(fuzz): fix gh token, cargo-fuzz install, and gnu fuzz target

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -61,8 +61,14 @@ jobs:
         with:
           workspaces: fuzz
 
+      # Installs the latest cargo-fuzz release: `tool` is left unpinned on
+      # purpose so it never goes stale. `with: tool:` keeps the name explicit,
+      # so a Dependabot bump of the action ref (e.g. @cargo-fuzz -> @v2.x)
+      # cannot drop it.
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@cargo-fuzz
+        with:
+          tool: cargo-fuzz
 
       - name: Format and lint
         run: just ci-check
@@ -70,6 +76,8 @@ jobs:
 
       - name: Find previous run carrying the corpus
         id: previous-run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Crashes fail the job (strict policy), so runs are usually red; the
           # corpus artifact is uploaded with if: always(), so pick the latest
@@ -78,7 +86,7 @@ jobs:
           # otherwise contaminate the corpus across code versions.
           run_id="$(
             gh api "repos/${{ github.repository }}/actions/workflows/fuzz.yml/runs" \
-              --jq '[.workflow_runs[] | select(.status == "completed" and .head_branch == "${{ github.event.repository.default_branch }}") | .id][0]'
+              --jq '[.workflow_runs[] | select(.status == "completed" and .head_branch == "${{ github.event.repository.default_branch || 'main' }}") | .id][0]'
           )"
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
 
@@ -92,7 +100,7 @@ jobs:
         continue-on-error: true
 
       - name: Build fuzz targets
-        run: cargo +nightly fuzz build
+        run: cargo +nightly fuzz build --target x86_64-unknown-linux-gnu
         working-directory: fuzz
 
       - name: Fuzz for 30 minutes

--- a/fuzz/justfile
+++ b/fuzz/justfile
@@ -39,9 +39,9 @@ ci-run target FEATURES="" BUDGET="1800":
     if [ -d "seeds/{{target}}" ]; then
         cp -n seeds/{{target}}/* "corpus/{{target}}/" || true
     fi
-    cargo +nightly fuzz run {{target}} {{FEATURES}} -- "merged/{{target}}" "corpus/{{target}}" -merge=1 -close_fd_mask=3 || true
+    cargo +nightly fuzz run {{target}} {{FEATURES}} --target x86_64-unknown-linux-gnu -- "merged/{{target}}" "corpus/{{target}}" -merge=1 -close_fd_mask=3 || true
     if [ -n "$(ls -A "merged/{{target}}" 2>/dev/null)" ]; then
         rm -rf "corpus/{{target}}"
         mv "merged/{{target}}" "corpus/{{target}}"
     fi
-    cargo +nightly fuzz run {{target}} {{FEATURES}} -- -max_total_time={{BUDGET}} -print_final_stats=1
+    cargo +nightly fuzz run {{target}} {{FEATURES}} --target x86_64-unknown-linux-gnu -- -max_total_time={{BUDGET}} -print_final_stats=1


### PR DESCRIPTION
## Background

The `fuzz-run` job of the `fuzz` workflow (schedule / manual dispatch) was failing. Two distinct root causes were found across iterations.

### 1. `gh` exited with code 4

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
```

The `Find previous run carrying the corpus` step calls `gh api` without `GH_TOKEN` set, so `gh` aborts before resolving the previous run that carries the accumulated corpus.

### 2. cargo-fuzz was not installed

Dependabot had rewritten `taiki-e/install-action@cargo-fuzz` (an `@<tool>` action ref) into a version tag, dropping the tool name. `INPUT_TOOL` ended up empty, so cargo-fuzz was never actually installed — the later `cargo +nightly fuzz build` would have failed.

### 3. cargo-fuzz built for musl, incompatible with AddressSanitizer

On the GitHub-hosted `ubuntu` runner cargo-fuzz uses the **host target triple**, which is `x86_64-unknown-linux-musl`. AddressSanitizer (used by cargo-fuzz) is incompatible with musl's statically linked libc, so `cargo +nightly fuzz build` failed with:

```
error: sanitizer is incompatible with statically linked libc, disable it using `-C target-feature=-crt-static`
error[E0463]: can't find crate for `core` (the `x86_64-unknown-linux-musl` target may not be installed)
```

Note: `CARGO_BUILD_TARGET` does **not** influence cargo-fuzz (verified locally — forcing a non-host triple still builds for the host), so the target must be passed explicitly via `--target`.

## Changes

- Set `env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` on the `Find previous run carrying the corpus` step so `gh api` can authenticate.
- Add `with: tool: cargo-fuzz` to `Install cargo-fuzz`. The tool is intentionally left unpinned so install-action always fetches the latest cargo-fuzz release (no long-term staleness); `with: tool:` also survives Dependabot bumps of the action ref.
- Pass `--target x86_64-unknown-linux-gnu` explicitly to `cargo +nightly fuzz build` (in `fuzz.yml`) and to both `cargo +nightly fuzz run` invocations in `fuzz/justfile` `ci-run`.
- Add `|| 'main'` fallback to the `head_branch` filter: scheduled runs have no `github.event.repository` payload, so the original expression resolved to an empty default branch and could never locate prior runs (breaking corpus restore).
- Remove the earlier `CARGO_BUILD_TARGET` attempt — it is ignored by cargo-fuzz and ineffective.

## Permissions

Job-level `permissions` stays `contents: read` + `actions: write`. `actions: write` is required: `actions/upload-artifact@v4` needs it to create artifacts, and downgrading to `actions: read` would break corpus upload. The token exposure surface is bounded by the existing `if: github.event_name != 'pull_request'` gate (fork PR code never runs with the token).

## Verification

- Run `33053847573` completed **success**: `cargo +nightly fuzz build --target x86_64-unknown-linux-gnu` compiled cleanly, and the 30-minute `cargo +nightly fuzz run` finished with no panic/crash. This confirmed the infra fixes (gh token, cargo-fuzz install, gnu target) end to end.
- Run `33059162783` then **failed by design**: the fuzzer found a real crash in `fuzz_targets/xml_bodies.rs:73` — `AccessControlPolicy: ser∘de is not idempotent` (S3 ACL serde roundtrip not idempotent). The crash input was uploaded as a `fuzz-artifacts` artifact. This is the intended strict policy (crashes fail the job) and is a separate product bug, not a workflow defect.

Refs #86
