### PR TITLE
fix(s3s/http)!: verify aws-chunked output against the declared decoded length

### DIFF
--- a/crates/s3s/src/http/aws_chunked_stream.rs
+++ b/crates/s3s/src/http/aws_chunked_stream.rs
@@ -101,6 +101,9 @@ pub enum AwsChunkedStreamError {
     /// Incomplete stream
     #[error("AwsChunkedStreamError: Incomplete")]
     Incomplete,
+    /// More bytes produced than the declared decoded length
+    #[error("AwsChunkedStreamError: LengthMismatch")]
+    LengthMismatch,
     /// Chunk metadata too large
     #[error("AwsChunkedStreamError: ChunkMetaTooLarge: size {0} exceeds limit {1}")]
     ChunkMetaTooLarge(usize, usize),
@@ -647,10 +650,22 @@ impl AwsChunkedStream {
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes, AwsChunkedStreamError>>> {
         let ans = Pin::new(&mut self.inner).poll_next(cx);
-        if let Poll::Ready(Some(Ok(ref bytes))) = ans {
-            self.remaining_length = self.remaining_length.saturating_sub(bytes.len());
+        match ans {
+            Poll::Ready(Some(Ok(bytes))) => {
+                // The declared decoded length must match the actual chunk data:
+                // producing more bytes than the declaration is an overrun
+                // (previously masked by saturating subtraction).
+                if !bytes.is_empty() && bytes.len() > self.remaining_length {
+                    return Poll::Ready(Some(Err(AwsChunkedStreamError::LengthMismatch)));
+                }
+                self.remaining_length = self.remaining_length.saturating_sub(bytes.len());
+                Poll::Ready(Some(Ok(bytes)))
+            }
+            // The chunk stream ended (0-size chunk and trailers processed)
+            // before the declared decoded length was delivered.
+            Poll::Ready(None) if self.remaining_length != 0 => Poll::Ready(Some(Err(AwsChunkedStreamError::Incomplete))),
+            other => other,
         }
-        ans
     }
 
     #[must_use]
@@ -928,6 +943,59 @@ mod tests {
         let data = chunked_stream.next().await.unwrap().unwrap();
         assert_eq!(data.as_ref(), b"0123456789abcdef");
         assert!(chunked_stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn unsigned_chunk_overrun_rejected_when_declaration_exceeded() {
+        // The decoded-length declaration says 4 bytes but the chunk carries 6:
+        // structurally valid, yet the produced bytes exceed the declaration.
+        let chunk1 = join(&[b"6\r\n", b"abcdef\r\n", b"0\r\n\r\n"]);
+        let chunk_results = vec![Ok(chunk1)];
+
+        let stream = futures::stream::iter(chunk_results);
+        let mut chunked_stream = AwsChunkedStream::new(
+            stream,
+            Sha256Sum::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+            AmzDate::parse("20130524T000000Z").unwrap(),
+            "us-east-1".into(),
+            "s3".into(),
+            "test-key".into(),
+            4, // decoded_content_length declaration
+            true,
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
+        );
+
+        // The whole chunk is streamed in one poll, so the overrun is reported
+        // on the first read.
+        let result = chunked_stream.next().await;
+        assert!(matches!(result, Some(Err(AwsChunkedStreamError::LengthMismatch))));
+    }
+
+    #[tokio::test]
+    async fn unsigned_chunk_shortfall_rejected_when_declaration_not_met() {
+        // The decoded-length declaration says 8 bytes but the chunk carries 4
+        // and the stream ends cleanly with a 0-size chunk.
+        let chunk1 = join(&[b"4\r\n", b"abcd\r\n", b"0\r\n\r\n"]);
+        let chunk_results = vec![Ok(chunk1)];
+
+        let stream = futures::stream::iter(chunk_results);
+        let mut chunked_stream = AwsChunkedStream::new(
+            stream,
+            Sha256Sum::from_hex("0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
+            AmzDate::parse("20130524T000000Z").unwrap(),
+            "us-east-1".into(),
+            "s3".into(),
+            "test-key".into(),
+            8, // decoded_content_length declaration
+            true,
+            crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
+        );
+
+        let first = chunked_stream.next().await.unwrap().unwrap();
+        assert_eq!(first.as_ref(), b"abcd");
+
+        let result = chunked_stream.next().await;
+        assert!(matches!(result, Some(Err(AwsChunkedStreamError::Incomplete))));
     }
 
     fn join(bytes: &[&[u8]]) -> Bytes {
@@ -1212,9 +1280,11 @@ mod tests {
             crate::config::DEFAULT_AWS_CHUNKED_STREAM_MAX_CHUNK_SIZE,
         );
 
-        // Stream ends without proper chunk metadata
+        // Stream ends without proper chunk metadata; the declared decoded
+        // length was never delivered, so the stream reports an incomplete
+        // upload instead of ending silently.
         let result = chunked_stream.next().await;
-        assert!(result.is_none());
+        assert!(matches!(result, Some(Err(AwsChunkedStreamError::Incomplete))));
     }
 
     #[tokio::test]


### PR DESCRIPTION

`x-amz-decoded-content-length` is a declaration that was never checked against the actual chunk data. `AwsChunkedStream::remaining_length` only decremented with saturating subtraction, so an overrun was silently masked and a clean end-of-stream (0-size chunk + trailers) never verified that the declaration had been delivered. `s3s` forwarded such requests with a Content-Length rewritten to the declared value, producing objects whose actual length differed from the declaration — AWS rejects the mismatch.

The structural checks already in place (chunk-level EOF, chunk size vs. chunk data) were orthogonal and did not cover the total: a structurally valid stream whose chunk data does not add up to the declaration passed through.

# Changes

- Check the declared length at the `poll` layer of `AwsChunkedStream`, for signed and unsigned chunks alike:
  - producing more bytes than the declaration (in a single poll or across polls) fails with the new `LengthMismatch` variant;
  - ending the stream without delivering the declaration fails with `Incomplete`.
- The check mirrors `UploadStream` (same `len > remaining` overrun condition, same error names).

# Breaking change

- API: `AwsChunkedStreamError` gains the `LengthMismatch` variant.
- Behavior: structurally valid aws-chunked requests whose decoded data does not match the declaration are now rejected instead of being forwarded with a mismatched length. Conforming SDK clients are unaffected; only buggy or malicious clients trigger the mismatch.

# Tests

- `unsigned_chunk_overrun_rejected_when_declaration_exceeded`: 4-byte declaration, 6-byte chunk → `LengthMismatch` on the first read.
- `unsigned_chunk_shortfall_rejected_when_declaration_not_met`: 8-byte declaration, 4-byte chunk + clean 0-size end → `Incomplete`.
- `test_format_error_missing_crlf` updated: a stream ending mid-metadata now reports `Incomplete` (the declaration was never delivered) instead of ending silently.
- Signed exact-match covered by the existing `example_put_object_chunked_stream`; full `aws_chunked_stream` suite green; `just dev` green.

# Related

Related: https://github.com/s3s-project/s3s/issues/176 (security audit: duplicated headers and query strings)
