### PR TITLE
fix(s3s/http)!: reject control characters in XML responses

### DIFF
--- a/crates/s3s/src/http/ser.rs
+++ b/crates/s3s/src/http/ser.rs
@@ -7,7 +7,7 @@ use super::Response;
 use crate::StdError;
 use crate::dto::SelectObjectContentEventStream;
 use crate::dto::{Metadata, StreamingBlob, Timestamp, TimestampFormat};
-use crate::error::{S3Error, S3Result};
+use crate::error::{S3Error, S3ErrorCode, S3Result};
 use crate::http::KeepAliveBody;
 use crate::http::{HeaderName, HeaderValue};
 use crate::utils::format::fmt_timestamp;
@@ -98,6 +98,23 @@ impl TryIntoHeaderValue for String {
 #[allow(clippy::declare_interior_mutable_const)]
 const APPLICATION_XML: HeaderValue = HeaderValue::from_static("application/xml");
 
+/// Rejects XML 1.0 control characters (anything below `0x20` except `\t`,
+/// `\n`, `\r`) in a serialized response body.
+///
+/// quick-xml does not validate the XML 1.0 Char production on output, so
+/// control characters in DTO values (request-controlled echoes like object
+/// keys in `ListObjects`, or implementation-provided values) would otherwise
+/// produce responses that strict XML parsers reject.
+fn reject_control_characters(buf: &[u8]) -> S3Result {
+    if buf.iter().any(|&b| b < b' ' && !matches!(b, b'\t' | b'\n' | b'\r')) {
+        return Err(S3Error::with_message(
+            S3ErrorCode::InternalError,
+            "XML response contains a control character",
+        ));
+    }
+    Ok(())
+}
+
 pub fn set_xml_body<T: xml::Serialize>(res: &mut Response, val: &T) -> S3Result {
     let mut buf = Vec::with_capacity(256);
     {
@@ -106,6 +123,7 @@ pub fn set_xml_body<T: xml::Serialize>(res: &mut Response, val: &T) -> S3Result 
             .and_then(|()| val.serialize(&mut ser))
             .map_err(S3Error::internal_error)?;
     }
+    reject_control_characters(&buf)?;
     res.body = Body::from(buf);
     res.headers.insert(hyper::header::CONTENT_TYPE, APPLICATION_XML);
     Ok(())
@@ -134,6 +152,7 @@ pub fn set_xml_body_no_decl<T: xml::Serialize>(res: &mut Response, val: &T) -> S
     let mut buf = Vec::with_capacity(256);
     let mut ser = xml::Serializer::new(&mut buf);
     val.serialize(&mut ser).map_err(S3Error::internal_error)?;
+    reject_control_characters(&buf)?;
     res.body = Body::from(buf);
     res.headers.insert(hyper::header::CONTENT_TYPE, APPLICATION_XML);
     Ok(())
@@ -172,6 +191,63 @@ mod tests {
 
     fn new_response() -> Response {
         Response::default()
+    }
+
+    #[test]
+    fn reject_control_characters_rejects_invalid_xml_characters() {
+        for b in [0x00u8, 0x01, 0x08, 0x0b, 0x0c, 0x0e, 0x1f] {
+            let buf = [b'<', b'x', b'>', b, b'<', b'/', b'x', b'>'];
+            assert!(
+                reject_control_characters(&buf).is_err(),
+                "byte 0x{b:02x} must be rejected as an invalid XML character"
+            );
+        }
+    }
+
+    #[test]
+    fn reject_control_characters_accepts_legal_whitespace() {
+        let buf = b"<x>a\tb\nc\rd</x>";
+        assert!(reject_control_characters(buf).is_ok());
+    }
+
+    #[test]
+    fn reject_control_characters_accepts_plain_body() {
+        assert!(reject_control_characters(b"<xml>hello</xml>").is_ok());
+        assert!(reject_control_characters(b"").is_ok());
+    }
+
+    #[test]
+    fn set_xml_body_rejects_control_characters() {
+        let mut res = new_response();
+        let val = crate::dto::ListObjectsOutput {
+            name: Some("a\x01b".into()),
+            ..Default::default()
+        };
+        let err = set_xml_body(&mut res, &val).expect_err("control characters in the response must be rejected");
+        assert_eq!(err.code(), &S3ErrorCode::InternalError);
+    }
+
+    #[test]
+    fn set_xml_body_accepts_legal_whitespace_values() {
+        let mut res = new_response();
+        let val = crate::dto::ListObjectsOutput {
+            name: Some("a\tb\nc".into()),
+            ..Default::default()
+        };
+        set_xml_body(&mut res, &val).expect("legal whitespace must pass");
+        let body = res.body.bytes().expect("in-memory body");
+        assert!(body.starts_with(b"<?xml"));
+    }
+
+    #[test]
+    fn set_xml_body_no_decl_rejects_control_characters() {
+        let mut res = new_response();
+        let val = crate::dto::ListObjectsOutput {
+            name: Some("a\x1fb".into()),
+            ..Default::default()
+        };
+        let err = set_xml_body_no_decl(&mut res, &val).expect_err("control characters must be rejected");
+        assert_eq!(err.code(), &S3ErrorCode::InternalError);
     }
 
     #[test]

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -1660,6 +1660,58 @@ mod put_object_max_size_tests {
         );
     }
 
+    /// A `ListObjects` response that echoes a request-controlled object key
+    /// containing a control character must not produce an invalid XML body:
+    /// the serialization layer rejects it with an internal error.
+    #[tokio::test]
+    async fn list_objects_with_control_character_key_rejected_at_serialization() {
+        use crate::config::{S3ConfigProvider, StaticConfigProvider};
+        use crate::http::{Body, Request};
+
+        struct ControlCharS3;
+        #[async_trait::async_trait]
+        impl crate::s3_trait::S3 for ControlCharS3 {
+            async fn list_objects(
+                &self,
+                _req: crate::S3Request<crate::dto::ListObjectsInput>,
+            ) -> crate::error::S3Result<crate::protocol::S3Response<crate::dto::ListObjectsOutput>> {
+                let output = crate::dto::ListObjectsOutput {
+                    name: Some("bucket".into()),
+                    contents: Some(vec![crate::dto::Object {
+                        key: Some("a\x01b".into()),
+                        ..Default::default()
+                    }]),
+                    ..Default::default()
+                };
+                Ok(crate::protocol::S3Response::new(output))
+            }
+        }
+
+        let s3: Arc<dyn crate::s3_trait::S3> = Arc::new(ControlCharS3);
+        let config: Arc<dyn S3ConfigProvider> = Arc::new(StaticConfigProvider::default());
+        let ccx = CallContext {
+            s3: &s3,
+            config: &config,
+            host: None,
+            auth: None,
+            access: None,
+            route: None,
+            validation: None,
+        };
+
+        let mut req = Request::from(
+            hyper::Request::builder()
+                .method(Method::GET)
+                .uri("http://localhost/bucket")
+                .header(crate::header::HOST, "localhost")
+                .body(Body::empty())
+                .unwrap(),
+        );
+
+        let resp = super::call(&mut req, &ccx).await.unwrap();
+        assert_eq!(resp.status, hyper::StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
     #[tokio::test]
     async fn post_object_keeps_post_object_max_file_size_when_put_limit_is_set() {
         let s3: Arc<dyn S3> = Arc::new(post_policy_test_helpers::TestS3NoOp);


### PR DESCRIPTION

quick-xml escapes only `&` `<` `>` `'` `"` and `\r` on output and never validates the XML 1.0 Char production, so control characters in DTO values produced invalid XML responses.

This is request-controllable, not just an implementation-bug surface: object keys may contain control characters (path parsing only enforces the 1024-byte length limit), and several operations echo request keys into response XML (`ListObjects`, `CreateMultipartUpload`, `CompleteMultipartUpload`, `DeleteObjects`, `PostObject`). A `PUT` of a key containing e.g. `\x01` makes every List-type response of that bucket unparseable for strict XML clients (AWS SDKs, expat, libxml2).

# Changes

- Scan the serialized body in `set_xml_body` / `set_xml_body_no_decl` — the only two XML entry points; error responses (`serialize_error`) and the keep-alive path (`CompleteMultipartUpload` polling) go through them as well, so there is no gap.
- Reject any byte below `0x20` other than `\t`, `\n`, `\r` with an internal error, never emitting an invalid XML document.
- Single O(n) scan, no allocation; legal values are unaffected.

# Breaking change

Behavior: responses that would have contained a control character (malicious request keys or buggy implementations) now fail with 500 instead of a 200 carrying invalid XML. Strict XML parsers failed on those responses anyway; lenient parsers now see an explicit error instead of silently accepting an ill-formed document. Legal data flows are unaffected.

# Tests

- `reject_control_characters_rejects_invalid_xml_characters`: `\x00`, `\x01`, `\x08`, `\x0b`, `\x0c`, `\x0e`, `\x1f` all rejected.
- `reject_control_characters_accepts_legal_whitespace` / `accepts_plain_body`: `\t`, `\n`, `\r`, plain and empty bodies pass.
- `set_xml_body_rejects_control_characters` / `set_xml_body_no_decl_rejects_control_characters`: end-to-end through the serializers → `InternalError`.
- `list_objects_with_control_character_key_rejected_at_serialization`: an S3 implementation echoing a `\x01` key through `ListObjects` → `ops::call` returns 500 (the request-controllable echo chain).
- `just dev` green.

# Related

Related: https://github.com/s3s-project/s3s/issues/176 (security audit: duplicated headers and query strings)
