### PR TITLE
docs(s3s): document the response-side memory surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ It is up to the user to implement security enhancements such as **HTTP body leng
 
 **Authentication is required for production deployments.** Without calling `set_auth`, the service accepts anonymous (unsigned) requests and skips authorization entirely: every S3 operation is open to any client that can reach the service, and signed requests fail with `NotImplemented` because no authentication provider is configured. A forgotten `set_auth` turns the service into a publicly readable and writable endpoint.
 
-For streaming uploads (`PUT Object`, `UploadPart`), `s3s` applies a default 5 GiB object-size limit matching the AWS single-PUT limit; set `S3Config::put_object_max_size` to `None` to disable it and enforce deployment-specific caps in the `S3` implementation. `POST Object` keeps using `S3Config::post_object_max_file_size`.
+For streaming uploads (`PUT Object`, `UploadPart`), `s3s` applies a default 5 GiB object-size limit matching the AWS single-PUT limit; set `S3Config::put_object_max_size` to `None` to disable it and enforce deployment-specific caps in the `S3` implementation. For production, set it explicitly even though the default is already 5 GiB. `POST Object` keeps using `S3Config::post_object_max_file_size`.
+
+List-type responses (`ListObjects`, `ListBuckets`, ...) are serialized in full by `s3s`: their memory usage grows with the number of entries the `S3` implementation returns. Implementations should paginate (`max-keys` / continuation tokens) and deployments should bound response sizes.
 
 ## Docker
 

--- a/crates/s3s/src/lib.rs
+++ b/crates/s3s/src/lib.rs
@@ -102,6 +102,11 @@
 //!   [`S3Config::put_object_max_size`](crate::config::S3Config::put_object_max_size);
 //!   implementations should still enforce their own deployment-specific
 //!   limits, and must do so if the cap is disabled (set to `None`)
+//! - List-type response bodies (`ListObjects`, `ListBuckets`, ...) are
+//!   serialized in full by `s3s`: their memory usage grows with the number of
+//!   entries the [`S3`] implementation returns. Implementations should
+//!   paginate (`max-keys` / continuation tokens) and deployments should bound
+//!   response sizes
 //! - Rate limiting
 //! - Back pressure
 //! - Network-level security (firewalls, VPNs, etc.)


### PR DESCRIPTION

Two implementation/config-side observations from the security audit were undocumented: List-type responses (`ListObjects`, `ListBuckets`, ...) are serialized in full by `s3s` with no size cap — memory grows with the entries the `S3` implementation returns — and production deployments should set `put_object_max_size` explicitly rather than relying on the (now 5 GiB) default.

# Changes

- README `## Security`: note that List-type response bodies are built in full and that implementations should paginate (`max-keys` / continuation tokens) while deployments should bound response sizes; add an explicit `put_object_max_size` production recommendation.
- Crate-level security notes (`s3s` module docs): mirror both points.

Documentation only; no behavior change.

# Tests

- `cargo doc` clean (no unresolved links).
- Existing test suite unaffected (`just dev` green).

# Related

Related: https://github.com/s3s-project/s3s/issues/176 (security audit: duplicated headers and query strings)
