### PR TITLE
feat(s3s): map stream-verification errors to S3 error codes

### DIFF
--- a/crates/s3s-fs/src/error.rs
+++ b/crates/s3s-fs/src/error.rs
@@ -43,7 +43,20 @@ where
 
 impl From<Error> for S3Error {
     fn from(e: Error) -> Self {
-        S3Error::with_source(S3ErrorCode::InternalError, e.source)
+        let source = e.source;
+
+        // Stream-verification errors from `s3s` (payload checksum, chunk
+        // signature, decoded length) carry a precise `S3` error code; map them
+        // so clients get `BadDigest` / `IncompleteBody` / `SignatureDoesNotMatch`
+        // instead of a generic 500.
+        if let Some(err) = source.downcast_ref::<s3s::stream::upload_stream::UploadStreamError>() {
+            return S3Error::with_source(err.to_s3_error_code(), source);
+        }
+        if let Some(err) = source.downcast_ref::<s3s::stream::aws_chunked_stream::AwsChunkedStreamError>() {
+            return S3Error::with_source(err.to_s3_error_code(), source);
+        }
+
+        S3Error::with_source(S3ErrorCode::InternalError, source)
     }
 }
 
@@ -73,4 +86,30 @@ macro_rules! try_ {
             }
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_upload_stream_errors_to_s3_error_codes() {
+        let e = Error::new(Box::new(s3s::stream::upload_stream::UploadStreamError::Sha256Mismatch));
+        let s3err: S3Error = e.into();
+        assert_eq!(s3err.code(), &S3ErrorCode::BadDigest);
+    }
+
+    #[test]
+    fn maps_aws_chunked_stream_errors_to_s3_error_codes() {
+        let e = Error::new(Box::new(s3s::stream::aws_chunked_stream::AwsChunkedStreamError::SignatureMismatch));
+        let s3err: S3Error = e.into();
+        assert_eq!(s3err.code(), &S3ErrorCode::SignatureDoesNotMatch);
+    }
+
+    #[test]
+    fn keeps_internal_error_for_unrecognized_sources() {
+        let e = Error::new(Box::new(std::io::Error::other("boom")));
+        let s3err: S3Error = e.into();
+        assert_eq!(s3err.code(), &S3ErrorCode::InternalError);
+    }
 }

--- a/crates/s3s/src/stream/aws_chunked_stream.rs
+++ b/crates/s3s/src/stream/aws_chunked_stream.rs
@@ -20,7 +20,7 @@
 //! unauthenticated data — a trade-off `s3s` leaves to the implementation.
 
 use crate::auth::SecretKey;
-use crate::error::StdError;
+use crate::error::{S3ErrorCode, StdError};
 use crate::protocol::TrailingHeaders;
 use crate::stream::{ByteStream, DynByteStream, RemainingLength};
 use crate::utils::SyncBoxFuture;
@@ -132,6 +132,24 @@ pub enum AwsChunkedStreamError {
     /// Too many trailer headers
     #[error("AwsChunkedStreamError: TooManyTrailerHeaders: count {0} exceeds limit {1}")]
     TooManyTrailerHeaders(usize, usize),
+}
+
+impl AwsChunkedStreamError {
+    /// Maps a stream-verification error to the `S3` error code a conforming
+    /// implementation should report.
+    #[must_use]
+    pub fn to_s3_error_code(&self) -> S3ErrorCode {
+        match self {
+            Self::Underlying(_) => S3ErrorCode::InternalError,
+            Self::SignatureMismatch => S3ErrorCode::SignatureDoesNotMatch,
+            Self::FormatError
+            | Self::Incomplete
+            | Self::LengthMismatch
+            | Self::TrailersTooLarge(..)
+            | Self::TooManyTrailerHeaders(..) => S3ErrorCode::IncompleteBody,
+            Self::ChunkMetaTooLarge(..) | Self::ChunkDataTooLarge(..) => S3ErrorCode::EntityTooLarge,
+        }
+    }
 }
 
 /// Chunk meta
@@ -738,6 +756,27 @@ fn trim_ascii_whitespace(mut s: &[u8]) -> &[u8] {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn to_s3_error_code_maps_all_variants() {
+        let cases = [
+            (
+                AwsChunkedStreamError::Underlying(Box::new(std::io::Error::other("boom"))),
+                S3ErrorCode::InternalError,
+            ),
+            (AwsChunkedStreamError::SignatureMismatch, S3ErrorCode::SignatureDoesNotMatch),
+            (AwsChunkedStreamError::FormatError, S3ErrorCode::IncompleteBody),
+            (AwsChunkedStreamError::Incomplete, S3ErrorCode::IncompleteBody),
+            (AwsChunkedStreamError::LengthMismatch, S3ErrorCode::IncompleteBody),
+            (AwsChunkedStreamError::ChunkMetaTooLarge(1, 2), S3ErrorCode::EntityTooLarge),
+            (AwsChunkedStreamError::ChunkDataTooLarge(1, 2), S3ErrorCode::EntityTooLarge),
+            (AwsChunkedStreamError::TrailersTooLarge(1, 2), S3ErrorCode::IncompleteBody),
+            (AwsChunkedStreamError::TooManyTrailerHeaders(1, 2), S3ErrorCode::IncompleteBody),
+        ];
+        for (err, expected) in cases {
+            assert_eq!(err.to_s3_error_code(), expected, "{err:?}");
+        }
+    }
 
     #[test]
     fn signature_ctx_debug_redacts_signing_key() {

--- a/crates/s3s/src/stream/upload_stream.rs
+++ b/crates/s3s/src/stream/upload_stream.rs
@@ -7,7 +7,7 @@
 
 use crate::crypto::Checksum as _;
 use crate::crypto::Sha256;
-use crate::error::StdError;
+use crate::error::{S3ErrorCode, StdError};
 use crate::stream::{ByteStream, DynByteStream, RemainingLength};
 use crate::utils::crypto::Sha256Sum;
 
@@ -60,6 +60,19 @@ pub enum UploadStreamError {
     /// Stream ended before reading declared length.
     #[error("UploadStreamError: Incomplete")]
     Incomplete,
+}
+
+impl UploadStreamError {
+    /// Maps a stream-verification error to the `S3` error code a conforming
+    /// implementation should report.
+    #[must_use]
+    pub fn to_s3_error_code(&self) -> S3ErrorCode {
+        match self {
+            Self::Underlying(_) => S3ErrorCode::InternalError,
+            Self::Sha256Mismatch => S3ErrorCode::BadDigest,
+            Self::LengthMismatch | Self::Incomplete => S3ErrorCode::IncompleteBody,
+        }
+    }
 }
 
 impl<S> UploadStream<S> {
@@ -223,6 +236,22 @@ mod tests {
 
     use futures::StreamExt as _;
     use std::io;
+
+    #[test]
+    fn to_s3_error_code_maps_all_variants() {
+        let cases = [
+            (UploadStreamError::Sha256Mismatch, S3ErrorCode::BadDigest),
+            (UploadStreamError::LengthMismatch, S3ErrorCode::IncompleteBody),
+            (UploadStreamError::Incomplete, S3ErrorCode::IncompleteBody),
+            (
+                UploadStreamError::Underlying(Box::new(io::Error::other("boom"))),
+                S3ErrorCode::InternalError,
+            ),
+        ];
+        for (err, expected) in cases {
+            assert_eq!(err.to_s3_error_code(), expected, "{err:?}");
+        }
+    }
 
     #[allow(clippy::unnecessary_wraps)]
     fn ok_bytes(data: &'static [u8]) -> Result<Bytes, StdError> {


### PR DESCRIPTION

Body-verification failures surfaced as generic 500s. `UploadStream` (single-chunk payload SHA-256) and `AwsChunkedStream` (per-chunk signature chain, decoded-length checks) report failures as stream errors; `s3s-fs` translated every stream error to `InternalError`, so clients received no diagnostic `S3` error code (`BadDigest`, `IncompleteBody`, `SignatureDoesNotMatch`) when a payload checksum, chunk signature, or decoded length was wrong.

# Changes

- `UploadStreamError::to_s3_error_code()` and `AwsChunkedStreamError::to_s3_error_code()` in `s3s`, encoding the protocol mapping: payload checksum mismatch → `BadDigest`; length/format errors → `IncompleteBody`; chunk-signature mismatch → `SignatureDoesNotMatch`; chunk-size-limit violations → `EntityTooLarge`; underlying I/O errors stay `InternalError`. This is the contract that any `S3` implementation can reuse.
- Expose the body-verification streams under `s3s::stream` as public API: `aws_chunked_stream` moves from the private `http` module (previously reachable only under `cfg(fuzzing)`) to a public submodule of `stream`, next to `upload_stream`; the fuzz target imports update accordingly. `AwsChunkedStreamError` becomes publicly reachable. Additive.
- `s3s-fs` downcasts the two error types in `From<Error> for S3Error` and translates via `to_s3_error_code`; unrecognized sources keep `InternalError`.

# Breaking change (s3s-fs behavior)

Verification failures now return 4xx errors with diagnostic codes (`BadDigest`, `IncompleteBody`, `SignatureDoesNotMatch`) instead of 500. Unrecognized sources keep `InternalError`. The `s3s` changes are additive.

# Tests

- `s3s`: `to_s3_error_code` covers every variant of both error enums.
- `s3s-fs`: `From<Error> for S3Error` maps `UploadStreamError::Sha256Mismatch` → `BadDigest`, `AwsChunkedStreamError::SignatureMismatch` → `SignatureDoesNotMatch`, and keeps `InternalError` for unrecognized sources.
- Fuzz workspace `ci-check` green (updated import path); `just dev` green.

# Related

Related: https://github.com/s3s-project/s3s/issues/176 (security audit: duplicated headers and query strings)
