### PR TITLE
fix(s3s/ops): reject repeated Host headers in routing

### DIFF
--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -167,8 +167,15 @@ fn extract_http2_authority(req: &Request) -> Option<&str> {
 }
 
 fn extract_host(req: &Request) -> S3Result<Option<String>> {
-    // First try to get from Host header.
-    if let Some(val) = req.headers.get(crate::header::HOST) {
+    // First try to get from Host header. Repeated Host lines are rejected
+    // instead of silently picking the first value: signature verification
+    // signs every value of a repeated header, so accepting only one here
+    // would let routing and the signature disagree about the host.
+    let mut iter = req.headers.get_all(crate::header::HOST).iter();
+    if let Some(val) = iter.next() {
+        if iter.next().is_some() {
+            return Err(invalid_request!("duplicate header: Host"));
+        }
         let on_err = |e| s3_error!(e, InvalidRequest, "invalid header: Host: {val:?}");
         let host = val.to_str().map_err(on_err)?;
         return Ok(Some(host.into()));

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -519,6 +519,56 @@ async fn vh_region_fallback_for_anonymous_request() {
     );
 }
 
+/// A repeated `Host` header must be rejected by `extract_host` instead of
+/// silently picking the first value: signature verification signs every
+/// value of a repeated header, so accepting only one would let routing and
+/// the signature disagree about the host.
+#[test]
+fn extract_host_rejects_duplicate_host_header() {
+    use crate::http::{Body, Request};
+
+    let req = Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .uri("http://example.com/test-key")
+            .header(crate::header::HOST, "example.com")
+            .header(crate::header::HOST, "attacker.example.com")
+            .body(Body::empty())
+            .unwrap(),
+    );
+
+    let err = super::extract_host(&req).expect_err("duplicate Host must be rejected");
+    assert_eq!(err.code(), &crate::S3ErrorCode::InvalidRequest);
+    assert_eq!(err.message(), Some("duplicate header: Host"));
+}
+
+/// `extract_host` keeps resolving a single Host value and the HTTP/2/3
+/// authority fallback.
+#[test]
+fn extract_host_accepts_single_value_and_authority() {
+    use crate::http::{Body, Request};
+
+    let req = Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .uri("http://example.com/test-key")
+            .header(crate::header::HOST, "example.com")
+            .body(Body::empty())
+            .unwrap(),
+    );
+    assert_eq!(super::extract_host(&req).unwrap().as_deref(), Some("example.com"));
+
+    let req = Request::from(
+        hyper::Request::builder()
+            .method(Method::GET)
+            .version(::http::Version::HTTP_2)
+            .uri("http://bucket.example.com:19000/test-key")
+            .body(Body::empty())
+            .unwrap(),
+    );
+    assert_eq!(super::extract_host(&req).unwrap().as_deref(), Some("bucket.example.com:19000"));
+}
+
 /// With an `S3Host` configured, an unrecognized host carrying a port
 /// (e.g. `localhost:8014`) can never be a CNAME bucket and must fall back
 /// to path-style parsing; a portless host that is a valid bucket name keeps


### PR DESCRIPTION

`extract_host` picked the first value of a repeated `Host` header with `HeaderMap::get`, while signature verification signs every value of a repeated header (`collect_signed_headers`). The routing view of the host (bucket resolution, vhost matching) and the signature view could therefore disagree: a request could be routed as one host while its signature was computed over a different host value. The mismatch is not exploitable (the signature still covers the value routing used, since it is one of the signed values), but it leaves the host semantics ambiguous and can mask upstream header rewriting.

# Changes

- `extract_host` now rejects a repeated `Host` header (`get_all` must yield exactly one value) with `InvalidRequest`, matching the fail-closed stance of the other single-value consumers (`content-length`, `authorization`, `x-amz-date`).
- Routing never observes a host that differs from what the signature covers.
- HTTP/2/3 `:authority` fallback is untouched.

# Tests

- `extract_host_rejects_duplicate_host_header`: a request with two `Host` lines fails with `InvalidRequest` / `duplicate header: Host`.
- `extract_host_accepts_single_value_and_authority`: single `Host` resolves as before; HTTP/2 without a `Host` header falls back to `:authority`.
- `just dev` green.

# Related

Related: https://github.com/s3s-project/s3s/issues/176 (security audit: duplicated headers and query strings)
