### PR TITLE
fix(s3s/ops): clarify multipart POST routing for object paths

### DIFF
--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -832,7 +832,11 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
                         req.s3ext.post_policy = policy;
                         break 'resolve &PostObject as &'static dyn Operation;
                     }
-                    // FIXME: POST /bucket/key hits this branch
+                    // A multipart POST whose path names an object is not a modeled S3
+                    // operation: `PostObject` binds to `/{Bucket}` only — the key is
+                    // carried by the `key` form field, never the URL path. AWS and
+                    // MinIO reject such requests with `MethodNotAllowed`; keep that
+                    // behavior.
                     S3Path::Object { .. } => return Err(s3_error!(MethodNotAllowed)),
                 }
             }

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -1082,6 +1082,40 @@ async fn post_multipart_bucket_routes_to_post_object() {
     }
 }
 
+/// A multipart POST whose path names an object is not a modeled S3
+/// operation: `PostObject` binds to `/{Bucket}` only — the key is carried by
+/// the form fields, never the URL path. AWS and `MinIO` reject such requests
+/// with `MethodNotAllowed`; this test locks the behavior.
+#[tokio::test]
+async fn post_multipart_object_path_rejected_as_method_not_allowed() {
+    use crate::auth::SecretKey;
+    use std::sync::Arc;
+
+    let s3: Arc<dyn crate::s3_trait::S3> = Arc::new(post_policy_test_helpers::TestS3NoOp);
+    let config = post_policy_test_helpers::create_test_config(1024 * 1024);
+    let auth = post_policy_test_helpers::create_test_auth();
+    let ccx = post_policy_test_helpers::create_test_context(&s3, &config, &auth);
+
+    let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
+    let policy_json = &format!(
+        r#"{{"expiration":"2030-01-01T00:00:00.000Z","conditions":[{}]}}"#,
+        post_policy_test_helpers::BASE_CONDITIONS,
+    );
+    let mut req = post_policy_test_helpers::build_post_object_request(policy_json, "hello", &secret_key, false);
+    // Reroute the request to the object level: `POST /bucket/key`.
+    req.uri = req
+        .uri
+        .to_string()
+        .replace("/test-bucket", "/test-bucket/test-key")
+        .parse()
+        .expect("valid test URI");
+
+    let Err(err) = super::prepare(&mut req, &ccx).await else {
+        panic!("multipart POST to an object path must be rejected");
+    };
+    assert_eq!(err.code(), &crate::error::S3ErrorCode::MethodNotAllowed);
+}
+
 // Helper functions for POST policy resource exhaustion tests
 
 /// Helper to create a test S3 service that tracks POST calls


### PR DESCRIPTION
## Problem

`ops::prepare` carries a misleading `FIXME` comment on the branch that rejects multipart `POST` requests whose path names an object (`S3Path::Object`) with `MethodNotAllowed`. The comment suggests the branch is an accidental fallthrough ("POST /bucket/key hits this branch"), inviting a "fix" that would route such requests to `PostObject`.

## Investigation

That behavior is correct, and routing them to `PostObject` would be wrong:

- The S3 model defines no POST operation on `/{Bucket}/{Key+}` without a subresource: the only object-level POST operations require `?uploads`, `?restore`, `?select&select-type=2`, or `?uploadId`.
- `PostObject` is a synthetic s3s operation bound to `/{Bucket}` only — the object key is carried by the `key` form field, never the URL path (AWS POST Object request syntax, and `${filename}` substitution both operate on the form field).
- MinIO (the AWS-compatible reference used in s3s E2E) rejects the same request shape explicitly: its PostPolicy handler checks that the URL does not contain an object name and returns `ErrMethodNotAllowed` (405) otherwise.
- The Ceph s3-tests suite posts every `test_post_object_*` case to `{endpoint}/{bucket}` only.

## Fix

- `ops::prepare`: replace the `FIXME` comment with an explanatory note documenting why `MethodNotAllowed` is returned, referencing `PostObject` binding to `/{Bucket}` and the AWS/MinIO parity.
- `ops::tests`: add a regression test (`post_multipart_object_path_rejected_as_method_not_allowed`) that builds a signed multipart POST Object request, reroutes it to `/bucket/key`, and asserts `prepare` fails with `MethodNotAllowed`.

## Verification

- `just dev` green (fetch / fmt / codegen idempotent / lint zero warnings / full test suite).

No behavior change: the branch returned `MethodNotAllowed` before and after; the regression test locks it in.
