### PR TITLE
build(s3s-sigv2): enable all-features docs.rs builds

### DIFF
--- a/crates/s3s-sigv2/Cargo.toml
+++ b/crates/s3s-sigv2/Cargo.toml
@@ -10,6 +10,10 @@ repository.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
## Summary

The s3s-sigv2 crate (extracted in #736/#737 and #761) lacks the `[package.metadata.docs.rs]` configuration that `s3s` has, so docs.rs builds the crate without any feature coverage. Mirror the s3s metadata (`all-features = true` + `rustdoc-args`).

## Changes

- `crates/s3s-sigv2/Cargo.toml`: add `[package.metadata.docs.rs]` with `all-features = true`.

## Tests

Verified with `just dev` (fetch/fmt/codegen/lint/test); the branch is a single commit on top of the current main (which already contains the SigV2 migration #761).