### PR TITLE
fix(s3s/host)!: ignore explicit ports when matching virtual-hosted base domains

### DIFF
--- a/crates/s3s/src/host.rs
+++ b/crates/s3s/src/host.rs
@@ -43,6 +43,17 @@
 //! fallback happens only for hosts that match the rule above or fail the
 //! bucket-name check; see
 //! [s3s-project/s3s#643](https://github.com/s3s-project/s3s/issues/643).
+//!
+//! # Port-agnostic base-domain matching
+//!
+//! Base-domain matching (in [`SingleDomain`] and [`MultiDomain`]) ignores an
+//! explicit `:<port>` suffix on either the request host or the configured
+//! base domain, so `user.example.com:19000` matches the base domain
+//! `example.com` exactly like `user.example.com` does (and a base domain
+//! configured with a port, e.g. `example.com:19000`, matches the same hosts).
+//! The signature path continues to use the raw `Host` value, and the CNAME
+//! fallback and `with_path_style_hosts` matching also keep the full value —
+//! only routing matches strip the port.
 #![deny(missing_docs)]
 
 use crate::error::S3Result;
@@ -184,6 +195,24 @@ pub enum DomainError {
     ZeroDomains,
 }
 
+/// Strips a validated `:<port>` suffix (all digits, fits in `u16`) from a
+/// host authority.
+///
+/// Routing matches use the stripped form; signature verification and wire
+/// passthrough keep the original value. Malformed ports (`:http`, `:65536`,
+/// empty suffix) and bare bracketed IPv6 literals are returned unchanged;
+/// malformed inputs at worst get partially stripped and then fall into the
+/// existing rejection paths.
+pub(crate) fn strip_port_suffix(host: &str) -> &str {
+    if host.ends_with(']') {
+        return host; // bracketed IPv6 literal without a port
+    }
+    match host.rsplit_once(':') {
+        Some((h, port)) if !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) && port.parse::<u16>().is_ok() => h,
+        _ => host,
+    }
+}
+
 /// Naive check for a valid domain.
 fn is_valid_domain(mut s: &str) -> bool {
     if s.is_empty() {
@@ -217,10 +246,14 @@ fn is_valid_domain(mut s: &str) -> bool {
 
 /// Checks whether two base domains would compete for the same host header.
 ///
-/// Two domains overlap when they are equal, or when one is a DNS subdomain of the other.
-/// The suffix must end on a label boundary, matching [`parse_host_header`]: `s3.example.com`
-/// is a subdomain of `example.com`, while `s3-example.com` is an unrelated domain.
+/// Two domains overlap when they are equal (after stripping any explicit
+/// `:<port>` suffix), or when one is a DNS subdomain of the other. The suffix
+/// must end on a label boundary, matching [`parse_host_header`]:
+/// `s3.example.com` is a subdomain of `example.com`, while `s3-example.com`
+/// is an unrelated domain.
 fn is_overlapping(a: &str, b: &str) -> bool {
+    let a = strip_port_suffix(a);
+    let b = strip_port_suffix(b);
     a == b || is_subdomain_of(a, b) || is_subdomain_of(b, a)
 }
 
@@ -230,11 +263,16 @@ fn is_subdomain_of(host: &str, base_domain: &str) -> bool {
 }
 
 fn parse_host_header<'a>(base_domain: &'a str, host: &'a str) -> Option<VirtualHost<'a>> {
-    if host == base_domain {
+    // Port-agnostic matching (see the module docs): an explicit `:<port>`
+    // suffix on either side does not participate in the comparison.
+    let host_part = strip_port_suffix(host);
+    let base_part = strip_port_suffix(base_domain);
+
+    if host_part == base_part {
         return Some(VirtualHost::new(base_domain));
     }
 
-    if let Some(bucket) = host.strip_suffix(base_domain).and_then(|h| h.strip_suffix('.')) {
+    if let Some(bucket) = host_part.strip_suffix(base_part).and_then(|h| h.strip_suffix('.')) {
         return Some(VirtualHost::new(base_domain).with_bucket(bucket));
     }
 
@@ -554,6 +592,123 @@ mod tests {
         let vh = result.unwrap();
         assert_eq!(vh.domain(), "example.com");
         assert_eq!(vh.bucket(), Some("example.com.org"));
+    }
+
+    #[test]
+    fn multi_domain_parse_with_port() {
+        // Regression for <https://github.com/s3s-project/s3s/issues/438>:
+        // an explicit non-default port on the host must not prevent
+        // virtual-hosted-style matching.
+        let md = MultiDomain::new(["fs.example.com"]).unwrap();
+
+        let vh = md.parse_host_header("user.fs.example.com:19000").unwrap();
+        assert_eq!(vh.domain(), "fs.example.com");
+        assert_eq!(vh.bucket(), Some("user"));
+
+        // exact match with a port
+        let vh = md.parse_host_header("fs.example.com:19000").unwrap();
+        assert_eq!(vh.domain(), "fs.example.com");
+        assert_eq!(vh.bucket(), None);
+
+        // a default port is treated like any other port
+        let vh = md.parse_host_header("user.fs.example.com:443").unwrap();
+        assert_eq!(vh.domain(), "fs.example.com");
+        assert_eq!(vh.bucket(), Some("user"));
+    }
+
+    #[test]
+    fn single_domain_parse_with_port() {
+        let sd = SingleDomain::new("fs.example.com").unwrap();
+
+        let vh = sd.parse_host_header("user.fs.example.com:19000").unwrap();
+        assert_eq!(vh.domain(), "fs.example.com");
+        assert_eq!(vh.bucket(), Some("user"));
+    }
+
+    #[test]
+    fn base_domain_with_port_matches_requests() {
+        // Base domains may carry a port (the rustfs SERVER_DOMAINS
+        // workaround); matching is port-agnostic on both sides.
+        let sd = SingleDomain::new("fs.example.com:19000").unwrap();
+
+        // client omits the port
+        let vh = sd.parse_host_header("user.fs.example.com").unwrap();
+        assert_eq!(vh.domain(), "fs.example.com:19000");
+        assert_eq!(vh.bucket(), Some("user"));
+
+        // client sends the same port
+        let vh = sd.parse_host_header("user.fs.example.com:19000").unwrap();
+        assert_eq!(vh.domain(), "fs.example.com:19000");
+        assert_eq!(vh.bucket(), Some("user"));
+
+        // a different port still matches exactly (ports do not participate)
+        let vh = sd.parse_host_header("fs.example.com:8080").unwrap();
+        assert_eq!(vh.domain(), "fs.example.com:19000");
+        assert_eq!(vh.bucket(), None);
+    }
+
+    #[test]
+    fn parse_with_malformed_ports_falls_back() {
+        // Malformed ports are not stripped; the host fails to match any
+        // base domain, and the non-numeric port makes it an invalid host
+        // (rejected as today — the helper must not change this).
+        let md = MultiDomain::new(["fs.example.com"]).unwrap();
+
+        for host in [
+            "user.fs.example.com:http",
+            "user.fs.example.com:65536",
+            "user.fs.example.com:",
+        ] {
+            let err = md.parse_host_header(host).unwrap_err();
+            assert_eq!(err.code(), &S3ErrorCode::InvalidRequest, "{host:?}");
+        }
+    }
+
+    #[test]
+    fn parse_without_false_strip() {
+        // A host ending in the base domain suffix-matches regardless of any
+        // embedded port: the full prefix becomes the bucket (with the port).
+        // This is unchanged from before the port-agnostic fix — the strip
+        // only affects the base-domain comparison, not suffix semantics.
+        let md = MultiDomain::new(["fs.example.com"]).unwrap();
+
+        let vh = md.parse_host_header("evil.fs.example.com:1234.fs.example.com").unwrap();
+        assert_eq!(vh.bucket(), Some("evil.fs.example.com:1234"));
+    }
+
+    #[test]
+    fn multi_domain_new_overlap_ignores_ports() {
+        // The overlap check runs on the port-stripped forms, so port variants
+        // of the same domain cannot coexist (they would route the same hosts).
+        for domains in [
+            ["example.com", "example.com:8080"],
+            ["a.com:1", "a.com:2"],
+            ["a.com:1", "b.a.com:2"],
+        ] {
+            let err = MultiDomain::new(domains).unwrap_err();
+            assert_eq!(err, DomainError::OverlappingSubdomains, "{domains:?}");
+        }
+
+        // unrelated domains stay accepted, port or not
+        for domains in [
+            ["example.com:8080", "example.org:8080"],
+            ["example.com:8080", "s3-example.com:8080"],
+        ] {
+            let md = MultiDomain::new(domains).unwrap();
+            assert_eq!(md.base_domains, domains, "{domains:?}");
+        }
+    }
+
+    #[test]
+    fn parse_with_port_and_bracketed_ipv6_stays_rejected() {
+        // Not fixed by this change (out of scope): bracketed IPv6 literals
+        // remain invalid hosts; the helper must not make them worse.
+        let md = MultiDomain::new(["fs.example.com"]).unwrap();
+
+        for host in ["[2001:db8::1]:443", "[::1]", "[::1]:8080"] {
+            let err = md.parse_host_header(host).unwrap_err();
+            assert_eq!(err.code(), &S3ErrorCode::InvalidRequest, "{host:?}");
+        }
     }
 
     #[test]

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -1830,14 +1830,14 @@ file content\r\n\
         let host = "user.fs.example.com:19000";
         let headers_for_signing = [("host", host)];
         let query_strings_for_signing = presigned_query_fields(&amz_date, "s3");
-        let canonical_request = sig_v4::create_presigned_canonical_request(
-            &method,
+        let canonical_request = s3s_sigv4::create_presigned_canonical_request(
+            method.as_str(),
             decoded_uri_path,
             &query_strings_for_signing,
             headers_for_signing,
         );
-        let string_to_sign = sig_v4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
-        let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
+        let string_to_sign = s3s_sigv4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
+        let signature = s3s_sigv4::calculate_signature(&string_to_sign, secret_key.expose(), &amz_date, "us-east-1", "s3");
         let mut signed_query_strings = query_strings_for_signing;
         signed_query_strings.push(("X-Amz-Signature".to_owned(), signature.as_str().to_owned()));
         let qs = OrderedQs::from_vec_unchecked(signed_query_strings);
@@ -1898,15 +1898,15 @@ file content\r\n\
             ("x-amz-content-sha256", payload_hash),
             ("x-amz-date", amz_date_str.as_str()),
         ];
-        let canonical_request = sig_v4::create_canonical_request(
-            &method,
+        let canonical_request = s3s_sigv4::create_canonical_request(
+            method.as_str(),
             decoded_uri_path,
             &[] as &[(&str, &str)],
             signed_headers,
-            sig_v4::Payload::SingleChunk(payload_hash),
+            s3s_sigv4::Payload::SingleChunk(payload_hash),
         );
-        let string_to_sign = sig_v4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
-        let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
+        let string_to_sign = s3s_sigv4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
+        let signature = s3s_sigv4::calculate_signature(&string_to_sign, secret_key.expose(), &amz_date, "us-east-1", "s3");
         let authorization = format!(
             "AWS4-HMAC-SHA256 Credential={access_key}/{}/us-east-1/s3/aws4_request, \
              SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={}",
@@ -1964,20 +1964,19 @@ file content\r\n\
             ("AWSAccessKeyId".to_owned(), "AKIAIOSFODNN7EXAMPLE".to_owned()),
             ("Expires".to_owned(), "4294967295".to_owned()),
         ];
-        let string_to_sign = crate::sig_v2::create_string_to_sign(
-            crate::sig_v2::Mode::PresignedUrl,
-            &method,
+        let string_to_sign = s3s_sigv2::create_string_to_sign(
+            s3s_sigv2::Mode::PresignedUrl,
+            method.as_str(),
             "/test.txt",
-            Some(&OrderedQs::from_vec_unchecked(qs_pairs.clone())),
-            &headers,
+            Some(&qs_pairs),
+            &[("host", host)],
             Some("user"),
-        )
-        .expect("presigned string-to-sign construction cannot fail");
+        );
         assert!(
             string_to_sign.contains("/user/test.txt"),
             "the routed bucket prefix must enter the canonicalized resource, got: {string_to_sign:?}"
         );
-        let signature = crate::sig_v2::calculate_signature(&secret_key, &string_to_sign);
+        let signature = s3s_sigv2::calculate_signature(secret_key.expose(), &string_to_sign);
         let mut qs_pairs = qs_pairs;
         qs_pairs.push(("Signature".to_owned(), signature.as_str().to_owned()));
         let qs = OrderedQs::from_vec_unchecked(qs_pairs);

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -1807,6 +1807,241 @@ file content\r\n\
     }
 
     #[tokio::test]
+    async fn v4_presigned_url_with_port_in_signed_host() {
+        // Signature-invariant nail for the port-agnostic routing fix (#438):
+        // signature verification must keep using the raw Host value including
+        // any port, even though routing now matches without it.
+        use crate::auth::SecretKey;
+        use crate::auth::SimpleAuth;
+        use crate::config::{S3ConfigProvider, StaticConfigProvider};
+        use std::sync::Arc;
+
+        let access_key = "AKIAIOSFODNN7EXAMPLE";
+        let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
+        let auth = SimpleAuth::from_single(access_key, secret_key.clone());
+        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+
+        let method = Method::GET;
+        let uri = Uri::from_static("https://user.fs.example.com:19000/test.txt");
+        let decoded_uri_path = "/test.txt";
+        let raw_uri_path = "/test.txt";
+        let amz_date = AmzDate::parse(&fmt_current_amz_date(time::OffsetDateTime::now_utc()))
+            .expect("current time should produce a valid x-amz-date");
+        let host = "user.fs.example.com:19000";
+        let headers_for_signing = [("host", host)];
+        let query_strings_for_signing = presigned_query_fields(&amz_date, "s3");
+        let canonical_request = sig_v4::create_presigned_canonical_request(
+            &method,
+            decoded_uri_path,
+            &query_strings_for_signing,
+            headers_for_signing,
+        );
+        let string_to_sign = sig_v4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
+        let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
+        let mut signed_query_strings = query_strings_for_signing;
+        signed_query_strings.push(("X-Amz-Signature".to_owned(), signature.as_str().to_owned()));
+        let qs = OrderedQs::from_vec_unchecked(signed_query_strings);
+
+        let headers = headers_from_slice(&[("host", host)]);
+        let mut body = Body::empty();
+        let mut cx = SignatureContext {
+            auth: Some(&auth),
+            config: &config,
+            req_version: ::http::Version::HTTP_11,
+            req_method: &method,
+            req_uri: &uri,
+            req_body: &mut body,
+            qs: Some(&qs),
+            hs: &headers,
+            decoded_uri_path,
+            raw_uri_path,
+            vh_bucket: Some("user"),
+            content_length: None,
+            mime: None,
+            decoded_content_length: None,
+            transformed_body: None,
+            multipart: None,
+            trailing_headers: None,
+        };
+
+        let cred = cx
+            .v4_check_presigned_url()
+            .await
+            .expect("the raw Host value with its port must be used for verification");
+        assert_eq!(cred.access_key, access_key);
+    }
+
+    #[tokio::test]
+    async fn v4_header_auth_with_port_in_signed_host() {
+        // Header-auth counterpart of the signature-invariant nail above.
+        use crate::auth::SecretKey;
+        use crate::auth::SimpleAuth;
+        use crate::config::{S3ConfigProvider, StaticConfigProvider};
+        use std::sync::Arc;
+
+        let access_key = "AKIAIOSFODNN7EXAMPLE";
+        let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".into();
+        let auth = SimpleAuth::from_single(access_key, secret_key.clone());
+        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+
+        let method = Method::GET;
+        let uri = Uri::from_static("https://user.fs.example.com:19000/test.txt");
+        let decoded_uri_path = "/test.txt";
+        let raw_uri_path = "/test.txt";
+        let amz_date = AmzDate::parse(&fmt_current_amz_date(time::OffsetDateTime::now_utc()))
+            .expect("current time should produce a valid x-amz-date");
+        let amz_date_str = amz_date.fmt_iso8601();
+        let host = "user.fs.example.com:19000";
+        let payload_hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        let signed_headers = [
+            ("host", host),
+            ("x-amz-content-sha256", payload_hash),
+            ("x-amz-date", amz_date_str.as_str()),
+        ];
+        let canonical_request = sig_v4::create_canonical_request(
+            &method,
+            decoded_uri_path,
+            &[] as &[(&str, &str)],
+            signed_headers,
+            sig_v4::Payload::SingleChunk(payload_hash),
+        );
+        let string_to_sign = sig_v4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
+        let signature = sig_v4::calculate_signature(&string_to_sign, &secret_key, &amz_date, "us-east-1", "s3");
+        let authorization = format!(
+            "AWS4-HMAC-SHA256 Credential={access_key}/{}/us-east-1/s3/aws4_request, \
+             SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={}",
+            amz_date.fmt_date(),
+            signature.as_str(),
+        );
+
+        let headers = headers_from_slice(&[
+            ("host", host),
+            ("x-amz-content-sha256", payload_hash),
+            ("x-amz-date", amz_date_str.as_str()),
+            ("authorization", authorization.as_str()),
+        ]);
+        let mut body = Body::empty();
+        let mut cx = SignatureContext {
+            auth: Some(&auth),
+            config: &config,
+            req_version: ::http::Version::HTTP_11,
+            req_method: &method,
+            req_uri: &uri,
+            req_body: &mut body,
+            qs: None,
+            hs: &headers,
+            decoded_uri_path,
+            raw_uri_path,
+            vh_bucket: Some("user"),
+            content_length: None,
+            mime: None,
+            decoded_content_length: None,
+            transformed_body: None,
+            multipart: None,
+            trailing_headers: None,
+        };
+
+        let cred = cx
+            .v4_check()
+            .await
+            .expect("header auth must be detected")
+            .expect("the raw Host value with its port must be used for verification");
+        assert_eq!(cred.access_key, access_key);
+    }
+
+    #[tokio::test]
+    async fn sig_v2_vhost_presigned_url_with_port_uses_wire_host() {
+        // SigV2 counterpart of the signature-invariant nail: the canonicalized
+        // resource must contain the routed bucket prefix (/user) derived from
+        // the port-carrying vhost host, while verification keeps the raw Host.
+        let host = "user.fs.example.com:19000";
+        let secret_key: crate::auth::SecretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into();
+
+        let method = Method::GET;
+        let uri = Uri::from_static("https://user.fs.example.com:19000/test.txt");
+        let headers = headers_from_slice(&[("host", host)]);
+        let qs_pairs = vec![
+            ("AWSAccessKeyId".to_owned(), "AKIAIOSFODNN7EXAMPLE".to_owned()),
+            ("Expires".to_owned(), "4294967295".to_owned()),
+        ];
+        let string_to_sign = crate::sig_v2::create_string_to_sign(
+            crate::sig_v2::Mode::PresignedUrl,
+            &method,
+            "/test.txt",
+            Some(&OrderedQs::from_vec_unchecked(qs_pairs.clone())),
+            &headers,
+            Some("user"),
+        )
+        .expect("presigned string-to-sign construction cannot fail");
+        assert!(
+            string_to_sign.contains("/user/test.txt"),
+            "the routed bucket prefix must enter the canonicalized resource, got: {string_to_sign:?}"
+        );
+        let signature = crate::sig_v2::calculate_signature(&secret_key, &string_to_sign);
+        let mut qs_pairs = qs_pairs;
+        qs_pairs.push(("Signature".to_owned(), signature.as_str().to_owned()));
+        let qs = OrderedQs::from_vec_unchecked(qs_pairs);
+
+        let mut body = Body::empty();
+        let enabled_config = sig_v2_test_config(true);
+        let auth = crate::auth::SimpleAuth::from_single("AKIAIOSFODNN7EXAMPLE", secret_key.clone());
+        let mut cx = SignatureContext {
+            auth: Some(&auth),
+            config: &enabled_config,
+            req_version: ::http::Version::HTTP_11,
+            req_method: &method,
+            req_uri: &uri,
+            req_body: &mut body,
+            qs: Some(&qs),
+            hs: &headers,
+            decoded_uri_path: "/test.txt",
+            raw_uri_path: "/test.txt",
+            vh_bucket: Some("user"),
+            content_length: None,
+            mime: None,
+            decoded_content_length: None,
+            transformed_body: None,
+            multipart: None,
+            trailing_headers: None,
+        };
+        let cred = cx
+            .v2_check()
+            .await
+            .expect("v2 presigned url must be detected")
+            .expect("vhost presigned SigV2 with a port-carrying host must verify");
+        assert_eq!(cred.access_key, "AKIAIOSFODNN7EXAMPLE");
+
+        // negative control: the SigV2 gate takes precedence over the fix
+        let mut body = Body::empty();
+        let disabled_config = sig_v2_test_config(false);
+        let mut cx = SignatureContext {
+            auth: Some(&auth),
+            config: &disabled_config,
+            req_version: ::http::Version::HTTP_11,
+            req_method: &method,
+            req_uri: &uri,
+            req_body: &mut body,
+            qs: Some(&qs),
+            hs: &headers,
+            decoded_uri_path: "/test.txt",
+            raw_uri_path: "/test.txt",
+            vh_bucket: Some("user"),
+            content_length: None,
+            mime: None,
+            decoded_content_length: None,
+            transformed_body: None,
+            multipart: None,
+            trailing_headers: None,
+        };
+        let err = cx
+            .v2_check()
+            .await
+            .expect("v2 presigned url must be detected")
+            .expect_err("SigV2 must be rejected when disabled");
+        assert_eq!(err.code(), &S3ErrorCode::AccessDenied);
+    }
+
+    #[tokio::test]
     async fn v4_presigned_url_put_with_valid_content_sha256() {
         use crate::auth::SecretKey;
         use crate::auth::SimpleAuth;

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -582,6 +582,111 @@ async fn host_fallback_path_style_and_cname() {
     );
 }
 
+/// A virtual-hosted-style request carrying an explicit non-default port must
+/// still route to the bucket (issue #438). Routing matches the port-stripped
+/// host; the signature path keeps the raw value (pinned in the signature
+/// tests). See
+/// [s3s-project/s3s#438](https://github.com/s3s-project/s3s/issues/438).
+#[tokio::test]
+async fn vhost_with_port_routes_bucket() {
+    use crate::config::{S3ConfigProvider, StaticConfigProvider};
+    use crate::host::MultiDomain;
+    use crate::http::{Body, Request};
+    use crate::path::S3Path;
+    use std::sync::Arc;
+
+    struct NoOpS3;
+    #[async_trait::async_trait]
+    impl crate::s3_trait::S3 for NoOpS3 {}
+
+    let s3: Arc<dyn crate::s3_trait::S3> = Arc::new(NoOpS3);
+    let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+    let host = MultiDomain::new(["fs.example.com"]).unwrap();
+    let ccx = CallContext {
+        s3: &s3,
+        config: &config,
+        host: Some(&host),
+        auth: None,
+        access: None,
+        route: None,
+        validation: None,
+    };
+
+    // HTTP/1.1: the Host header carries the port.
+    let mut req = Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .uri("http://user.fs.example.com:19000/avatar.png")
+            .header(crate::header::HOST, "user.fs.example.com:19000")
+            .body(Body::empty())
+            .unwrap(),
+    );
+    let _ = super::prepare(&mut req, &ccx).await;
+    assert!(
+        matches!(req.s3ext.s3_path, Some(S3Path::Object { ref bucket, .. }) if bucket.as_ref() == "user"),
+        "port-carrying vhost host must route to its bucket"
+    );
+
+    // HTTP/2: no Host header; the :authority is injected as the host.
+    let mut req = Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .version(::http::Version::HTTP_2)
+            .uri("http://user.fs.example.com:19000/avatar.png")
+            .body(Body::empty())
+            .unwrap(),
+    );
+    assert!(req.headers.get(crate::header::HOST).is_none());
+    let _ = super::prepare(&mut req, &ccx).await;
+    assert!(
+        matches!(req.s3ext.s3_path, Some(S3Path::Object { ref bucket, .. }) if bucket.as_ref() == "user"),
+        "HTTP/2 :authority with a port must route to its bucket"
+    );
+}
+
+/// Control group for the port-agnostic fix: when the base domain is not
+/// configured, the port-carrying host must keep the pre-fix path-style
+/// behavior (#643 semantics untouched).
+#[tokio::test]
+async fn vhost_with_port_unconfigured_domain_falls_back_to_path_style() {
+    use crate::config::{S3ConfigProvider, StaticConfigProvider};
+    use crate::host::MultiDomain;
+    use crate::http::{Body, Request};
+    use crate::path::S3Path;
+    use std::sync::Arc;
+
+    struct NoOpS3;
+    #[async_trait::async_trait]
+    impl crate::s3_trait::S3 for NoOpS3 {}
+
+    let s3: Arc<dyn crate::s3_trait::S3> = Arc::new(NoOpS3);
+    let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+    let host = MultiDomain::new(["other.example.com"]).unwrap();
+    let ccx = CallContext {
+        s3: &s3,
+        config: &config,
+        host: Some(&host),
+        auth: None,
+        access: None,
+        route: None,
+        validation: None,
+    };
+
+    let mut req = Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .uri("http://user.fs.example.com:19000/avatar.png")
+            .header(crate::header::HOST, "user.fs.example.com:19000")
+            .body(Body::empty())
+            .unwrap(),
+    );
+    let _ = super::prepare(&mut req, &ccx).await;
+    assert!(
+        !matches!(req.s3ext.s3_path, Some(S3Path::Object { ref bucket, .. }) if bucket.as_ref() == "user"),
+        "an unconfigured domain with a port must not route to a vhost bucket"
+    );
+}
+
 /// With a path-style host rule configured, an unrecognized host matching it
 /// is parsed as path-style even when it is a valid bucket name. See
 /// [s3s-project/s3s#643](https://github.com/s3s-project/s3s/issues/643).

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -1050,6 +1050,118 @@ async fn presigned_url_expires_0_should_be_expired() {
     assert_eq!(err.code(), &S3ErrorCode::AccessDenied);
 }
 
+/// End-to-end: a `SigV4` presigned URL whose host carries an explicit
+/// non-default port must route to the bucket and verify (issue #438,
+/// rustfs/rustfs#1099). Covers the full chain: routing (port-agnostic base
+/// domain match), signature verification (raw Host value), and dispatch to
+/// the `S3` implementation with the correct bucket.
+#[tokio::test]
+async fn presigned_url_with_port_and_vhost_routes_bucket() {
+    use crate::auth::{SecretKey, SimpleAuth};
+    use crate::config::{S3Config, S3ConfigProvider, StaticConfigProvider};
+    use crate::host::MultiDomain;
+    use crate::http::{Body, Request};
+    use std::sync::Arc;
+
+    struct RecordingS3 {
+        received: std::sync::Mutex<Option<(String, String)>>, // (bucket, key)
+    }
+    #[async_trait::async_trait]
+    impl crate::s3_trait::S3 for RecordingS3 {
+        async fn get_object(
+            &self,
+            req: crate::S3Request<crate::dto::GetObjectInput>,
+        ) -> crate::error::S3Result<crate::protocol::S3Response<crate::dto::GetObjectOutput>> {
+            *self.received.lock().unwrap() = Some((req.input.bucket.clone(), req.input.key.clone()));
+            Ok(crate::protocol::S3Response::new(crate::dto::GetObjectOutput::default()))
+        }
+    }
+
+    let access_key = "AKIAIOSFODNN7EXAMPLE";
+    let secret_key: SecretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into();
+    let recording = Arc::new(RecordingS3 {
+        received: std::sync::Mutex::new(None),
+    });
+    let s3: Arc<dyn crate::s3_trait::S3> = recording.clone();
+    let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::new(Arc::new(S3Config {
+        presigned_url_max_skew_time_secs: u32::MAX,
+        ..Default::default()
+    })));
+    let auth = SimpleAuth::from_single(access_key, secret_key.clone());
+    let host = MultiDomain::new(["fs.example.com"]).unwrap();
+    let ccx = CallContext {
+        s3: &s3,
+        config: &config,
+        host: Some(&host),
+        auth: Some(&auth),
+        access: None,
+        route: None,
+        validation: None,
+    };
+
+    // Sign a presigned URL for the port-carrying vhost host.
+    let host_hdr = "user.fs.example.com:19000";
+    let amz_date = s3s_sigv4::AmzDate::parse(&format_current_amz_date()).expect("current time is a valid x-amz-date");
+    let query_fields = [
+        ("X-Amz-Algorithm".to_owned(), "AWS4-HMAC-SHA256".to_owned()),
+        (
+            "X-Amz-Credential".to_owned(),
+            format!("{access_key}/{}/us-east-1/s3/aws4_request", amz_date.fmt_date()),
+        ),
+        ("X-Amz-Date".to_owned(), amz_date.fmt_iso8601().to_string()),
+        ("X-Amz-Expires".to_owned(), "604800".to_owned()),
+        ("X-Amz-SignedHeaders".to_owned(), "host".to_owned()),
+    ];
+    let canonical_request =
+        s3s_sigv4::create_presigned_canonical_request("GET", "/avatar.png", &query_fields, [("host", host_hdr)]);
+    let string_to_sign = s3s_sigv4::create_string_to_sign(&canonical_request, &amz_date, "us-east-1", "s3");
+    let signature = s3s_sigv4::calculate_signature(&string_to_sign, secret_key.expose(), &amz_date, "us-east-1", "s3");
+    let mut query_fields: Vec<(String, String)> = query_fields.into();
+    query_fields.push(("X-Amz-Signature".to_owned(), signature));
+
+    let mut uri = format!("https://{host_hdr}/avatar.png?").to_owned();
+    uri.push_str(
+        &query_fields
+            .iter()
+            .map(|(k, v)| format!("{k}={}", urlencoding::encode(v)))
+            .collect::<Vec<_>>()
+            .join("&"),
+    );
+
+    let mut req = Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .uri(uri)
+            .header(crate::header::HOST, host_hdr)
+            .body(Body::empty())
+            .unwrap(),
+    );
+
+    let response = super::call(&mut req, &ccx).await.unwrap();
+    assert_eq!(
+        response.status,
+        hyper::StatusCode::OK,
+        "presigned URL with a port-carrying host must succeed"
+    );
+
+    let (bucket, key) = recording.received.lock().unwrap().take().expect("get_object was called");
+    assert_eq!(bucket.as_str(), "user");
+    assert_eq!(key.as_str(), "avatar.png");
+}
+
+fn format_current_amz_date() -> String {
+    let dt = time::OffsetDateTime::now_utc();
+    format!(
+        "{:04}{:02}{:02}T{:02}{:02}{:02}Z",
+        dt.year(),
+        u8::from(dt.month()),
+        dt.day(),
+        dt.hour(),
+        dt.minute(),
+        dt.second()
+    )
+}
+
 #[allow(clippy::too_many_lines)]
 #[tokio::test]
 async fn post_multipart_bucket_routes_to_post_object() {

--- a/scripts/e2e-boto3-fs.sh
+++ b/scripts/e2e-boto3-fs.sh
@@ -16,7 +16,6 @@ s3s-fs \
     --secret-key    SKEXAMPLES3S    \
     --host          localhost       \
     --port          8014            \
-    --domain        localhost:8014  \
     --domain        localhost       \
     "$DATA_DIR" | tee target/s3s-fs-boto3.log &
 

--- a/scripts/e2e-fs.sh
+++ b/scripts/e2e-fs.sh
@@ -16,7 +16,6 @@ s3s-fs \
     --secret-key    SKEXAMPLES3S    \
     --host          localhost       \
     --port          8014            \
-    --domain        localhost:8014  \
     --domain        localhost       \
     "$DATA_DIR" | tee target/s3s-fs.log &
 

--- a/scripts/e2e-rclone-fs.sh
+++ b/scripts/e2e-rclone-fs.sh
@@ -37,7 +37,6 @@ fi
     --secret-key SKEXAMPLES3S \
     --host 127.0.0.1 \
     --port "$S3S_RCLONE_PORT" \
-    --domain "localhost:$S3S_RCLONE_PORT" \
     --domain localhost \
     "$DATA_DIR" > "$SERVER_LOG" 2>&1 &
 S3S_FS_PID=$!

--- a/scripts/s3s-fs.sh
+++ b/scripts/s3s-fs.sh
@@ -17,6 +17,5 @@ s3s-fs \
     --secret-key    SKEXAMPLES3S    \
     --host          localhost       \
     --port          8014            \
-    --domain        localhost:8014  \
     --domain        localhost       \
     "$DATA_DIR"


### PR DESCRIPTION
## Problem

A virtual-hosted-style request carrying an explicit non-default port (e.g. `https://user.fs.example.com:19000/key.png?X-Amz-…`) failed to match the configured base domain (`fs.example.com`) in the built-in `SingleDomain` / `MultiDomain` host parsers and silently degraded to path-style — so presigned URLs built for such hosts resolved to the wrong bucket (s3s-project/s3s#438, rustfs/rustfs#1099).

## Changes

Routing matches are now port-agnostic:

- New `pub(crate) fn strip_port_suffix` (host.rs): strips a validated `:<port>` suffix (all digits, fits in `u16`; bracketed IPv6 literals handled) from a host authority. Malformed ports are never stripped.
- `parse_host_header` compares the port-stripped forms of both the request host and the configured base domain (exact and suffix matches). Four combinations (base/host with or without a port) now converge; base domains configured with a port (the rustfs `SERVER_DOMAINS` workaround) keep working.
- `is_overlapping` runs on the port-stripped forms, so `["example.com", "example.com:8080"]` is rejected as `OverlappingSubdomains` at construction instead of producing iteration-order-dependent routing.

Unchanged (signature/passthrough invariants): signature verification keeps the raw `Host` value with its port, the CNAME fallback and `with_path_style_hosts` matching keep the full value, `VirtualHost::domain()` keeps the configured text, and `looks_like_virtual_hosted_style` is untouched (no second behavior change).

## Behavior change

One observable change besides the fix itself: `MultiDomain::new` now rejects port variants of the same (or subdomain-related) base domain, e.g. `["example.com", "example.com:8080"]`, which previously constructed successfully with ambiguous, iteration-order-dependent routing. Affected configurations fail at construction with `OverlappingSubdomains`; migrate by dropping redundant port entries or using distinct DNS names.

## Tests

- host.rs equivalence table: port/no-port on both sides (the issue repro, workaround combinations, exact-with-port, different ports, default port), malformed ports (not stripped), suffix semantics unchanged, and the overlap enumeration.
- Signature-invariant nails: SigV4 header-auth and presigned self-signed verification with port-carrying hosts, plus a SigV2 vhost presigned case (with `enable_sig_v2` enabled/disabled controls) asserting the routed bucket prefix enters the canonicalized resource.
- Routing integration: HTTP/1.1 and HTTP/2 (`:authority` injection) port-carrying vhost requests resolve the bucket; a control group pins the #643 path-style fallback for unconfigured domains.

Verified with `just dev` (fetch/fmt/codegen/lint/test) and `just semver-checks` (no API diff).

Refs #438
