### PR TITLE
feat(s3s/ops): add optional streaming object-size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,13 @@ The data types, serialization and deserialization are generated from the smithy 
 
 ## Security
 
-`S3Service` and other adapters in this project have no security protection. If they are exposed to the Internet directly, they may be **attacked**.
+`S3Service` and other adapters in this project are not a complete security boundary. If they are exposed to the Internet directly, they may be **attacked**.
 
 It is up to the user to implement security enhancements such as **HTTP body length limits**, object-size limits, rate limits and back pressure.
 
 **Authentication is required for production deployments.** Without calling `set_auth`, the service accepts anonymous (unsigned) requests and skips authorization entirely: every S3 operation is open to any client that can reach the service, and signed requests fail with `NotImplemented` because no authentication provider is configured. A forgotten `set_auth` turns the service into a publicly readable and writable endpoint.
+
+For streaming uploads (`PUT Object`, `UploadPart`), `s3s` does not impose an object-size limit by default. If `S3Config::put_object_max_size` is not configured, the `S3` implementation is responsible for enforcing deployment-specific object caps. `POST Object` keeps using `S3Config::post_object_max_file_size`.
 
 ## Docker
 

--- a/codegen/src/v1/ops.rs
+++ b/codegen/src/v1/ops.rs
@@ -335,6 +335,15 @@ fn codegen_post_object_fork_op(rust_types: &RustTypes) {
     g(["    fn name(&self) -> &'static str {", "        \"PostObject\"", "    }", ""]);
     g(["    fn needs_full_body(&self) -> bool {", "        false", "    }", ""]);
     g(["    fn has_request_payload(&self) -> bool {", "        true", "    }", ""]);
+    g([
+        "    fn has_streaming_body(&self) -> bool {",
+        "        // POST Object's body is the multipart file stream governed by",
+        "        // `post_object_max_file_size`, not the request body wrapped by",
+        "        // `put_object_max_size`.",
+        "        false",
+        "    }",
+        "",
+    ]);
 
     g([
         "    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {",
@@ -941,6 +950,11 @@ fn codegen_op_http_call(op: &Operation, rust_types: &RustTypes) {
     g!("}}");
     g!();
 
+    g!("fn has_streaming_body(&self) -> bool {{");
+    g!("{}", has_streaming_body(op, rust_types));
+    g!("}}");
+    g!();
+
     g!("async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {{");
 
     let method = op.name.to_snake_case();
@@ -1139,6 +1153,23 @@ fn needs_full_body(op: &Operation, rust_types: &RustTypes) -> bool {
 fn has_request_payload(op: &Operation, rust_types: &RustTypes) -> bool {
     let rust::Type::Struct(ty) = &rust_types[op.input.as_str()] else { return false };
     ty.fields.iter().any(|field| field.position == "payload")
+}
+
+/// Whether the operation streams a request body directly to the `S3`
+/// implementation without buffering: its input carries a `StreamingBlob`
+/// payload (`PutObject`, `UploadPart`, `WriteGetObjectResponse`).
+fn has_streaming_body(op: &Operation, rust_types: &RustTypes) -> bool {
+    if op.name == "PostObject" {
+        // Synthetic operation: the body is the multipart file stream governed
+        // by `post_object_max_file_size`, not the request body wrapped by
+        // `put_object_max_size`.
+        return false;
+    }
+
+    let rust::Type::Struct(ty) = &rust_types[op.input.as_str()] else { panic!() };
+    ty.fields
+        .iter()
+        .any(|field| field.position == "payload" && field.type_ == "StreamingBlob")
 }
 
 #[allow(clippy::too_many_lines)]

--- a/crates/s3s/src/config.rs
+++ b/crates/s3s/src/config.rs
@@ -23,11 +23,13 @@
 //! // Using custom config values
 //! let mut config = S3Config::default();
 //! config.xml_max_body_size = 10 * 1024 * 1024;
+//! config.put_object_max_size = Some(5 * 1024 * 1024 * 1024);
 //!
 //! // Using static config provider (immutable)
 //! let static_provider = Arc::new(StaticConfigProvider::new(Arc::new(config.clone())));
 //! let snapshot = static_provider.snapshot();
 //! assert_eq!(snapshot.xml_max_body_size, 10 * 1024 * 1024);
+//! assert_eq!(snapshot.put_object_max_size, Some(5 * 1024 * 1024 * 1024));
 //!
 //! // Using hot-reload config provider (can be updated at runtime)
 //! let hot_reload_provider = Arc::new(HotReloadConfigProvider::default());
@@ -90,6 +92,13 @@ pub trait S3ConfigProvider: Send + Sync + 'static {
 /// Contains configurable parameters for the S3 service with sensible defaults.
 /// The configuration is immutable after creation.
 ///
+/// Streaming uploads such as `PUT Object` and `UploadPart` are not capped by
+/// default. When [`S3Config::put_object_max_size`] is unset, the
+/// [`S3`](crate::S3) implementation is responsible for enforcing object-size
+/// limits for those streams. Set it only when the adapter should enforce an
+/// opt-in deployment hardening limit before handing the stream to the
+/// implementation.
+///
 /// Use with [`StaticConfigProvider`] or [`HotReloadConfigProvider`].
 ///
 /// # Example
@@ -99,11 +108,13 @@ pub trait S3ConfigProvider: Send + Sync + 'static {
 ///
 /// let mut config = S3Config::default();
 /// config.xml_max_body_size = 10 * 1024 * 1024;
+/// config.put_object_max_size = Some(5 * 1024 * 1024 * 1024);
 ///
 /// // Wrap in StaticConfigProvider for immutable config
 /// let static_provider = Arc::new(StaticConfigProvider::new(Arc::new(config.clone())));
 /// let snapshot = static_provider.snapshot();
 /// assert_eq!(snapshot.xml_max_body_size, 10 * 1024 * 1024);
+/// assert_eq!(snapshot.put_object_max_size, Some(5 * 1024 * 1024 * 1024));
 ///
 /// // Or wrap in HotReloadConfigProvider for runtime updates
 /// let hot_config = Arc::new(HotReloadConfigProvider::new(Arc::new(config)));
@@ -128,6 +139,22 @@ pub struct S3Config {
     ///
     /// Default: 5 GB (5 * 1024 * 1024 * 1024)
     pub post_object_max_file_size: u64,
+
+    /// Optional maximum object size for streaming uploads in bytes.
+    ///
+    /// When set, `s3s` limits decoded streaming request bodies for operations
+    /// such as `PUT Object` and `UploadPart` before passing them to the
+    /// [`S3`](crate::S3) implementation. For aws-chunked requests, signature
+    /// verification installs the decoded stream before this limit is applied.
+    /// When unset, `s3s` does not impose a streaming object-size limit and the
+    /// implementation must enforce any deployment-specific cap.
+    ///
+    /// `POST Object` keeps using [`S3Config::post_object_max_file_size`] as its
+    /// file-size limit.
+    ///
+    /// Default: None
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub put_object_max_size: Option<u64>,
 
     /// Maximum size for custom-route request bodies in bytes.
     ///
@@ -243,7 +270,8 @@ impl Default for S3Config {
         Self {
             xml_max_body_size: 20 * 1024 * 1024,               // 20 MB
             post_object_max_file_size: 5 * 1024 * 1024 * 1024, // 5 GB
-            custom_route_max_body_size: Some(1024 * 1024),     // 1 MB
+            put_object_max_size: None,
+            custom_route_max_body_size: Some(1024 * 1024), // 1 MB
             aws_chunked_stream_max_chunk_size: DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
             form_max_field_size: 1024 * 1024,       // 1 MB
             form_max_fields_size: 20 * 1024 * 1024, // 20 MB
@@ -367,6 +395,7 @@ mod tests {
         let config = S3Config::default();
         assert_eq!(config.xml_max_body_size, 20 * 1024 * 1024);
         assert_eq!(config.post_object_max_file_size, 5 * 1024 * 1024 * 1024);
+        assert_eq!(config.put_object_max_size, None);
         assert_eq!(config.custom_route_max_body_size, Some(1024 * 1024));
         assert_eq!(config.form_max_field_size, 1024 * 1024);
         assert_eq!(config.form_max_fields_size, 20 * 1024 * 1024);
@@ -445,6 +474,7 @@ mod tests {
         let snapshot = provider.snapshot();
         assert_eq!(snapshot.xml_max_body_size, 20 * 1024 * 1024);
         assert_eq!(snapshot.post_object_max_file_size, 5 * 1024 * 1024 * 1024);
+        assert_eq!(snapshot.put_object_max_size, None);
     }
 
     #[test]
@@ -453,6 +483,7 @@ mod tests {
         let snapshot = provider.snapshot();
         assert_eq!(snapshot.xml_max_body_size, 20 * 1024 * 1024);
         assert_eq!(snapshot.post_object_max_file_size, 5 * 1024 * 1024 * 1024);
+        assert_eq!(snapshot.put_object_max_size, None);
     }
 
     #[test]
@@ -460,6 +491,7 @@ mod tests {
         let config = S3Config {
             xml_max_body_size: 10 * 1024 * 1024,
             post_object_max_file_size: 1024 * 1024 * 1024,
+            put_object_max_size: Some(512 * 1024 * 1024),
             custom_route_max_body_size: Some(512 * 1024),
             aws_chunked_stream_max_chunk_size: DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
             form_max_field_size: 512 * 1024,
@@ -488,6 +520,7 @@ mod tests {
         assert_eq!(config.xml_max_body_size, 1024);
         // Other fields should have defaults
         assert_eq!(config.post_object_max_file_size, 5 * 1024 * 1024 * 1024);
+        assert_eq!(config.put_object_max_size, None);
         assert_eq!(config.custom_route_max_body_size, Some(1024 * 1024));
         assert_eq!(config.form_max_field_size, 1024 * 1024);
         assert_eq!(config.sig_v4_allowed_services, ["s3", "sts"]);
@@ -498,6 +531,12 @@ mod tests {
     fn test_serde_omits_unset_expected_region() {
         let json = serde_json::to_value(S3Config::default()).expect("serialize failed");
         assert!(json.get("expected_region").is_none());
+    }
+
+    #[test]
+    fn test_serde_omits_unset_put_object_max_size() {
+        let json = serde_json::to_value(S3Config::default()).expect("serialize failed");
+        assert!(json.get("put_object_max_size").is_none());
     }
 
     #[test]

--- a/crates/s3s/src/lib.rs
+++ b/crates/s3s/src/lib.rs
@@ -97,6 +97,10 @@
 //!   accepts anonymous requests and skips authorization entirely — every S3
 //!   operation is open to any client
 //! - HTTP body length limits
+//! - Object-size limits in the [`S3`] implementation for streaming uploads
+//!   (`PUT Object`, `UploadPart`) when
+//!   [`S3Config::put_object_max_size`](crate::config::S3Config::put_object_max_size)
+//!   is not configured
 //! - Rate limiting
 //! - Back pressure
 //! - Network-level security (firewalls, VPNs, etc.)

--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -570,6 +570,10 @@ impl super::Operation for AbortMultipartUpload {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -685,6 +689,10 @@ impl super::Operation for CompleteMultipartUpload {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -881,6 +889,10 @@ impl super::Operation for CopyObject {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -963,6 +975,10 @@ impl super::Operation for CreateBucket {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1024,6 +1040,10 @@ impl super::Operation for CreateBucketMetadataConfiguration {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1083,6 +1103,10 @@ impl super::Operation for CreateBucketMetadataTableConfiguration {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1242,6 +1266,10 @@ impl super::Operation for CreateMultipartUpload {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1314,6 +1342,10 @@ impl super::Operation for CreateSession {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1363,6 +1395,10 @@ impl super::Operation for DeleteBucket {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -1421,6 +1457,10 @@ impl super::Operation for DeleteBucketAnalyticsConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1473,6 +1513,10 @@ impl super::Operation for DeleteBucketCors {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1522,6 +1566,10 @@ impl super::Operation for DeleteBucketEncryption {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -1580,6 +1628,10 @@ impl super::Operation for DeleteBucketIntelligentTieringConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1635,6 +1687,10 @@ impl super::Operation for DeleteBucketInventoryConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1684,6 +1740,10 @@ impl super::Operation for DeleteBucketLifecycle {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -1739,6 +1799,10 @@ impl super::Operation for DeleteBucketMetadataConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1788,6 +1852,10 @@ impl super::Operation for DeleteBucketMetadataTableConfiguration {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -1846,6 +1914,10 @@ impl super::Operation for DeleteBucketMetricsConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1895,6 +1967,10 @@ impl super::Operation for DeleteBucketOwnershipControls {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -1950,6 +2026,10 @@ impl super::Operation for DeleteBucketPolicy {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1999,6 +2079,10 @@ impl super::Operation for DeleteBucketReplication {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2054,6 +2138,10 @@ impl super::Operation for DeleteBucketTagging {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2103,6 +2191,10 @@ impl super::Operation for DeleteBucketWebsite {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2186,6 +2278,10 @@ impl super::Operation for DeleteObject {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2241,6 +2337,10 @@ impl super::Operation for DeleteObjectTagging {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2315,6 +2415,10 @@ impl super::Operation for DeleteObjects {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2364,6 +2468,10 @@ impl super::Operation for DeletePublicAccessBlock {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2420,6 +2528,10 @@ impl super::Operation for GetBucketAbac {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2481,6 +2593,10 @@ impl super::Operation for GetBucketAccelerateConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2532,6 +2648,10 @@ impl super::Operation for GetBucketAcl {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2594,6 +2714,10 @@ impl super::Operation for GetBucketAnalyticsConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2645,6 +2769,10 @@ impl super::Operation for GetBucketCors {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2701,6 +2829,10 @@ impl super::Operation for GetBucketEncryption {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2763,6 +2895,10 @@ impl super::Operation for GetBucketIntelligentTieringConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2819,6 +2955,10 @@ impl super::Operation for GetBucketInventoryConfiguration {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2881,6 +3021,10 @@ impl super::Operation for GetBucketLifecycleConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2935,6 +3079,10 @@ impl super::Operation for GetBucketLocation {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2986,6 +3134,10 @@ impl super::Operation for GetBucketLogging {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -3045,6 +3197,10 @@ impl super::Operation for GetBucketMetadataConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3098,6 +3254,10 @@ impl super::Operation for GetBucketMetadataTableConfiguration {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -3160,6 +3320,10 @@ impl super::Operation for GetBucketMetricsConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3211,6 +3375,10 @@ impl super::Operation for GetBucketNotificationConfiguration {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -3270,6 +3438,10 @@ impl super::Operation for GetBucketOwnershipControls {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3323,6 +3495,10 @@ impl super::Operation for GetBucketPolicy {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -3382,6 +3558,10 @@ impl super::Operation for GetBucketPolicyStatus {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3435,6 +3615,10 @@ impl super::Operation for GetBucketReplication {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -3492,6 +3676,10 @@ impl super::Operation for GetBucketRequestPayment {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3543,6 +3731,10 @@ impl super::Operation for GetBucketTagging {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -3600,6 +3792,10 @@ impl super::Operation for GetBucketVersioning {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3651,6 +3847,10 @@ impl super::Operation for GetBucketWebsite {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -3821,6 +4021,10 @@ impl super::Operation for GetObject {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3882,6 +4086,10 @@ impl super::Operation for GetObjectAcl {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -3970,6 +4178,10 @@ impl super::Operation for GetObjectAttributes {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4033,6 +4245,10 @@ impl super::Operation for GetObjectLegalHold {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4086,6 +4302,10 @@ impl super::Operation for GetObjectLockConfiguration {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -4152,6 +4372,10 @@ impl super::Operation for GetObjectRetention {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4211,6 +4435,10 @@ impl super::Operation for GetObjectTagging {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -4275,6 +4503,10 @@ impl super::Operation for GetObjectTorrent {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4328,6 +4560,10 @@ impl super::Operation for GetPublicAccessBlock {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -4385,6 +4621,10 @@ impl super::Operation for HeadBucket {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -4549,6 +4789,10 @@ impl super::Operation for HeadObject {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4603,6 +4847,10 @@ impl super::Operation for ListBucketAnalyticsConfigurations {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -4663,6 +4911,10 @@ impl super::Operation for ListBucketIntelligentTieringConfigurations {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4720,6 +4972,10 @@ impl super::Operation for ListBucketInventoryConfigurations {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4774,6 +5030,10 @@ impl super::Operation for ListBucketMetricsConfigurations {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -4837,6 +5097,10 @@ impl super::Operation for ListBuckets {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4888,6 +5152,10 @@ impl super::Operation for ListDirectoryBuckets {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -4964,6 +5232,10 @@ impl super::Operation for ListMultipartUploads {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -5047,6 +5319,10 @@ impl super::Operation for ListObjectVersions {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5121,6 +5397,10 @@ impl super::Operation for ListObjects {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -5207,6 +5487,10 @@ impl super::Operation for ListObjectsV2 {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5288,6 +5572,10 @@ impl super::Operation for ListParts {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5349,6 +5637,10 @@ impl super::Operation for PutBucketAbac {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5405,6 +5697,10 @@ impl super::Operation for PutBucketAccelerateConfiguration {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -5486,6 +5782,10 @@ impl super::Operation for PutBucketAcl {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5542,6 +5842,10 @@ impl super::Operation for PutBucketAnalyticsConfiguration {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -5605,6 +5909,10 @@ impl super::Operation for PutBucketCors {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5666,6 +5974,10 @@ impl super::Operation for PutBucketEncryption {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5724,6 +6036,10 @@ impl super::Operation for PutBucketIntelligentTieringConfiguration {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5780,6 +6096,10 @@ impl super::Operation for PutBucketInventoryConfiguration {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -5850,6 +6170,10 @@ impl super::Operation for PutBucketLifecycleConfiguration {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5911,6 +6235,10 @@ impl super::Operation for PutBucketLogging {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5967,6 +6295,10 @@ impl super::Operation for PutBucketMetricsConfiguration {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6028,6 +6360,10 @@ impl super::Operation for PutBucketNotificationConfiguration {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6087,6 +6423,10 @@ impl super::Operation for PutBucketOwnershipControls {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6154,6 +6494,10 @@ impl super::Operation for PutBucketPolicy {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6218,6 +6562,10 @@ impl super::Operation for PutBucketReplication {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6279,6 +6627,10 @@ impl super::Operation for PutBucketRequestPayment {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6338,6 +6690,10 @@ impl super::Operation for PutBucketTagging {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6404,6 +6760,10 @@ impl super::Operation for PutBucketVersioning {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6463,6 +6823,10 @@ impl super::Operation for PutBucketWebsite {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6849,6 +7213,10 @@ impl super::Operation for PutObject {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6937,6 +7305,10 @@ impl super::Operation for PutObjectAcl {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -7013,6 +7385,10 @@ impl super::Operation for PutObjectLegalHold {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -7080,6 +7456,10 @@ impl super::Operation for PutObjectLockConfiguration {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -7162,6 +7542,10 @@ impl super::Operation for PutObjectRetention {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -7232,6 +7616,10 @@ impl super::Operation for PutObjectTagging {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -7291,6 +7679,10 @@ impl super::Operation for PutPublicAccessBlock {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -7378,6 +7770,10 @@ impl super::Operation for RenameObject {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -7444,6 +7840,10 @@ impl super::Operation for RestoreObject {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -7517,6 +7917,10 @@ impl super::Operation for SelectObjectContent {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -7576,6 +7980,10 @@ impl super::Operation for UpdateBucketMetadataAnnotationTableConfiguration {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -7641,6 +8049,10 @@ impl super::Operation for UpdateBucketMetadataInventoryTableConfiguration {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -7702,6 +8114,10 @@ impl super::Operation for UpdateBucketMetadataJournalTableConfiguration {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -7837,6 +8253,10 @@ impl super::Operation for UploadPart {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -7954,6 +8374,10 @@ impl super::Operation for UploadPartCopy {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -8156,6 +8580,10 @@ impl super::Operation for WriteGetObjectResponse {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -8271,6 +8699,13 @@ impl super::Operation for PostObject {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        // POST Object's body is the multipart file stream governed by
+        // `post_object_max_file_size`, not the request body wrapped by
+        // `put_object_max_size`.
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {

--- a/crates/s3s/src/ops/generated_minio.rs
+++ b/crates/s3s/src/ops/generated_minio.rs
@@ -571,6 +571,10 @@ impl super::Operation for AbortMultipartUpload {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -686,6 +690,10 @@ impl super::Operation for CompleteMultipartUpload {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -885,6 +893,10 @@ impl super::Operation for CopyObject {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -967,6 +979,10 @@ impl super::Operation for CreateBucket {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1028,6 +1044,10 @@ impl super::Operation for CreateBucketMetadataConfiguration {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1087,6 +1107,10 @@ impl super::Operation for CreateBucketMetadataTableConfiguration {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -1249,6 +1273,10 @@ impl super::Operation for CreateMultipartUpload {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1321,6 +1349,10 @@ impl super::Operation for CreateSession {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1373,6 +1405,10 @@ impl super::Operation for DeleteBucket {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -1431,6 +1467,10 @@ impl super::Operation for DeleteBucketAnalyticsConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1483,6 +1523,10 @@ impl super::Operation for DeleteBucketCors {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1532,6 +1576,10 @@ impl super::Operation for DeleteBucketEncryption {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -1590,6 +1638,10 @@ impl super::Operation for DeleteBucketIntelligentTieringConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1645,6 +1697,10 @@ impl super::Operation for DeleteBucketInventoryConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1694,6 +1750,10 @@ impl super::Operation for DeleteBucketLifecycle {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -1749,6 +1809,10 @@ impl super::Operation for DeleteBucketMetadataConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1798,6 +1862,10 @@ impl super::Operation for DeleteBucketMetadataTableConfiguration {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -1856,6 +1924,10 @@ impl super::Operation for DeleteBucketMetricsConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -1905,6 +1977,10 @@ impl super::Operation for DeleteBucketOwnershipControls {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -1960,6 +2036,10 @@ impl super::Operation for DeleteBucketPolicy {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2009,6 +2089,10 @@ impl super::Operation for DeleteBucketReplication {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2064,6 +2148,10 @@ impl super::Operation for DeleteBucketTagging {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2113,6 +2201,10 @@ impl super::Operation for DeleteBucketWebsite {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2196,6 +2288,10 @@ impl super::Operation for DeleteObject {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2251,6 +2347,10 @@ impl super::Operation for DeleteObjectTagging {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2325,6 +2425,10 @@ impl super::Operation for DeleteObjects {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2374,6 +2478,10 @@ impl super::Operation for DeletePublicAccessBlock {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2430,6 +2538,10 @@ impl super::Operation for GetBucketAbac {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2491,6 +2603,10 @@ impl super::Operation for GetBucketAccelerateConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2542,6 +2658,10 @@ impl super::Operation for GetBucketAcl {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2604,6 +2724,10 @@ impl super::Operation for GetBucketAnalyticsConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2655,6 +2779,10 @@ impl super::Operation for GetBucketCors {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2711,6 +2839,10 @@ impl super::Operation for GetBucketEncryption {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2773,6 +2905,10 @@ impl super::Operation for GetBucketIntelligentTieringConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2829,6 +2965,10 @@ impl super::Operation for GetBucketInventoryConfiguration {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -2891,6 +3031,10 @@ impl super::Operation for GetBucketLifecycleConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2945,6 +3089,10 @@ impl super::Operation for GetBucketLocation {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -2996,6 +3144,10 @@ impl super::Operation for GetBucketLogging {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -3055,6 +3207,10 @@ impl super::Operation for GetBucketMetadataConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3108,6 +3264,10 @@ impl super::Operation for GetBucketMetadataTableConfiguration {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -3170,6 +3330,10 @@ impl super::Operation for GetBucketMetricsConfiguration {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3221,6 +3385,10 @@ impl super::Operation for GetBucketNotificationConfiguration {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -3280,6 +3448,10 @@ impl super::Operation for GetBucketOwnershipControls {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3333,6 +3505,10 @@ impl super::Operation for GetBucketPolicy {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -3392,6 +3568,10 @@ impl super::Operation for GetBucketPolicyStatus {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3445,6 +3625,10 @@ impl super::Operation for GetBucketReplication {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -3502,6 +3686,10 @@ impl super::Operation for GetBucketRequestPayment {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3553,6 +3741,10 @@ impl super::Operation for GetBucketTagging {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -3610,6 +3802,10 @@ impl super::Operation for GetBucketVersioning {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3661,6 +3857,10 @@ impl super::Operation for GetBucketWebsite {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -3831,6 +4031,10 @@ impl super::Operation for GetObject {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -3892,6 +4096,10 @@ impl super::Operation for GetObjectAcl {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -3980,6 +4188,10 @@ impl super::Operation for GetObjectAttributes {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4043,6 +4255,10 @@ impl super::Operation for GetObjectLegalHold {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4096,6 +4312,10 @@ impl super::Operation for GetObjectLockConfiguration {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -4162,6 +4382,10 @@ impl super::Operation for GetObjectRetention {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4221,6 +4445,10 @@ impl super::Operation for GetObjectTagging {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -4285,6 +4513,10 @@ impl super::Operation for GetObjectTorrent {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4338,6 +4570,10 @@ impl super::Operation for GetPublicAccessBlock {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -4395,6 +4631,10 @@ impl super::Operation for HeadBucket {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -4559,6 +4799,10 @@ impl super::Operation for HeadObject {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4613,6 +4857,10 @@ impl super::Operation for ListBucketAnalyticsConfigurations {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -4673,6 +4921,10 @@ impl super::Operation for ListBucketIntelligentTieringConfigurations {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4730,6 +4982,10 @@ impl super::Operation for ListBucketInventoryConfigurations {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4784,6 +5040,10 @@ impl super::Operation for ListBucketMetricsConfigurations {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -4847,6 +5107,10 @@ impl super::Operation for ListBuckets {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -4898,6 +5162,10 @@ impl super::Operation for ListDirectoryBuckets {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -4974,6 +5242,10 @@ impl super::Operation for ListMultipartUploads {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -5057,6 +5329,10 @@ impl super::Operation for ListObjectVersions {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5131,6 +5407,10 @@ impl super::Operation for ListObjects {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -5217,6 +5497,10 @@ impl super::Operation for ListObjectsV2 {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5298,6 +5582,10 @@ impl super::Operation for ListParts {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5357,6 +5645,10 @@ impl super::Operation for ListenBucketNotification {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -5421,6 +5713,10 @@ impl super::Operation for PutBucketAbac {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5477,6 +5773,10 @@ impl super::Operation for PutBucketAccelerateConfiguration {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -5558,6 +5858,10 @@ impl super::Operation for PutBucketAcl {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5614,6 +5918,10 @@ impl super::Operation for PutBucketAnalyticsConfiguration {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -5677,6 +5985,10 @@ impl super::Operation for PutBucketCors {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5738,6 +6050,10 @@ impl super::Operation for PutBucketEncryption {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5796,6 +6112,10 @@ impl super::Operation for PutBucketIntelligentTieringConfiguration {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5852,6 +6172,10 @@ impl super::Operation for PutBucketInventoryConfiguration {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -5922,6 +6246,10 @@ impl super::Operation for PutBucketLifecycleConfiguration {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -5983,6 +6311,10 @@ impl super::Operation for PutBucketLogging {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6039,6 +6371,10 @@ impl super::Operation for PutBucketMetricsConfiguration {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6100,6 +6436,10 @@ impl super::Operation for PutBucketNotificationConfiguration {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6159,6 +6499,10 @@ impl super::Operation for PutBucketOwnershipControls {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6226,6 +6570,10 @@ impl super::Operation for PutBucketPolicy {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6290,6 +6638,10 @@ impl super::Operation for PutBucketReplication {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6351,6 +6703,10 @@ impl super::Operation for PutBucketRequestPayment {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6410,6 +6766,10 @@ impl super::Operation for PutBucketTagging {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6477,6 +6837,10 @@ impl super::Operation for PutBucketVersioning {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -6536,6 +6900,10 @@ impl super::Operation for PutBucketWebsite {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -6928,6 +7296,10 @@ impl super::Operation for PutObject {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -7016,6 +7388,10 @@ impl super::Operation for PutObjectAcl {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -7092,6 +7468,10 @@ impl super::Operation for PutObjectLegalHold {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -7160,6 +7540,10 @@ impl super::Operation for PutObjectLockConfiguration {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -7242,6 +7626,10 @@ impl super::Operation for PutObjectRetention {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -7312,6 +7700,10 @@ impl super::Operation for PutObjectTagging {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -7371,6 +7763,10 @@ impl super::Operation for PutPublicAccessBlock {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -7458,6 +7854,10 @@ impl super::Operation for RenameObject {
         false
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -7524,6 +7924,10 @@ impl super::Operation for RestoreObject {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -7597,6 +8001,10 @@ impl super::Operation for SelectObjectContent {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -7656,6 +8064,10 @@ impl super::Operation for UpdateBucketMetadataAnnotationTableConfiguration {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -7721,6 +8133,10 @@ impl super::Operation for UpdateBucketMetadataInventoryTableConfiguration {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -7782,6 +8198,10 @@ impl super::Operation for UpdateBucketMetadataJournalTableConfiguration {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
@@ -7917,6 +8337,10 @@ impl super::Operation for UploadPart {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -8034,6 +8458,10 @@ impl super::Operation for UploadPartCopy {
     }
 
     fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
         false
     }
 
@@ -8236,6 +8664,10 @@ impl super::Operation for WriteGetObjectResponse {
         true
     }
 
+    fn has_streaming_body(&self) -> bool {
+        true
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
         let input = Self::deserialize_http(req)?;
         let mut s3_req = super::build_s3_request(input, req);
@@ -8351,6 +8783,13 @@ impl super::Operation for PostObject {
 
     fn has_request_payload(&self) -> bool {
         true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        // POST Object's body is the multipart file stream governed by
+        // `post_object_max_file_size`, not the request body wrapped by
+        // `put_object_max_size`.
+        false
     }
 
     async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -84,6 +84,17 @@ pub trait Operation: Send + Sync + 'static {
     /// bodyless operations such as `GetObject` and `DeleteObject`.
     fn has_request_payload(&self) -> bool;
 
+    /// Whether this operation streams the request body directly to the
+    /// user-implemented [`S3`] handler without buffering.
+    ///
+    /// `true` for operations whose input carries a `StreamingBlob` payload
+    /// (e.g. `PutObject`, `UploadPart`). These bodies are not bounded by
+    /// [`S3Config::xml_max_body_size`]; see
+    /// [`S3Config::put_object_max_size`].
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
     async fn call(&self, ccx: &CallContext<'_>, req: &mut Request) -> S3Result<Response>;
 }
 
@@ -861,9 +872,11 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
 
     debug!(op = %op.name(), ?s3_path, "checked access");
 
+    let config = ccx.config.snapshot();
     if op.needs_full_body() {
-        let config = ccx.config.snapshot();
         extract_full_body(content_length, &mut req.body, config.xml_max_body_size).await?;
+    } else if op.has_streaming_body() {
+        req.body.set_limit(config.put_object_max_size);
     }
 
     Ok(Prepare::S3(op))

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -1369,6 +1369,323 @@ mod post_policy_test_helpers {
     }
 }
 
+mod put_object_max_size_tests {
+    use super::*;
+
+    use crate::auth::{SecretKey, SimpleAuth};
+    use crate::config::{S3Config, S3ConfigProvider, StaticConfigProvider};
+    use crate::dto::StreamingBlob;
+    use crate::error::StdError;
+    use crate::s3_trait::S3;
+    use bytes::Bytes;
+    use futures::StreamExt;
+    use std::sync::Arc;
+
+    /// The streaming-body predicate is model-driven: exactly the operations
+    /// whose input carries a `StreamingBlob` payload (`PutObject`,
+    /// `UploadPart`, `WriteGetObjectResponse`). `PostObject` is excluded —
+    /// its body is the multipart file stream governed by
+    /// `post_object_max_file_size`.
+    #[test]
+    fn has_streaming_body_matches_streaming_payload_operations() {
+        assert!(PutObject.has_streaming_body());
+        assert!(UploadPart.has_streaming_body());
+        assert!(WriteGetObjectResponse.has_streaming_body());
+        assert!(!PostObject.has_streaming_body());
+        assert!(!GetObject.has_streaming_body());
+        assert!(!DeleteObjects.has_streaming_body());
+        assert!(!PutBucketPolicy.has_streaming_body());
+    }
+
+    fn test_config(put_object_max_size: Option<u64>) -> Arc<dyn S3ConfigProvider> {
+        Arc::new(StaticConfigProvider::new(Arc::new(S3Config {
+            put_object_max_size,
+            presigned_url_max_skew_time_secs: u32::MAX,
+            ..Default::default()
+        })))
+    }
+
+    fn test_context<'a>(
+        s3: &'a Arc<dyn S3>,
+        config: &'a Arc<dyn S3ConfigProvider>,
+        auth: Option<&'a dyn crate::auth::S3Auth>,
+    ) -> CallContext<'a> {
+        CallContext {
+            s3,
+            config,
+            host: None,
+            auth,
+            access: None,
+            route: None,
+            validation: None,
+        }
+    }
+
+    fn plain_put_request(body: Bytes) -> Request {
+        Request::from(
+            hyper::Request::builder()
+                .method(Method::PUT)
+                .uri("http://localhost/test-bucket/test-key")
+                .header(crate::header::HOST, "localhost")
+                .header(hyper::header::CONTENT_LENGTH, body.len())
+                .body(Body::from(body))
+                .unwrap(),
+        )
+    }
+
+    fn upload_part_request(body: Bytes) -> Request {
+        Request::from(
+            hyper::Request::builder()
+                .method(Method::PUT)
+                .uri("http://localhost/test-bucket/test-key?partNumber=1&uploadId=test-upload")
+                .header(crate::header::HOST, "localhost")
+                .header(hyper::header::CONTENT_LENGTH, body.len())
+                .body(Body::from(body))
+                .unwrap(),
+        )
+    }
+
+    async fn collect_stream<S>(mut stream: S) -> Result<Bytes, StdError>
+    where
+        S: futures::Stream<Item = Result<Bytes, StdError>> + Unpin,
+    {
+        let mut collected = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            collected.extend_from_slice(&chunk?);
+        }
+        Ok(Bytes::from(collected))
+    }
+
+    async fn expect_limit_error(blob: StreamingBlob) -> StdError {
+        let err = collect_stream(blob)
+            .await
+            .expect_err("stream should fail once the object-size limit is exceeded");
+        assert!(err.to_string().contains("exceeds limit"), "limit error should be clear, got: {err}");
+        err
+    }
+
+    fn signed_aws_chunked_put_request(chunk_data: &Bytes, access_key: &str, secret_key: &SecretKey) -> Request {
+        let method = Method::PUT;
+        let uri_path = "/test-bucket/test-key";
+        let amz_date = s3s_sigv4::AmzDate::parse("20130524T000000Z").unwrap();
+        let decoded_content_length = chunk_data.len().to_string();
+        let headers_for_signing = [
+            ("host", "s3.amazonaws.com"),
+            ("x-amz-content-sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"),
+            ("x-amz-date", "20130524T000000Z"),
+            ("x-amz-decoded-content-length", decoded_content_length.as_str()),
+        ];
+        let canonical_request = crate::sig_v4::create_canonical_request(
+            &method,
+            uri_path,
+            &[] as &[(&str, &str)],
+            headers_for_signing,
+            crate::sig_v4::Payload::MultipleChunks,
+        );
+        let seed_string_to_sign = crate::sig_v4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
+        let seed_signature = crate::sig_v4::calculate_signature(&seed_string_to_sign, secret_key, &amz_date, "us-east-1", "s3");
+
+        let chunk_string_to_sign = crate::sig_v4::create_chunk_string_to_sign(
+            &amz_date,
+            "us-east-1",
+            "s3",
+            seed_signature.as_str(),
+            std::slice::from_ref(chunk_data),
+        );
+        let chunk_signature = crate::sig_v4::calculate_signature(&chunk_string_to_sign, secret_key, &amz_date, "us-east-1", "s3");
+        let final_string_to_sign =
+            crate::sig_v4::create_chunk_string_to_sign(&amz_date, "us-east-1", "s3", chunk_signature.as_str(), &[]);
+        let final_signature = crate::sig_v4::calculate_signature(&final_string_to_sign, secret_key, &amz_date, "us-east-1", "s3");
+
+        let mut streaming_body = Vec::new();
+        streaming_body
+            .extend_from_slice(format!("{:x};chunk-signature={}\r\n", chunk_data.len(), chunk_signature.as_str()).as_bytes());
+        streaming_body.extend_from_slice(chunk_data);
+        streaming_body.extend_from_slice(b"\r\n");
+        streaming_body.extend_from_slice(format!("0;chunk-signature={}\r\n\r\n", final_signature.as_str()).as_bytes());
+
+        let authorization = format!(
+            "AWS4-HMAC-SHA256 Credential={access_key}/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length, Signature={}",
+            seed_signature.as_str(),
+        );
+
+        Request::from(
+            hyper::Request::builder()
+                .method(method)
+                .uri("https://s3.amazonaws.com/test-bucket/test-key")
+                .header(crate::header::HOST, "s3.amazonaws.com")
+                .header(hyper::header::CONTENT_LENGTH, streaming_body.len())
+                .header("content-encoding", "aws-chunked")
+                .header(crate::header::AUTHORIZATION, authorization)
+                .header(crate::header::X_AMZ_CONTENT_SHA256, "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
+                .header(crate::header::X_AMZ_DATE, "20130524T000000Z")
+                .header(crate::header::X_AMZ_DECODED_CONTENT_LENGTH, decoded_content_length)
+                .body(Body::from(Bytes::from(streaming_body)))
+                .unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn none_leaves_plain_put_stream_unchanged() {
+        let s3: Arc<dyn S3> = Arc::new(post_policy_test_helpers::TestS3NoOp);
+        let config = test_config(None);
+        let ccx = test_context(&s3, &config, None);
+        let expected_body = Bytes::from_static(b"hello");
+        let mut req = plain_put_request(expected_body.clone());
+
+        let Prepare::S3(op) = super::prepare(&mut req, &ccx).await.expect("prepare should succeed") else {
+            panic!("plain PUT should resolve to an S3 operation");
+        };
+        assert_eq!(op.name(), "PutObject");
+
+        let input = generated::PutObject::deserialize_http(&mut req).expect("deserialize should succeed");
+        let body = input.body.expect("put object input should carry a body");
+        let collected = collect_stream(body).await.expect("unlimited stream should be readable");
+        assert_eq!(collected, expected_body);
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_plain_put_at_read_time() {
+        let s3: Arc<dyn S3> = Arc::new(post_policy_test_helpers::TestS3NoOp);
+        let config = test_config(Some(4));
+        let ccx = test_context(&s3, &config, None);
+        let mut req = plain_put_request(Bytes::from_static(b"hello"));
+
+        let Prepare::S3(op) = super::prepare(&mut req, &ccx).await.expect("prepare should succeed") else {
+            panic!("plain PUT should resolve to an S3 operation");
+        };
+        assert_eq!(op.name(), "PutObject");
+
+        let input = generated::PutObject::deserialize_http(&mut req).expect("deserialize should succeed");
+        expect_limit_error(input.body.expect("put object input should carry a body")).await;
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_upload_part_at_read_time() {
+        let s3: Arc<dyn S3> = Arc::new(post_policy_test_helpers::TestS3NoOp);
+        let config = test_config(Some(4));
+        let ccx = test_context(&s3, &config, None);
+        let mut req = upload_part_request(Bytes::from_static(b"hello"));
+
+        let Prepare::S3(op) = super::prepare(&mut req, &ccx).await.expect("prepare should succeed") else {
+            panic!("upload part should resolve to an S3 operation");
+        };
+        assert_eq!(op.name(), "UploadPart");
+
+        let input = generated::UploadPart::deserialize_http(&mut req).expect("deserialize should succeed");
+        expect_limit_error(input.body.expect("upload part input should carry a body")).await;
+    }
+
+    #[tokio::test]
+    async fn empty_body_operations_are_unaffected_when_limit_is_set() {
+        let s3: Arc<dyn S3> = Arc::new(post_policy_test_helpers::TestS3NoOp);
+        let config = test_config(Some(0));
+        let ccx = test_context(&s3, &config, None);
+        let mut req = Request::from(
+            hyper::Request::builder()
+                .method(Method::GET)
+                .uri("http://localhost/test-bucket/test-key")
+                .header(crate::header::HOST, "localhost")
+                .body(Body::empty())
+                .unwrap(),
+        );
+
+        let Prepare::S3(op) = super::prepare(&mut req, &ccx).await.expect("prepare should succeed") else {
+            panic!("GET object should resolve to an S3 operation");
+        };
+        assert_eq!(op.name(), "GetObject");
+
+        let input = generated::GetObject::deserialize_http(&mut req).expect("deserialize should succeed");
+        assert_eq!(input.bucket, "test-bucket");
+        assert_eq!(input.key, "test-key");
+        assert!(
+            req.body
+                .store_all_limited(0)
+                .await
+                .expect("empty limited body should be readable")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn post_object_keeps_post_object_max_file_size_when_put_limit_is_set() {
+        let s3: Arc<dyn S3> = Arc::new(post_policy_test_helpers::TestS3NoOp);
+        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::new(Arc::new(S3Config {
+            post_object_max_file_size: 1024,
+            put_object_max_size: Some(1),
+            expected_region: Some("us-east-1".parse().expect("valid test region")),
+            presigned_url_max_skew_time_secs: u32::MAX,
+            ..Default::default()
+        })));
+        let auth = post_policy_test_helpers::create_test_auth();
+        let ccx = test_context(&s3, &config, Some(&auth));
+        let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
+        let policy_json = &format!(
+            r#"{{"expiration":"2030-01-01T00:00:00.000Z","conditions":[{}]}}"#,
+            post_policy_test_helpers::BASE_CONDITIONS,
+        );
+        let file_content = "hello";
+        let mut req = post_policy_test_helpers::build_post_object_request(policy_json, file_content, &secret_key, false);
+
+        let Prepare::S3(op) = super::prepare(&mut req, &ccx).await.expect("prepare should succeed") else {
+            panic!("POST Object should resolve to an S3 operation");
+        };
+        assert_eq!(op.name(), "PostObject");
+
+        let stream = req
+            .s3ext
+            .post_object_stream
+            .take()
+            .expect("post object stream should be prepared");
+        let collected = collect_stream(stream)
+            .await
+            .expect("POST Object stream should use its own limit");
+        assert_eq!(collected, Bytes::from_static(b"hello"));
+    }
+
+    #[tokio::test]
+    async fn aws_chunked_put_limit_applies_after_decoding() {
+        let s3: Arc<dyn S3> = Arc::new(post_policy_test_helpers::TestS3NoOp);
+        let access_key = "AKIAIOSFODNN7EXAMPLE";
+        let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
+        let auth = SimpleAuth::from_single(access_key, secret_key.clone());
+
+        let config = test_config(Some(5));
+        let ccx = test_context(&s3, &config, Some(&auth));
+        let decoded = Bytes::from_static(b"hello");
+        let mut req = signed_aws_chunked_put_request(&decoded, access_key, &secret_key);
+
+        let Prepare::S3(op) = super::prepare(&mut req, &ccx)
+            .await
+            .expect("prepare should decode before limiting")
+        else {
+            panic!("aws-chunked PUT should resolve to an S3 operation");
+        };
+        assert_eq!(op.name(), "PutObject");
+
+        let input = generated::PutObject::deserialize_http(&mut req).expect("deserialize should succeed");
+        let body = input.body.expect("put object input should carry a body");
+        let collected = collect_stream(body)
+            .await
+            .expect("decoded stream at limit should be readable");
+        assert_eq!(collected, decoded);
+
+        let config = test_config(Some(4));
+        let ccx = test_context(&s3, &config, Some(&auth));
+        let mut req = signed_aws_chunked_put_request(&decoded, access_key, &secret_key);
+        let Prepare::S3(op) = super::prepare(&mut req, &ccx)
+            .await
+            .expect("prepare should still finish before read-time limit")
+        else {
+            panic!("aws-chunked PUT should resolve to an S3 operation");
+        };
+        assert_eq!(op.name(), "PutObject");
+
+        let input = generated::PutObject::deserialize_http(&mut req).expect("deserialize should succeed");
+        expect_limit_error(input.body.expect("put object input should carry a body")).await;
+    }
+}
+
 #[tokio::test]
 async fn post_object_rejects_wrong_region() {
     use crate::auth::SecretKey;

--- a/crates/s3s/src/service.rs
+++ b/crates/s3s/src/service.rs
@@ -70,6 +70,24 @@
 //! readable and writable endpoint. Call [`set_auth`](S3ServiceBuilder::set_auth) in
 //! any deployment that is not fully trusted, and prefer configuring an access
 //! provider via [`set_access`](S3ServiceBuilder::set_access) as well.
+//!
+//! # Deployment notes
+//!
+//! `S3Service` is an adapter and does not provide a complete security boundary
+//! by itself. For public deployments, configure authentication, authorization,
+//! request timeouts, rate limits, back pressure, and header/body limits in this
+//! service or in the surrounding HTTP stack.
+//!
+//! Streaming uploads (`PUT Object` and `UploadPart`) are passed to the
+//! [`S3`](crate::S3) implementation as streams. By default,
+//! [`S3Config::put_object_max_size`](crate::config::S3Config::put_object_max_size)
+//! is `None`, so `s3s` does not impose an object-size limit for those streams;
+//! the [`S3`](crate::S3) implementation is responsible for enforcing any
+//! deployment-specific object cap. Set `put_object_max_size` to opt in to an
+//! adapter-level limit; aws-chunked requests are capped after signature
+//! verification has installed the decoded stream. `POST Object` keeps using
+//! [`S3Config::post_object_max_file_size`](crate::config::S3Config::post_object_max_file_size)
+//! as its file-size limit.
 
 use crate::access::S3Access;
 use crate::auth::S3Auth;
@@ -182,7 +200,11 @@ impl S3ServiceBuilder {
     /// Sets the configuration provider for the service.
     ///
     /// The configuration provider supplies runtime configuration values such as
-    /// maximum body sizes and other limits.
+    /// maximum body sizes and other limits. In particular,
+    /// [`S3Config::put_object_max_size`](crate::config::S3Config::put_object_max_size)
+    /// is an opt-in limit for streaming `PUT Object` and `UploadPart` bodies;
+    /// when it is unset, the [`S3`](crate::S3) implementation is responsible for
+    /// those object-size limits.
     ///
     /// If not set, defaults to [`StaticConfigProvider::default()`].
     ///
@@ -828,6 +850,7 @@ mod tests {
         assert_eq!(config.xml_max_body_size, 20 * 1024 * 1024);
         assert_eq!(config.post_object_max_file_size, 5 * 1024 * 1024 * 1024);
         assert_eq!(config.custom_route_max_body_size, Some(1024 * 1024));
+        assert_eq!(config.put_object_max_size, None);
     }
 
     #[test]
@@ -838,6 +861,7 @@ mod tests {
             xml_max_body_size: 10 * 1024 * 1024,
             post_object_max_file_size: 2 * 1024 * 1024 * 1024,
             custom_route_max_body_size: Some(512 * 1024),
+            put_object_max_size: Some(1024 * 1024 * 1024),
             ..Default::default()
         })));
 
@@ -849,6 +873,7 @@ mod tests {
         assert_eq!(config.xml_max_body_size, 10 * 1024 * 1024);
         assert_eq!(config.post_object_max_file_size, 2 * 1024 * 1024 * 1024);
         assert_eq!(config.custom_route_max_body_size, Some(512 * 1024));
+        assert_eq!(config.put_object_max_size, Some(1024 * 1024 * 1024));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Finding F2 of the security audit in issue #221: a plain `PUT /bucket/key` body is passed to the `S3` implementation as a streaming blob with no size cap at the s3s layer. `S3Config::xml_max_body_size` does not cover this path, and POST Object is the only upload with a framework-level cap (`post_object_max_file_size`). On an Internet-exposed deployment (or with no `auth` configured), an authenticated or anonymous client can upload arbitrarily large objects and exhaust storage or memory. The `S3` implementation may impose its own cap; s3s neither documented nor enforced one.

## Changes

### Opt-in config

Add `S3Config::put_object_max_size: Option<u64>`, default `None` (behavior unchanged). When set, streaming request bodies for upload operations are capped before deserialization, so oversized uploads are rejected at read time with a clear error. `#[serde(skip_serializing_if = "Option::is_none")]` keeps the serialized config unchanged when unset.

### Limit mechanism

`ops::prepare` installs the body's built-in limit via `Body::set_limit` for operations that stream a request body directly to the `S3` implementation. This reuses the mechanism introduced for the custom-route body limit (#755, `Body::remaining_limit` / `BodySizeLimitExceeded`), so both limit paths report the same error type and behavior.

The set of limited operations is model-driven rather than a runtime name list: codegen derives a new `Operation::has_streaming_body` predicate from the input payload field type (`StreamingBlob`), covering `PutObject`, `UploadPart`, and `WriteGetObjectResponse`. `PostObject` is excluded — its body is the multipart file stream governed by `post_object_max_file_size`. A generated-predicate test locks the exact set.

### Documentation

Document the responsibility boundary in the README security section, the crate docs, the `S3Service` deployment notes, and the `S3Config` field docs: when the option is unset, object-size limits for streaming uploads are the `S3` implementation's responsibility.

### Tests

- Plain `PUT` unchanged when the option is `None`
- Oversized `PUT` and `UploadPart` rejected at read time when the option is set
- Empty-body operations unaffected by a set limit
- POST Object keeps `post_object_max_file_size` when `put_object_max_size` is set
- aws-chunked uploads limited after decoding (at the limit readable, over the limit fails)
- Generated predicate matches exactly `PutObject` / `UploadPart` / `WriteGetObjectResponse`

## Notes

- `WriteGetObjectResponse` is now also capped when the option is set: it is a streaming body with the same unbounded asymmetry; the opt-in config wording ("such as PUT Object and UploadPart") covers it.
- The option is enforced at read time; handlers that never read the body are not affected (same boundary as the custom-route limit).

## Verification

- `just dev` green (fmt / codegen idempotent / lint zero warnings / full test suite)
- `cargo check -p s3s --features minio` passes
- No generated-file drift after re-running `just codegen`

Refs #221
