### PR TITLE
fix(s3s-sigv4)!: validate the Authorization signature segment eagerly

### DIFF
--- a/crates/s3s-sigv4/src/authorization.rs
+++ b/crates/s3s-sigv4/src/authorization.rs
@@ -6,6 +6,7 @@
 //! See [sigv4-auth-using-authorization-header](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html)
 //!
 
+use crate::crypto::is_sha256_checksum;
 use serde::{Deserialize, Serialize};
 
 /// Authorization
@@ -44,10 +45,13 @@ pub struct CredentialV4<'a> {
 
 /// [`AuthorizationV4`]
 #[derive(Debug, thiserror::Error)]
-#[error("ParseAuthorizationError")]
-pub struct ParseAuthorizationError {
-    /// private placeholder
-    _priv: (),
+pub enum ParseAuthorizationError {
+    /// The header does not match the `Authorization` header structure.
+    #[error("ParseAuthorizationError: malformed authorization header")]
+    Malformed,
+    /// The `Signature=` value is not a canonical lowercase hex SHA-256 digest.
+    #[error("ParseAuthorizationError: invalid signature format")]
+    InvalidSignature,
 }
 
 /// [`CredentialV4`]
@@ -77,10 +81,17 @@ impl<'a> AuthorizationV4<'a> {
     /// # Errors
     /// Returns an `Err` if the header is invalid
     pub fn parse(header: &'a str) -> Result<Self, ParseAuthorizationError> {
-        match parser::parse_authorization(header) {
-            Ok(("", ans)) => Ok(ans),
-            Ok(_) | Err(_) => Err(ParseAuthorizationError { _priv: () }),
+        let Ok(("", ans)) = parser::parse_authorization(header) else {
+            return Err(ParseAuthorizationError::Malformed);
+        };
+
+        // Validate the signature segment eagerly so callers can distinguish a
+        // malformed header from a syntactically invalid signature.
+        if !is_sha256_checksum(ans.signature) {
+            return Err(ParseAuthorizationError::InvalidSignature);
         }
+
+        Ok(ans)
     }
 }
 
@@ -260,6 +271,50 @@ mod tests {
     fn parse_rejects_empty_or_whitespace_input() {
         assert!(AuthorizationV4::parse("").is_err());
         assert!(AuthorizationV4::parse("AWS4-HMAC-SHA256").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_invalid_signature_formats() {
+        let header = |signature: &str| {
+            format!(
+                "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, SignedHeaders=host, Signature={signature}"
+            )
+        };
+
+        // wrong length
+        assert!(matches!(
+            AuthorizationV4::parse(&header("abc")),
+            Err(ParseAuthorizationError::InvalidSignature)
+        ));
+        assert!(matches!(
+            AuthorizationV4::parse(&header(&"a".repeat(63))),
+            Err(ParseAuthorizationError::InvalidSignature)
+        ));
+        assert!(matches!(
+            AuthorizationV4::parse(&header(&"a".repeat(65))),
+            Err(ParseAuthorizationError::InvalidSignature)
+        ));
+        // non-hex characters
+        assert!(matches!(
+            AuthorizationV4::parse(&header(&format!("z{}", "a".repeat(63)))),
+            Err(ParseAuthorizationError::InvalidSignature)
+        ));
+        // uppercase hex is not canonical
+        assert!(matches!(
+            AuthorizationV4::parse(&header(&"A".repeat(64))),
+            Err(ParseAuthorizationError::InvalidSignature)
+        ));
+        // empty
+        assert!(matches!(
+            AuthorizationV4::parse(&header("")),
+            Err(ParseAuthorizationError::InvalidSignature)
+        ));
+    }
+
+    #[test]
+    fn parse_distinguishes_invalid_signature_from_malformed() {
+        let malformed = "AWS4-HMAC-SHA256 not-an-authorization";
+        assert!(matches!(AuthorizationV4::parse(malformed), Err(ParseAuthorizationError::Malformed)));
     }
 
     #[test]

--- a/crates/s3s/src/ops/signature.rs
+++ b/crates/s3s/src/ops/signature.rs
@@ -23,7 +23,7 @@ use s3s_sigv4::AmzContentSha256;
 use s3s_sigv4::AmzDate;
 use s3s_sigv4::PostSignatureV4;
 use s3s_sigv4::PresignedUrlV4;
-use s3s_sigv4::{AuthorizationV4, CredentialV4};
+use s3s_sigv4::{AuthorizationV4, CredentialV4, ParseAuthorizationError};
 
 use std::mem;
 use std::ops::Not;
@@ -60,6 +60,12 @@ fn extract_authorization_v4(hs: &HeaderMap) -> S3Result<Option<AuthorizationV4<'
     };
     match AuthorizationV4::parse(val) {
         Ok(x) => Ok(Some(x)),
+        // A structurally valid header with a non-canonical signature is a
+        // signature problem, not a malformed header: keep the `SignatureDoesNotMatch`
+        // error that the signature-comparison step used to produce.
+        Err(ParseAuthorizationError::InvalidSignature) => {
+            Err(s3_error!(SignatureDoesNotMatch, "invalid header: authorization: invalid signature"))
+        }
         Err(e) => Err(invalid_request!(e, "invalid header: authorization")),
     }
 }
@@ -927,6 +933,34 @@ mod tests {
 
         assert_eq!(err.code(), &S3ErrorCode::SignatureDoesNotMatch);
         assert_eq!(err.message(), Some("invalid header: x-amz-meta-name"));
+    }
+
+    #[test]
+    fn extract_authorization_v4_rejects_invalid_signature_with_signature_error() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_static(
+                "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=not-a-real-signature",
+            ),
+        );
+
+        let err = extract_authorization_v4(&headers).expect_err("non-canonical signature must be rejected");
+
+        // The error must stay a signature error, not a malformed-header error.
+        assert_eq!(err.code(), &S3ErrorCode::SignatureDoesNotMatch);
+    }
+
+    #[test]
+    fn extract_authorization_v4_rejects_malformed_header_with_invalid_request() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_static("AWS4-HMAC-SHA256 garbage"),
+        );
+
+        let err = extract_authorization_v4(&headers).expect_err("malformed authorization header must be rejected");
+        assert_eq!(err.code(), &S3ErrorCode::InvalidRequest);
     }
 
     #[test]


### PR DESCRIPTION

`AuthorizationV4::parse` accepted any `Signature=` value; the 64-lowercase-hex format check happened later in `s3s` via `Signature::from_hex`. The caller could not tell a malformed header apart from a syntactically invalid signature, and validation was deferred past clock-skew and region checks.

# Changes

- `AuthorizationV4::parse` now validates the `Signature=` segment with `is_sha256_checksum` (64 lowercase hex, the exact acceptance set of `Signature::from_hex`) right after structural parsing, and fails fast on a non-canonical value.
- `ParseAuthorizationError` becomes an enum: `Malformed` (structural failure) vs `InvalidSignature` (non-canonical signature).
- `s3s` maps `InvalidSignature` to `SignatureDoesNotMatch` so the wire error is unchanged; `Malformed` keeps `InvalidRequest`.
- The signature check now runs before clock-skew/region validation, so only the error priority among multiple rejections changes (all are still 4xx).

# SigV2 is intentionally untouched

SigV2 signatures are Base64 (28 chars, 20-byte HMAC-SHA1 payload) and are validated by `Signature::from_base64` in `s3s`. Its `Authorization` parsing failure is a soft fallback in `v2_check`: a parse failure falls through to V4/anonymous instead of rejecting. Validating the signature inside `s3s-sigv2::AuthorizationV2::parse` would therefore downgrade a hard `SignatureDoesNotMatch` into a soft anonymous fallback, so the existing check layer is the correct one for SigV2.

# Breaking change (API)

`ParseAuthorizationError` is now an enum; code matching on the old unit struct fails to compile. The crate is pre-1.0 (`0.16.0-alpha.1`).

# Tests

- `parse_rejects_invalid_signature_formats`: wrong length, non-hex characters, uppercase hex, empty value — all `InvalidSignature`.
- `parse_distinguishes_invalid_signature_from_malformed`: structural failure is `Malformed`.
- `s3s`: `extract_authorization_v4_rejects_invalid_signature_with_signature_error` (`SignatureDoesNotMatch`) and `extract_authorization_v4_rejects_malformed_header_with_invalid_request` (`InvalidRequest`).
- `just dev` green.

# Related

Related: https://github.com/s3s-project/s3s/issues/176 (security audit: duplicated headers and query strings)
