### PR TITLE
feat(s3s/config)!: default put_object_max_size to 5 GiB

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ It is up to the user to implement security enhancements such as **HTTP body leng
 
 **Authentication is required for production deployments.** Without calling `set_auth`, the service accepts anonymous (unsigned) requests and skips authorization entirely: every S3 operation is open to any client that can reach the service, and signed requests fail with `NotImplemented` because no authentication provider is configured. A forgotten `set_auth` turns the service into a publicly readable and writable endpoint.
 
-For streaming uploads (`PUT Object`, `UploadPart`), `s3s` does not impose an object-size limit by default. If `S3Config::put_object_max_size` is not configured, the `S3` implementation is responsible for enforcing deployment-specific object caps. `POST Object` keeps using `S3Config::post_object_max_file_size`.
+For streaming uploads (`PUT Object`, `UploadPart`), `s3s` applies a default 5 GiB object-size limit matching the AWS single-PUT limit; set `S3Config::put_object_max_size` to `None` to disable it and enforce deployment-specific caps in the `S3` implementation. `POST Object` keeps using `S3Config::post_object_max_file_size`.
 
 ## Docker
 

--- a/crates/s3s/src/config.rs
+++ b/crates/s3s/src/config.rs
@@ -53,6 +53,9 @@ use crate::region::Region;
 // AWS-compatible default: https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html#PresignedUrl-Expiration
 pub(crate) const DEFAULT_PRESIGNED_URL_MAX_EXPIRES_SECS: u32 = 7 * 24 * 60 * 60;
 
+/// Default `S3Config::put_object_max_size`: 5 GiB, matching the AWS single-PUT object size limit.
+pub(crate) const DEFAULT_PUT_OBJECT_MAX_SIZE: u64 = 5 * 1024 * 1024 * 1024;
+
 // Aligned with MinIO: https://github.com/minio/minio/blob/master/cmd/streaming-signature-v4.go
 pub(crate) const DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE: usize = 256 * 1024 * 1024;
 
@@ -130,14 +133,14 @@ pub struct S3Config {
     /// This limit prevents unbounded memory allocation for operations that require
     /// the full body in memory (e.g., XML parsing).
     ///
-    /// Default: 20 MB (20 * 1024 * 1024)
+    /// Default: 20 MiB (20 * 1024 * 1024)
     pub xml_max_body_size: usize,
 
     /// Maximum file size for POST object in bytes.
     ///
-    /// S3 has a 5GB limit for single PUT object, so this is a reasonable default.
+    /// S3 has a 5 GiB limit for single PUT object, so this is a reasonable default.
     ///
-    /// Default: 5 GB (5 * 1024 * 1024 * 1024)
+    /// Default: 5 GiB (5 * 1024 * 1024 * 1024)
     pub post_object_max_file_size: u64,
 
     /// Optional maximum object size for streaming uploads in bytes.
@@ -152,7 +155,8 @@ pub struct S3Config {
     /// `POST Object` keeps using [`S3Config::post_object_max_file_size`] as its
     /// file-size limit.
     ///
-    /// Default: None
+    /// Default: 5 GiB (5 * 1024 * 1024 * 1024), matching the AWS single-PUT object
+    /// size limit. Set this to `None` explicitly to disable the limit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub put_object_max_size: Option<u64>,
 
@@ -164,7 +168,7 @@ pub struct S3Config {
     ///
     /// Set to `None` to disable the limit.
     ///
-    /// Default: 1 MB (1024 * 1024)
+    /// Default: 1 MiB (1024 * 1024)
     pub custom_route_max_body_size: Option<u64>,
 
     /// Maximum chunk data size for aws-chunked streaming uploads in bytes.
@@ -173,21 +177,21 @@ pub struct S3Config {
     /// so this limit bounds the memory retained per chunk. Unsigned chunks are streamed
     /// without buffering and are not subject to this limit.
     ///
-    /// Default: 256 MB (256 * 1024 * 1024)
+    /// Default: 256 MiB (256 * 1024 * 1024)
     pub aws_chunked_stream_max_chunk_size: usize,
 
     /// Maximum size per form field in bytes.
     ///
     /// This prevents denial-of-service attacks via oversized individual fields.
     ///
-    /// Default: 1 MB (1024 * 1024)
+    /// Default: 1 MiB (1024 * 1024)
     pub form_max_field_size: usize,
 
     /// Maximum total size for all form fields combined in bytes.
     ///
     /// This prevents denial-of-service attacks via accumulation of many fields.
     ///
-    /// Default: 20 MB (20 * 1024 * 1024)
+    /// Default: 20 MiB (20 * 1024 * 1024)
     pub form_max_fields_size: usize,
 
     /// Maximum number of parts in multipart form.
@@ -288,13 +292,13 @@ pub struct S3Config {
 impl Default for S3Config {
     fn default() -> Self {
         Self {
-            xml_max_body_size: 20 * 1024 * 1024,               // 20 MB
-            post_object_max_file_size: 5 * 1024 * 1024 * 1024, // 5 GB
-            put_object_max_size: None,
-            custom_route_max_body_size: Some(1024 * 1024), // 1 MB
+            xml_max_body_size: 20 * 1024 * 1024,               // 20 MiB
+            post_object_max_file_size: 5 * 1024 * 1024 * 1024, // 5 GiB
+            put_object_max_size: Some(DEFAULT_PUT_OBJECT_MAX_SIZE),
+            custom_route_max_body_size: Some(1024 * 1024), // 1 MiB
             aws_chunked_stream_max_chunk_size: DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
-            form_max_field_size: 1024 * 1024,       // 1 MB
-            form_max_fields_size: 20 * 1024 * 1024, // 20 MB
+            form_max_field_size: 1024 * 1024,       // 1 MiB
+            form_max_fields_size: 20 * 1024 * 1024, // 20 MiB
             form_max_parts: 1000,
             presigned_url_max_skew_time_secs: 900, // 15 minutes
             expected_region: None,
@@ -416,7 +420,7 @@ mod tests {
         let config = S3Config::default();
         assert_eq!(config.xml_max_body_size, 20 * 1024 * 1024);
         assert_eq!(config.post_object_max_file_size, 5 * 1024 * 1024 * 1024);
-        assert_eq!(config.put_object_max_size, None);
+        assert_eq!(config.put_object_max_size, Some(DEFAULT_PUT_OBJECT_MAX_SIZE));
         assert_eq!(config.custom_route_max_body_size, Some(1024 * 1024));
         assert_eq!(config.form_max_field_size, 1024 * 1024);
         assert_eq!(config.form_max_fields_size, 20 * 1024 * 1024);
@@ -495,7 +499,7 @@ mod tests {
         let snapshot = provider.snapshot();
         assert_eq!(snapshot.xml_max_body_size, 20 * 1024 * 1024);
         assert_eq!(snapshot.post_object_max_file_size, 5 * 1024 * 1024 * 1024);
-        assert_eq!(snapshot.put_object_max_size, None);
+        assert_eq!(snapshot.put_object_max_size, Some(DEFAULT_PUT_OBJECT_MAX_SIZE));
     }
 
     #[test]
@@ -504,7 +508,7 @@ mod tests {
         let snapshot = provider.snapshot();
         assert_eq!(snapshot.xml_max_body_size, 20 * 1024 * 1024);
         assert_eq!(snapshot.post_object_max_file_size, 5 * 1024 * 1024 * 1024);
-        assert_eq!(snapshot.put_object_max_size, None);
+        assert_eq!(snapshot.put_object_max_size, Some(DEFAULT_PUT_OBJECT_MAX_SIZE));
     }
 
     #[test]
@@ -542,12 +546,27 @@ mod tests {
         assert_eq!(config.xml_max_body_size, 1024);
         // Other fields should have defaults
         assert_eq!(config.post_object_max_file_size, 5 * 1024 * 1024 * 1024);
-        assert_eq!(config.put_object_max_size, None);
+        assert_eq!(config.put_object_max_size, Some(DEFAULT_PUT_OBJECT_MAX_SIZE));
         assert_eq!(config.custom_route_max_body_size, Some(1024 * 1024));
         assert_eq!(config.form_max_field_size, 1024 * 1024);
         assert_eq!(config.sig_v4_allowed_services, ["s3", "sts"]);
         assert_eq!(config.presigned_url_max_expires_secs, DEFAULT_PRESIGNED_URL_MAX_EXPIRES_SECS);
         assert!(config.normalize_content_length);
+    }
+
+    #[test]
+    fn test_serde_null_disables_put_object_max_size() {
+        // An explicit `null` opts out of the default limit (the opt-out path).
+        let json = r#"{"put_object_max_size": null}"#;
+        let config: S3Config = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(config.put_object_max_size, None);
+    }
+
+    #[test]
+    fn test_serde_explicit_put_object_max_size_overrides_default() {
+        let json = r#"{"put_object_max_size": 1024}"#;
+        let config: S3Config = serde_json::from_str(json).expect("deserialize failed");
+        assert_eq!(config.put_object_max_size, Some(1024));
     }
 
     #[test]
@@ -557,8 +576,13 @@ mod tests {
     }
 
     #[test]
-    fn test_serde_omits_unset_put_object_max_size() {
-        let json = serde_json::to_value(S3Config::default()).expect("serialize failed");
+    fn test_serde_omits_explicit_none_put_object_max_size() {
+        // The default now serializes as a value; only an explicit `None` is omitted.
+        let config = S3Config {
+            put_object_max_size: None,
+            ..S3Config::default()
+        };
+        let json = serde_json::to_value(config).expect("serialize failed");
         assert!(json.get("put_object_max_size").is_none());
     }
 

--- a/crates/s3s/src/http/multipart.rs
+++ b/crates/s3s/src/http/multipart.rs
@@ -40,8 +40,8 @@ pub struct MultipartLimits {
 impl Default for MultipartLimits {
     fn default() -> Self {
         Self {
-            max_field_size: 1024 * 1024,       // 1 MB
-            max_fields_size: 20 * 1024 * 1024, // 20 MB
+            max_field_size: 1024 * 1024,       // 1 MiB
+            max_fields_size: 20 * 1024 * 1024, // 20 MiB
             max_parts: 1000,
         }
     }

--- a/crates/s3s/src/lib.rs
+++ b/crates/s3s/src/lib.rs
@@ -98,9 +98,10 @@
 //!   operation is open to any client
 //! - HTTP body length limits
 //! - Object-size limits in the [`S3`] implementation for streaming uploads
-//!   (`PUT Object`, `UploadPart`) when
-//!   [`S3Config::put_object_max_size`](crate::config::S3Config::put_object_max_size)
-//!   is not configured
+//!   (`PUT Object`, `UploadPart`): `s3s` applies a default 5 GiB cap via
+//!   [`S3Config::put_object_max_size`](crate::config::S3Config::put_object_max_size);
+//!   implementations should still enforce their own deployment-specific
+//!   limits, and must do so if the cap is disabled (set to `None`)
 //! - Rate limiting
 //! - Back pressure
 //! - Network-level security (firewalls, VPNs, etc.)

--- a/crates/s3s/src/service.rs
+++ b/crates/s3s/src/service.rs
@@ -81,11 +81,12 @@
 //! Streaming uploads (`PUT Object` and `UploadPart`) are passed to the
 //! [`S3`](crate::S3) implementation as streams. By default,
 //! [`S3Config::put_object_max_size`](crate::config::S3Config::put_object_max_size)
-//! is `None`, so `s3s` does not impose an object-size limit for those streams;
-//! the [`S3`](crate::S3) implementation is responsible for enforcing any
-//! deployment-specific object cap. Set `put_object_max_size` to opt in to an
-//! adapter-level limit; aws-chunked requests are capped after signature
-//! verification has installed the decoded stream. `POST Object` keeps using
+//! is `Some(5 GiB)`, matching the AWS single-PUT object size limit, so `s3s`
+//! caps those streams; set it to `None` to disable the adapter-level limit
+//! and leave object-size enforcement to the
+//! [`S3`](crate::S3) implementation. aws-chunked requests are capped after
+//! signature verification has installed the decoded stream. `POST Object`
+//! keeps using
 //! [`S3Config::post_object_max_file_size`](crate::config::S3Config::post_object_max_file_size)
 //! as its file-size limit.
 
@@ -850,7 +851,7 @@ mod tests {
         assert_eq!(config.xml_max_body_size, 20 * 1024 * 1024);
         assert_eq!(config.post_object_max_file_size, 5 * 1024 * 1024 * 1024);
         assert_eq!(config.custom_route_max_body_size, Some(1024 * 1024));
-        assert_eq!(config.put_object_max_size, None);
+        assert_eq!(config.put_object_max_size, Some(5 * 1024 * 1024 * 1024));
     }
 
     #[test]


### PR DESCRIPTION

`S3Config::put_object_max_size` previously defaulted to `None`, so `s3s` imposed no object-size limit on streaming uploads (`PUT Object`, `UploadPart`) unless deployments configured one explicitly. The AWS single-PUT object size limit is 5 GiB; with no default cap, the entire storage surface of a default-configured service was unbounded (a storage-exhaustion denial-of-service surface for anonymous or authenticated clients alike, and an easy misconfiguration when the deployment expected AWS parity).

# Changes

- `S3Config::put_object_max_size` now defaults to `Some(5 GiB)` (matching the AWS single-PUT object size limit) via a named constant in `config`.
- An explicit `None` remains the opt-out path: `put_object_max_size = null` (or `None` in programmatic config) disables the adapter-level limit and defers object-size enforcement to the `S3` implementation, as before.
- Serialization/deserialization semantics: the struct-level `#[serde(default)]` on `S3Config` applies the struct default to missing fields, so legacy configs that omit the field inherit the new cap instead of silently reverting to unlimited; an explicit `null` still maps to `None`. The serialized default config now emits `put_object_max_size` (the `skip_serializing_if` omits only an explicit `None`).
- The limit is applied to decoded streaming bodies before they reach the `S3` implementation; aws-chunked requests are capped after signature verification installs the decoded stream. `POST Object` keeps using `S3Config::post_object_max_file_size`.
- Doc comments and the README now state the default and the opt-out path.

# Breaking change

Requests with streaming bodies over 5 GiB that previously succeeded (or were left to the implementation's own cap) now fail while the body is read once the limit is exceeded. Deployments that relied on the unlimited default must set `put_object_max_size = null` / `None` explicitly to keep the previous behavior. Affected operations: `PUT Object`, `UploadPart`, `WriteGetObjectResponse` (the streaming-body operations). `POST Object` is unaffected. Serialized config output changes: the default config now includes `put_object_max_size`.

# Tests

- `S3Config::default()` asserts the 5 GiB default (config + service-layer defaults).
- Deserialization: missing field → 5 GiB default; explicit `null` → `None` (opt-out); explicit value → override.
- Serialization: an explicit `None` is omitted; the default config emits the value.
- Existing streaming-limit tests (`rejects_oversized_plain_put_at_read_time`, aws-chunked paths) keep passing against the explicit-config mechanics.

# Related

Related: https://github.com/s3s-project/s3s/issues/176 (security audit: duplicated headers and query strings)
