### PR TITLE
docs(s3s): warn that services without auth are fully open

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ The data types, serialization and deserialization are generated from the smithy 
 
 `S3Service` and other adapters in this project have no security protection. If they are exposed to the Internet directly, they may be **attacked**.
 
-It is up to the user to implement security enhancements such as **HTTP body length limit**, rate limit and back pressure.
+It is up to the user to implement security enhancements such as **HTTP body length limits**, object-size limits, rate limits and back pressure.
+
+**Authentication is required for production deployments.** Without calling `set_auth`, the service accepts anonymous (unsigned) requests and skips authorization entirely: every S3 operation is open to any client that can reach the service, and signed requests fail with `NotImplemented` because no authentication provider is configured. A forgotten `set_auth` turns the service into a publicly readable and writable endpoint.
 
 ## Docker
 

--- a/crates/s3s/src/lib.rs
+++ b/crates/s3s/src/lib.rs
@@ -92,6 +92,10 @@
 //! protection. If exposed to the Internet directly, they may be vulnerable to attacks.
 //!
 //! It is the user's responsibility to implement security enhancements such as:
+//! - Authentication: without
+//!   [`set_auth`](crate::service::S3ServiceBuilder::set_auth), the service
+//!   accepts anonymous requests and skips authorization entirely — every S3
+//!   operation is open to any client
 //! - HTTP body length limits
 //! - Rate limiting
 //! - Back pressure

--- a/crates/s3s/src/service.rs
+++ b/crates/s3s/src/service.rs
@@ -59,6 +59,17 @@
 //! - **Host**: None (assumes path-style requests)
 //! - **Route**: None (no custom routes)
 //! - **Validation**: None (uses AWS-compatible validation)
+//!
+//! # Authentication is required for production deployments
+//!
+//! Without [`set_auth`](S3ServiceBuilder::set_auth), the service accepts anonymous
+//! (unsigned) requests and **skips authorization entirely**: every S3 operation is
+//! open to any client that can reach the service, with no access checks performed.
+//! Signed requests fail with `NotImplemented` because no authentication provider is
+//! configured. A forgotten `set_auth` therefore turns the service into a publicly
+//! readable and writable endpoint. Call [`set_auth`](S3ServiceBuilder::set_auth) in
+//! any deployment that is not fully trusted, and prefer configuring an access
+//! provider via [`set_access`](S3ServiceBuilder::set_access) as well.
 
 use crate::access::S3Access;
 use crate::auth::S3Auth;
@@ -242,8 +253,11 @@ impl S3ServiceBuilder {
     /// The authentication provider verifies AWS Signature Version 4 or Version 2 signatures
     /// on incoming requests.
     ///
-    /// If not set, unsigned requests are allowed, but signed requests will fail with
-    /// `NotImplemented` ("This service has no authentication provider").
+    /// **Important**: authentication is required before exposing the service beyond a
+    /// trusted network. If not set, unsigned (anonymous) requests are accepted and
+    /// authorization is skipped entirely, so every S3 operation is open to any client;
+    /// signed requests fail with `NotImplemented` ("This service has no authentication
+    /// provider").
     ///
     /// # Example
     ///


### PR DESCRIPTION
## Problem

Finding F3 of the security audit in issue #221: when `S3ServiceBuilder::set_auth` is not called, the service accepts anonymous (unsigned) requests and `ops::authorize` returns `Ok` immediately — every S3 operation is open to any client that can reach the service, with no access checks performed. Signed requests fail with `NotImplemented` because no authentication provider is configured. A forgotten `set_auth` therefore turns a misconfigured deployment into a publicly readable and writable endpoint.

The existing docs described the behavior factually ("Auth: None (no authentication required)") without calling out the security consequence.

## Changes

Prominent documentation of the default, in all public-facing security surfaces (no behavior change):

- `S3ServiceBuilder` module docs: new "Authentication is required for production deployments" section warning that without `set_auth` anonymous requests are accepted and authorization is skipped entirely, and that signed requests fail with `NotImplemented`.
- `S3ServiceBuilder::set_auth` rustdoc: "**Important**: authentication is required before exposing the service beyond a trusted network" with the same consequence summary.
- Crate-level security notes (`lib.rs`): authentication listed first in the "user's responsibility" checklist, with an intra-doc link to `S3ServiceBuilder::set_auth`.
- README security section: bold warning that a forgotten `set_auth` turns the service into a publicly readable and writable endpoint.

## Notes

The audit's longer-term suggestion — requiring an explicit `set_auth` (or an explicit `AllowAnonymous` flag) before the service can start — is a breaking change that would affect the example implementations (`s3s-fs`), `s3s-proxy`, the E2E suite, and all downstream users. It remains under evaluation and is intentionally out of scope here; this PR closes the documentation half of F3.

## Verification

- `just dev` green (fmt / codegen idempotent / lint zero warnings / full test suite); the only warning is pre-existing dead code unrelated to this PR.
- No code behavior touched; docs-only change.

Refs #221
