### PR TITLE
docs(s3s): declare the checksum-trailer verification contract

### DIFF
--- a/crates/s3s/src/http/aws_chunked_stream.rs
+++ b/crates/s3s/src/http/aws_chunked_stream.rs
@@ -2,6 +2,22 @@
 // SPDX-FileCopyrightText: 2023-2026 The s3s Authors
 
 //! aws-chunked stream
+//!
+//! Decodes an `aws-chunked` request body, verifying the per-chunk signature
+//! chain for signed modes and the trailer signature for
+//! `STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER`. The decoded bytes are never
+//! yielded before their signature has been verified.
+//!
+//! # Checksum trailers
+//!
+//! `x-amz-checksum-*` trailer values are exposed via [`TrailingHeaders`]
+//! without verification: comparing them against a digest computed while
+//! consuming the body is the responsibility of the [`S3`](crate::S3)
+//! implementation (the reference implementation `s3s-fs` rejects mismatches
+//! with `BadDigest`). The unsigned mode
+//! (`STREAMING-UNSIGNED-PAYLOAD-TRAILER`) relies on those values for data
+//! integrity, so implementations that skip checksum verification accept
+//! unauthenticated data — a trade-off `s3s` leaves to the implementation.
 
 use crate::auth::SecretKey;
 use crate::error::StdError;

--- a/crates/s3s/src/protocol.rs
+++ b/crates/s3s/src/protocol.rs
@@ -48,6 +48,22 @@ impl From<HttpError> for StdError {
 ///
 /// This handle lets you take streaming-trailer headers after the
 /// request body stream has been fully consumed.
+///
+/// # Integrity contract
+///
+/// `s3s` parses and exposes streaming trailers but does **not** verify their
+/// payloads. In particular, `x-amz-checksum-*` trailer values are the
+/// responsibility of the [`S3`](crate::S3) implementation: it must compare
+/// them against the digest it computed while consuming the body and reject
+/// mismatches (the reference implementation `s3s-fs` returns `BadDigest`).
+/// Implementations may compute digests however they like (asynchronous
+/// pipelines, dedicated hardware, or not at all for an optional-integrity
+/// trade-off); `s3s` only guarantees that the values arrive intact and in
+/// order with the rest of the stream.
+///
+/// Signature-bearing modes (`STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER`)
+/// additionally protect the trailer block with `x-amz-trailer-signature`,
+/// which `s3s` verifies before exposing the handle.
 #[derive(Clone)]
 pub struct TrailingHeaders(pub(crate) std::sync::Arc<std::sync::Mutex<Option<HeaderMap>>>);
 


### PR DESCRIPTION

`AwsChunkedStream` parses `x-amz-checksum-*` trailers and exposes them via `TrailingHeaders` without verifying their payloads, while AWS verifies them — a semantic gap. Investigation showed the reference implementation `s3s-fs` already verifies trailer checksums (it loads trailer values into `input.checksum_*` and compares them against the digest computed while consuming the body, rejecting mismatches with `BadDigest`), so the gap was documentation, not behavior.

# Changes

- `TrailingHeaders` docs gain an "Integrity contract" section: `s3s` only parses and exposes streaming trailers; verification of `x-amz-checksum-*` values is the `S3` implementation's responsibility. Digest computation strategy is left to the implementation (asynchronous pipelines, dedicated hardware, or skipping for an optional-integrity trade-off). Signed trailer modes additionally protect the trailer block with `x-amz-trailer-signature`, which `s3s` verifies before exposing the handle.
- `aws_chunked_stream` module docs state the verified-before-yield guarantee, the unsigned mode's reliance on checksum trailers for data integrity (skipping verification means accepting unauthenticated data), and the trade-off left to the implementation.

Documentation only; no behavior change.

# Tests

- `cargo doc` clean (no unresolved links).
- Existing test suite unaffected (`just dev` green).

# Related

Related: https://github.com/s3s-project/s3s/issues/176 (security audit: duplicated headers and query strings)
