### PR TITLE
feat(s3s/post_policy): substitute ${filename} in the key field of POST uploads

### DIFF
--- a/crates/s3s/src/http/multipart.rs
+++ b/crates/s3s/src/http/multipart.rs
@@ -81,15 +81,46 @@ impl Multipart {
     /// Finds field value
     #[must_use]
     pub fn find_field_value<'a>(&'a self, name: &str) -> Option<&'a str> {
-        let upper_bound = self.fields.partition_point(|x| x.0.as_str() <= name);
+        let idx = Self::find_field_index(&self.fields, name)?;
+        Some(self.fields[idx].1.as_str())
+    }
+
+    fn find_field_value_mut<'a>(fields: &'a mut [(String, String)], name: &str) -> Option<&'a mut String> {
+        let idx = Self::find_field_index(fields, name)?;
+        Some(&mut fields[idx].1)
+    }
+
+    fn find_field_index(fields: &[(String, String)], name: &str) -> Option<usize> {
+        let upper_bound = fields.partition_point(|x| x.0.as_str() <= name);
         if upper_bound == 0 {
             return None;
         }
-        let pair = &self.fields[upper_bound - 1];
+        let idx = upper_bound - 1;
+        let pair = &fields[idx];
         if pair.0.as_str() != name {
             return None;
         }
-        Some(pair.1.as_str())
+        Some(idx)
+    }
+
+    /// Substitutes the `${filename}` variable in the `key` field with the
+    /// filename supplied by the file part, per the AWS POST upload contract:
+    /// <https://docs.aws.amazon.com/AmazonS3/latest/developerguide/sigv4-HTTPPOSTConstructPolicy.html>
+    ///
+    /// Amazon S3 replaces the variable verbatim and defines no escaping
+    /// mechanism, so a key containing a literal `${filename}` cannot be
+    /// uploaded through POST — this matches AWS behavior. Callers must invoke
+    /// this before evaluating POST policy conditions so that `eq`/`starts-with`
+    /// constraints on `$key` apply to the final substituted key.
+    pub(crate) fn substitute_key_filename(&mut self) {
+        const FILENAME_VARIABLE: &str = "${filename}";
+        let file_name = &self.file.name;
+        let Some(key) = Self::find_field_value_mut(&mut self.fields, "key") else {
+            return;
+        };
+        if key.contains(FILENAME_VARIABLE) {
+            *key = key.replace(FILENAME_VARIABLE, file_name);
+        }
     }
 
     /// Create a Multipart for testing purposes
@@ -779,6 +810,54 @@ mod tests {
         }
 
         Ok(buf.into())
+    }
+
+    fn test_file(name: &str) -> File {
+        File {
+            name: name.to_owned(),
+            content_type: None,
+            stream: None,
+        }
+    }
+
+    #[test]
+    fn substitute_key_filename_replaces_variable_before_policy_checks() {
+        let mut m = Multipart::new_for_test(
+            vec![
+                ("key".to_owned(), "user/betty/${filename}".to_owned()),
+                ("policy".to_owned(), "policy-data".to_owned()),
+            ],
+            test_file("photo1.jpg"),
+        );
+        m.substitute_key_filename();
+        assert_eq!(m.find_field_value("key"), Some("user/betty/photo1.jpg"));
+
+        // Every occurrence is substituted, matching a verbatim replace.
+        let mut m =
+            Multipart::new_for_test(vec![("key".to_owned(), "${filename}/copies/${filename}".to_owned())], test_file("a.txt"));
+        m.substitute_key_filename();
+        assert_eq!(m.find_field_value("key"), Some("a.txt/copies/a.txt"));
+    }
+
+    #[test]
+    fn substitute_key_filename_leaves_plain_keys_and_other_fields_alone() {
+        let mut m = Multipart::new_for_test(
+            vec![
+                ("key".to_owned(), "plain-key.txt".to_owned()),
+                ("success_action_redirect".to_owned(), "https://example.com/${filename}".to_owned()),
+            ],
+            test_file("photo1.jpg"),
+        );
+        m.substitute_key_filename();
+        assert_eq!(m.find_field_value("key"), Some("plain-key.txt"));
+        // Only the key field participates in the substitution contract.
+        assert_eq!(m.find_field_value("success_action_redirect"), Some("https://example.com/${filename}"));
+
+        // No key field at all: nothing to do (the missing-key error is
+        // reported later by input deserialization).
+        let mut m = Multipart::new_for_test(vec![("policy".to_owned(), "policy-data".to_owned())], test_file("photo1.jpg"));
+        m.substitute_key_filename();
+        assert_eq!(m.find_field_value("key"), None);
     }
 
     #[test]

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -558,6 +558,10 @@ async fn resolve_post_object(
 ) -> S3Result<(crate::stream::DynByteStream, Option<PostPolicy>)> {
     debug!(?multipart);
 
+    // Substitute `${filename}` in the key field before the policy conditions
+    // are evaluated, so `$key` constraints apply to the final key.
+    multipart.substitute_key_filename();
+
     let policy = parse_post_policy(multipart)?;
     let max_file_size = post_object_max_file_size(policy.as_ref(), ccx.config.snapshot().post_object_max_file_size);
 

--- a/crates/s3s/src/post_policy.rs
+++ b/crates/s3s/src/post_policy.rs
@@ -765,6 +765,42 @@ mod tests {
         assert_eq!(e.code(), &S3ErrorCode::InvalidPolicyDocument);
     }
 
+    /// Regression test for <https://github.com/rustfs/rustfs/issues/6177>:
+    /// policy conditions on `$key` must be evaluated against the key AFTER
+    /// `${filename}` substitution, matching the AWS POST contract.
+    #[test]
+    fn test_validate_conditions_apply_to_substituted_key() {
+        let json = r#"{
+            "expiration": "2030-01-01T00:00:00.000Z",
+            "conditions": [
+                {"bucket": "mybucket"},
+                ["starts-with", "$key", "user/betty/"]
+            ]
+        }"#;
+        let policy = PostPolicy::from_json(json).unwrap();
+
+        let mut multipart = create_test_multipart(vec![("key", "user/betty/${filename}")], None);
+
+        // The raw key with the unsubstituted variable happens to satisfy this
+        // prefix, but an `eq` condition would not — validate against the
+        // substituted key, which is what the stored object will be named.
+        multipart.substitute_key_filename();
+        assert_eq!(multipart.find_field_value("key"), Some("user/betty/test.txt"));
+        assert!(policy.validate_conditions_only(&multipart, 0, Some("mybucket")).is_ok());
+
+        let eq_json = r#"{
+            "expiration": "2030-01-01T00:00:00.000Z",
+            "conditions": [
+                {"bucket": "mybucket"},
+                ["eq", "$key", "user/betty/test.txt"]
+            ]
+        }"#;
+        let eq_policy = PostPolicy::from_json(eq_json).unwrap();
+        let mut multipart = create_test_multipart(vec![("key", "user/betty/${filename}")], None);
+        multipart.substitute_key_filename();
+        assert!(eq_policy.validate_conditions_only(&multipart, 0, Some("mybucket")).is_ok());
+    }
+
     /// Regression test for <https://github.com/rustfs/rustfs/issues/1785>
     /// `validate_conditions_only` with `url_bucket` should work for boto3-style policies.
     #[test]


### PR DESCRIPTION
## Related Issues

Ports rustfs/s3s#22 to upstream s3s-project/s3s.

Fixes rustfs/rustfs#6177 (the s3s half; RustFS can pick it up via a rev bump once this merges).

## Summary of Changes

Amazon S3 replaces the `${filename}` variable in the `key` form field of a POST upload with the filename supplied by the file part's Content-Disposition, and evaluates POST policy conditions against the substituted key. s3s previously stored the literal `${filename}` as part of the object key.

- `Multipart::substitute_key_filename` replaces every occurrence of `${filename}` in the `key` field with the parsed file-part filename.
- `resolve_post_object` invokes it before policy validation, so `eq` and `starts-with` conditions on `$key` constrain the final substituted key exactly as AWS does. The POST signature is computed over the base64 policy field and is unaffected.
- Only the `key` field participates in the substitution. AWS defines no escaping mechanism, so a literal `${filename}` in a POST key remains unrepresentable; this matches Amazon S3 behavior and is documented on the method.
- Key validity is unchanged: whatever filename the client supplies passes through the same key validation as any directly PUT key.

## Verification

- `cargo fmt --all --check`
- `git diff --check upstream/main...HEAD`
- `cargo test -p s3s --lib` (819 passed, 3 ignored)
- `cargo clippy -p s3s --all-targets`
