### PR TITLE
feat(s3s/ops)!: backfill known Content-Length for streaming uploads

### DIFF
--- a/crates/s3s/src/config.rs
+++ b/crates/s3s/src/config.rs
@@ -263,6 +263,26 @@ pub struct S3Config {
     ///
     /// Default: false
     pub normalize_forward_slash_path: bool,
+
+    /// Whether to backfill a known request-body length into the
+    /// `Content-Length` header when the client omitted it.
+    ///
+    /// When enabled (default), a `Content-Length` is inserted before the
+    /// [`S3`](crate::S3) implementation observes the request if the body
+    /// length is known: the `x-amz-decoded-content-length` value for
+    /// aws-chunked uploads, or an exact remaining length (e.g. an empty
+    /// body without `Content-Length`, which is empty by definition per
+    /// RFC 9112 §6.3). This lets storage implementations obtain the object
+    /// size up front instead of treating `None` as ambiguous. The inserted
+    /// header is visible in [`S3Request`](crate::S3Request) via `headers`,
+    /// so they may not be the exact wire headers.
+    ///
+    /// Requests whose length is unknown (e.g. chunked `Transfer-Encoding`
+    /// without aws-chunked) are never backfilled and keep a missing
+    /// `Content-Length`.
+    ///
+    /// Default: true
+    pub normalize_content_length: bool,
 }
 
 impl Default for S3Config {
@@ -282,6 +302,7 @@ impl Default for S3Config {
             enable_sig_v2: false,
             presigned_url_max_expires_secs: DEFAULT_PRESIGNED_URL_MAX_EXPIRES_SECS,
             normalize_forward_slash_path: false,
+            normalize_content_length: true,
         }
     }
 }
@@ -503,6 +524,7 @@ mod tests {
             enable_sig_v2: true,
             presigned_url_max_expires_secs: 86_400,
             normalize_forward_slash_path: false,
+            normalize_content_length: true,
         };
 
         let json = serde_json::to_string(&config).expect("serialize failed");
@@ -525,6 +547,7 @@ mod tests {
         assert_eq!(config.form_max_field_size, 1024 * 1024);
         assert_eq!(config.sig_v4_allowed_services, ["s3", "sts"]);
         assert_eq!(config.presigned_url_max_expires_secs, DEFAULT_PRESIGNED_URL_MAX_EXPIRES_SECS);
+        assert!(config.normalize_content_length);
     }
 
     #[test]

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -51,6 +51,7 @@ use crate::post_policy::PostPolicy;
 use crate::protocol::S3Request;
 use crate::route::S3Route;
 use crate::s3_trait::S3;
+use crate::stream::ByteStream as _;
 use crate::validation::{AwsNameValidation, NameValidation};
 
 use std::mem;
@@ -877,6 +878,22 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
         extract_full_body(content_length, &mut req.body, config.xml_max_body_size).await?;
     } else if op.has_streaming_body() {
         req.body.set_limit(config.put_object_max_size);
+        // Backfill a known request-body length so that the `S3`
+        // implementation never sees an ambiguous missing `Content-Length`.
+        // The `x-amz-decoded-content-length` value wins (aws-chunked uploads),
+        // otherwise an exact remaining length (e.g. an empty body without
+        // `Content-Length`, which is empty by definition per RFC 9112 §6.3).
+        // Unknown-length bodies (chunked transfer-encoding without
+        // aws-chunked) stay untouched.
+        if config.normalize_content_length && content_length.is_none() {
+            let known = extract_decoded_content_length(&req.headers)?
+                .map(|x| x as u64)
+                .or_else(|| req.body.remaining_length().exact().map(|x| x as u64));
+            if let Some(known) = known {
+                req.headers
+                    .insert(hyper::header::CONTENT_LENGTH, hyper::header::HeaderValue::from(known));
+            }
+        }
     }
 
     Ok(Prepare::S3(op))

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -3424,8 +3424,10 @@ mod bodyless_content_length_tests {
     use crate::protocol::S3Response;
     use crate::sig_v4;
     use bytes::Bytes;
+    use hyper::header::HeaderValue;
     use hyper::{Method, StatusCode, Uri, Version};
     use std::sync::Arc;
+    use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     const ACCESS_KEY: &str = "test-access";
@@ -3691,6 +3693,123 @@ mod bodyless_content_length_tests {
         }
 
         assert_eq!(test_s3.put_object.load(Ordering::SeqCst), 0);
+    }
+
+    struct ContentLengthRecordingS3 {
+        received: Mutex<Option<(Option<i64>, Option<u64>)>>, // (input.content_length, headers content-length)
+    }
+
+    #[async_trait::async_trait]
+    impl crate::s3_trait::S3 for ContentLengthRecordingS3 {
+        async fn put_object(
+            &self,
+            req: crate::S3Request<crate::dto::PutObjectInput>,
+        ) -> crate::error::S3Result<S3Response<crate::dto::PutObjectOutput>> {
+            let header_cl = req.headers.get(hyper::header::CONTENT_LENGTH).map(|v| {
+                v.to_str()
+                    .expect("test header is ASCII")
+                    .parse::<u64>()
+                    .expect("test header parses")
+            });
+            *self.received.lock().unwrap() = Some((req.input.content_length, header_cl));
+            Ok(S3Response::new(crate::dto::PutObjectOutput::default()))
+        }
+    }
+
+    fn empty_body_signed_put(version: Version) -> Request {
+        let uri = "http://localhost/test-bucket/test-key.txt".parse::<Uri>().unwrap();
+        let authorization = sign_request(&Method::PUT, &uri, EMPTY_SHA256);
+        Request::from(
+            hyper::Request::builder()
+                .method(Method::PUT)
+                .version(version)
+                .uri(uri.clone())
+                .header(crate::header::HOST, uri.authority().unwrap().as_str())
+                .header(crate::header::X_AMZ_CONTENT_SHA256, EMPTY_SHA256)
+                .header(crate::header::X_AMZ_DATE, AMZ_DATE)
+                .header(crate::header::AUTHORIZATION, authorization)
+                .body(Body::empty())
+                .unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn backfills_known_content_length_for_zero_length_put() {
+        // RFC 9112 §6.3: a PUT without `Content-Length` and without
+        // `Transfer-Encoding` has an empty body. The length is known (exact
+        // zero), so with the default `normalize_content_length` the `S3`
+        // implementation must observe `Some(0)` and an inserted
+        // `Content-Length: 0` header instead of an ambiguous `None`.
+        let recording = Arc::new(ContentLengthRecordingS3 {
+            received: Mutex::new(None),
+        });
+        let s3: Arc<dyn crate::s3_trait::S3> = recording.clone();
+        let config = test_config();
+        let auth = SimpleAuth::from_single(ACCESS_KEY, SECRET_KEY);
+        let ccx = test_context(&s3, &config, &auth);
+
+        for version in [Version::HTTP_11, Version::HTTP_2] {
+            let mut req = empty_body_signed_put(version);
+            assert!(req.headers.get(hyper::header::CONTENT_LENGTH).is_none());
+
+            let response = super::call(&mut req, &ccx).await.unwrap();
+            assert_eq!(response.status, StatusCode::OK, "empty-body PutObject over {version:?} must be accepted");
+
+            let (input_len, header_len) = recording.received.lock().unwrap().take().expect("put_object was called");
+            assert_eq!(input_len, Some(0), "dto content_length must be backfilled over {version:?}");
+            assert_eq!(header_len, Some(0), "Content-Length header must be inserted over {version:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn decoded_content_length_takes_priority_over_exact_length() {
+        // aws-chunked uploads express the object size via
+        // `x-amz-decoded-content-length`; when present it must win over the
+        // exact remaining length of the (empty) body.
+        let recording = Arc::new(ContentLengthRecordingS3 {
+            received: Mutex::new(None),
+        });
+        let s3: Arc<dyn crate::s3_trait::S3> = recording.clone();
+        let config = test_config();
+        let auth = SimpleAuth::from_single(ACCESS_KEY, SECRET_KEY);
+        let ccx = test_context(&s3, &config, &auth);
+
+        let mut req = empty_body_signed_put(Version::HTTP_11);
+        req.headers
+            .insert(crate::header::X_AMZ_DECODED_CONTENT_LENGTH, HeaderValue::from_static("5"));
+
+        let response = super::call(&mut req, &ccx).await.unwrap();
+        assert_eq!(response.status, StatusCode::OK);
+
+        let (input_len, header_len) = recording.received.lock().unwrap().take().expect("put_object was called");
+        assert_eq!(input_len, Some(5), "decoded content length must take priority");
+        assert_eq!(header_len, Some(5));
+    }
+
+    #[tokio::test]
+    async fn normalize_content_length_disabled_keeps_strict_header_semantics() {
+        let recording = Arc::new(ContentLengthRecordingS3 {
+            received: Mutex::new(None),
+        });
+        let s3: Arc<dyn crate::s3_trait::S3> = recording.clone();
+        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::new(Arc::new(S3Config {
+            presigned_url_max_skew_time_secs: u32::MAX,
+            expected_region: Some(REGION.parse().expect("valid test region")),
+            normalize_content_length: false,
+            ..Default::default()
+        })));
+        let auth = SimpleAuth::from_single(ACCESS_KEY, SECRET_KEY);
+        let ccx = test_context(&s3, &config, &auth);
+
+        let mut req = empty_body_signed_put(Version::HTTP_11);
+        assert!(req.headers.get(hyper::header::CONTENT_LENGTH).is_none());
+
+        let response = super::call(&mut req, &ccx).await.unwrap();
+        assert_eq!(response.status, StatusCode::OK, "s3s still accepts the request");
+
+        let (input_len, header_len) = recording.received.lock().unwrap().take().expect("put_object was called");
+        assert_eq!(input_len, None, "dto content_length must reflect the wire headers when disabled");
+        assert_eq!(header_len, None, "no Content-Length may be inserted when disabled");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

A PUT without `Content-Length` and without `Transfer-Encoding` has an empty body (RFC 9112 §6.3). hyper omits `Content-Length` for empty bodies, so hyper/reqwest-based clients send exactly this when storing an empty object — and it is what rustfs/rustfs#6830 reports as a `400 UnexpectedContent`.

`s3s` currently defines `PutObjectInput.content_length` (and the other payload-operation inputs) as a strict reflection of the wire headers: a missing header yields `None`, even when the body length is known (an empty body is protocol-known to be zero; aws-chunked uploads declare the object size in `x-amz-decoded-content-length`). Storage implementations with a know-the-size-up-front pipeline must then treat `None` as ambiguous — the assumption behind the RustFS bug.

## Changes

New `S3Config::normalize_content_length` (default `true`): for streaming operations (`has_streaming_body`: `PutObject`, `UploadPart`, `WriteGetObjectResponse`), when the client sent no `Content-Length` but the body length is known, `s3s` inserts a `Content-Length` before the `S3` implementation observes the request:

- the `x-amz-decoded-content-length` value wins (aws-chunked uploads);
- otherwise an exact remaining length (`Body::remaining_length()` is `Exact(0)` for the empty body above) is used;
- unknown-length bodies (chunked `Transfer-Encoding` without aws-chunked) are never backfilled and keep the existing 411 (`Length Required`) behavior, including the signature-verification checks.

The insertion happens in `ops::prepare` after signature verification, so the verification paths (including the `MissingContentLength` rejections) see the original value; the generated input parsing then naturally picks up the inserted header. Set `normalize_content_length: false` to restore the strict header-reflection semantics.

## Breaking change

`S3Request.headers` may now contain an inserted `Content-Length` that was not on the wire, and payload-operation inputs may carry a `content_length` where the client sent none (e.g. `Some(0)` for an empty PUT without `Content-Length`, or the decoded length for aws-chunked uploads). Implementations relying on `None` meaning "the client sent no `Content-Length`" observe this change; the new default matches what MinIO/SeaweedFS/Garage accept.

## Tests

- Default (enabled): empty-body PUT without `Content-Length` over HTTP/1.1 and HTTP/2 → `200`, `PutObjectInput.content_length == Some(0)`, and an inserted `Content-Length: 0` header visible to the `S3` implementation.
- `x-amz-decoded-content-length` takes priority over the exact remaining length.
- Disabled: strict semantics preserved (`None`, no header inserted).
- Regression: `signed_put_object_still_rejects_missing_content_length` (unknown-length body → 411) and the bodyless-operation suite pass unchanged.

Verified with `just dev` (fetch/fmt/codegen/lint/test) and the full workspace test suite, rebased on the current main (which includes the streaming body-limit work in #758; the backfill nests under the same `has_streaming_body` branch).
