### PR TITLE
fix(s3s)!: strip XML bodies from bodyless status and HEAD error responses

### DIFF
--- a/crates/s3s/src/http/mod.rs
+++ b/crates/s3s/src/http/mod.rs
@@ -30,7 +30,7 @@ mod request;
 pub use self::request::Request;
 
 mod response;
-pub use self::response::Response;
+pub use self::response::{Response, is_bodyless_status, strip_body};
 
 pub use hyper::header::{HeaderName, HeaderValue, InvalidHeaderValue};
 pub use hyper::http::StatusCode;

--- a/crates/s3s/src/http/response.rs
+++ b/crates/s3s/src/http/response.rs
@@ -38,6 +38,22 @@ impl Response {
     }
 }
 
+/// RFC 9110 §6.4.1: responses with a 1xx, 204, 205 or 304 status code MUST NOT
+/// carry a body.
+#[must_use]
+pub fn is_bodyless_status(status: StatusCode) -> bool {
+    status.is_informational() || matches!(status, StatusCode::NO_CONTENT | StatusCode::RESET_CONTENT | StatusCode::NOT_MODIFIED)
+}
+
+/// Clears the response body and removes `Transfer-Encoding`, keeping metadata
+/// headers such as `Content-Length` and `Content-Type` intact. Used for `HEAD`
+/// responses (RFC 9110 §9.3.2): the body must be suppressed, but the headers
+/// may still describe the equivalent `GET` response.
+pub fn strip_body(res: &mut Response) {
+    res.headers.remove(hyper::header::TRANSFER_ENCODING);
+    res.body = Body::empty();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -68,5 +84,35 @@ mod tests {
         assert_eq!(ans.headers().get("x-test").unwrap().to_str().unwrap(), "value");
         assert_eq!(ans.extensions().get::<usize>(), Some(&42));
         assert_eq!(http_body::Body::size_hint(ans.body()).exact(), Some(4));
+    }
+
+    #[test]
+    fn is_bodyless_status_matches_rfc_9110() {
+        assert!(is_bodyless_status(StatusCode::CONTINUE));
+        assert!(is_bodyless_status(StatusCode::NO_CONTENT));
+        assert!(is_bodyless_status(StatusCode::RESET_CONTENT));
+        assert!(is_bodyless_status(StatusCode::NOT_MODIFIED));
+        assert!(!is_bodyless_status(StatusCode::OK));
+        assert!(!is_bodyless_status(StatusCode::NOT_FOUND));
+        assert!(!is_bodyless_status(StatusCode::TEMPORARY_REDIRECT));
+    }
+
+    #[test]
+    fn strip_body_clears_body_and_transfer_encoding_only() {
+        let mut res = Response::with_status(StatusCode::NOT_FOUND);
+        res.headers
+            .insert(hyper::header::CONTENT_LENGTH, HeaderValue::from_static("123"));
+        res.headers
+            .insert(hyper::header::CONTENT_TYPE, HeaderValue::from_static("application/xml"));
+        res.headers
+            .insert(hyper::header::TRANSFER_ENCODING, HeaderValue::from_static("chunked"));
+        res.body = Body::from(Bytes::from_static(b"<Error/>"));
+
+        strip_body(&mut res);
+
+        assert!(http_body::Body::is_end_stream(&res.body));
+        assert!(!res.headers.contains_key(hyper::header::TRANSFER_ENCODING));
+        assert!(res.headers.contains_key(hyper::header::CONTENT_LENGTH));
+        assert!(res.headers.contains_key(hyper::header::CONTENT_TYPE));
     }
 }

--- a/crates/s3s/src/ops/bodyless_error_tests.rs
+++ b/crates/s3s/src/ops/bodyless_error_tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-2026 The s3s Authors
 
-use crate::{ops, S3Error};
+use crate::{S3Error, ops};
 
 use http_body::Body;
 

--- a/crates/s3s/src/ops/bodyless_error_tests.rs
+++ b/crates/s3s/src/ops/bodyless_error_tests.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-2026 The s3s Authors
 
-use super::*;
-
-use crate::ops;
+use crate::{ops, S3Error};
 
 use http_body::Body;
 

--- a/crates/s3s/src/ops/bodyless_error_tests.rs
+++ b/crates/s3s/src/ops/bodyless_error_tests.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-2026 The s3s Authors
+
+use super::*;
+
+use crate::ops;
+
+use http_body::Body;
+
+fn xml_body(err: S3Error) -> String {
+    let res = ops::serialize_error(err, false).unwrap();
+    let bytes = res.body.bytes().unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+fn assert_empty_body(err: S3Error) -> crate::http::Response {
+    let res = ops::serialize_error(err, false).unwrap();
+    assert!(Body::is_end_stream(&res.body), "body must be empty");
+    assert!(!res.headers.contains_key(hyper::header::CONTENT_LENGTH), "{:?}", res.headers);
+    assert!(!res.headers.contains_key(hyper::header::CONTENT_TYPE), "{:?}", res.headers);
+    assert!(!res.headers.contains_key(hyper::header::TRANSFER_ENCODING), "{:?}", res.headers);
+    res
+}
+
+#[test]
+fn not_modified_error_is_bodyless() {
+    let res = assert_empty_body(s3_error!(NotModified));
+    assert_eq!(res.status, hyper::StatusCode::NOT_MODIFIED);
+}
+
+#[test]
+fn no_content_status_is_bodyless() {
+    let mut err = s3_error!(NoSuchKey);
+    err.set_status_code(hyper::StatusCode::NO_CONTENT);
+    let res = assert_empty_body(err);
+    assert_eq!(res.status, hyper::StatusCode::NO_CONTENT);
+}
+
+#[test]
+fn informational_status_is_bodyless() {
+    let mut err = s3_error!(NoSuchKey);
+    err.set_status_code(hyper::StatusCode::CONTINUE);
+    let res = assert_empty_body(err);
+    assert_eq!(res.status, hyper::StatusCode::CONTINUE);
+}
+
+#[test]
+fn reset_content_status_is_bodyless() {
+    let mut err = s3_error!(NoSuchKey);
+    err.set_status_code(hyper::StatusCode::RESET_CONTENT);
+    let res = assert_empty_body(err);
+    assert_eq!(res.status, hyper::StatusCode::RESET_CONTENT);
+}
+
+#[test]
+fn to_http_response_is_bodyless_for_not_modified() {
+    let res = s3_error!(NotModified).to_http_response().unwrap();
+    assert!(Body::is_end_stream(res.body()));
+    assert_eq!(res.status(), hyper::StatusCode::NOT_MODIFIED);
+}
+
+#[test]
+fn regular_error_keeps_xml_body() {
+    let xml = xml_body(s3_error!(NoSuchKey));
+    assert!(xml.contains("<Code>NoSuchKey</Code>"), "{xml}");
+}
+
+#[test]
+fn bodyless_error_preserves_custom_headers() {
+    let mut err = s3_error!(NotModified);
+    err.set_headers({
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert(crate::header::X_AMZ_REQUEST_ID, "test-request-id".parse().unwrap());
+        headers
+    });
+    let res = assert_empty_body(err);
+    assert_eq!(res.headers.get(crate::header::X_AMZ_REQUEST_ID).unwrap(), "test-request-id");
+}

--- a/crates/s3s/src/ops/head_error_tests.rs
+++ b/crates/s3s/src/ops/head_error_tests.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-2026 The s3s Authors
 
-use super::*;
-
 use crate::ops;
 
 use http_body::Body;

--- a/crates/s3s/src/ops/head_error_tests.rs
+++ b/crates/s3s/src/ops/head_error_tests.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-2026 The s3s Authors
+
+use super::*;
+
+use crate::ops;
+
+use http_body::Body;
+use hyper::Method;
+
+#[test]
+fn head_error_response_is_bodyless() {
+    let res = ops::serialize_error_for_method(&Method::HEAD, s3_error!(NoSuchKey), false).unwrap();
+    assert_eq!(res.status, hyper::StatusCode::NOT_FOUND);
+    assert!(Body::is_end_stream(&res.body), "HEAD response body must be empty");
+    assert!(!res.headers.contains_key(hyper::header::TRANSFER_ENCODING), "{:?}", res.headers);
+}
+
+#[test]
+fn get_error_response_keeps_xml_body() {
+    let res = ops::serialize_error_for_method(&Method::GET, s3_error!(NoSuchKey), false).unwrap();
+    assert!(!Body::is_end_stream(&res.body), "GET response must keep the XML body");
+    assert_eq!(res.headers.get(hyper::header::CONTENT_TYPE).unwrap(), "application/xml");
+}
+
+#[test]
+fn head_not_modified_is_bodyless() {
+    let res = ops::serialize_error_for_method(&Method::HEAD, s3_error!(NotModified), false).unwrap();
+    assert!(Body::is_end_stream(&res.body));
+}

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -31,6 +31,9 @@ mod tests;
 mod bodyless_error_tests;
 
 #[cfg(test)]
+mod head_error_tests;
+
+#[cfg(test)]
 mod route_skip_validation_tests;
 
 #[cfg(test)]
@@ -158,6 +161,16 @@ pub(crate) fn serialize_error(mut e: S3Error, no_decl: bool) -> S3Result<Respons
         http::strip_body(&mut res);
     }
     drop(e);
+    Ok(res)
+}
+/// Serializes an error response for the given request method. `HEAD` responses
+/// must not carry a body (RFC 9110 §9.3.2): the body is stripped while the
+/// metadata headers are preserved.
+pub(crate) fn serialize_error_for_method(method: &Method, e: S3Error, no_decl: bool) -> S3Result<Response> {
+    let mut res = serialize_error(e, no_decl)?;
+    if *method == Method::HEAD {
+        http::strip_body(&mut res);
+    }
     Ok(res)
 }
 
@@ -412,7 +425,7 @@ pub async fn call(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Response
         Ok(op) => op,
         Err(err) => {
             error!(?err, "failed to prepare");
-            return serialize_error(err, false);
+            return serialize_error_for_method(&req.method, err, false);
         }
     };
 
@@ -424,7 +437,7 @@ pub async fn call(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Response
                 }
                 Err(err) => {
                     error!(op = %op.name(), ?err, "op returns error");
-                    serialize_error(err, false)
+                    serialize_error_for_method(&req.method, err, false)
                 }
             }
         }
@@ -433,7 +446,7 @@ pub async fn call(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Response
             let result = reject_custom_route_body_too_large(extract_content_length(req)?, max_body_size);
             if let Err(err) = result {
                 error!(?err, "custom route request body is too large");
-                return serialize_error(err, false);
+                return serialize_error_for_method(&req.method, err, false);
             }
 
             let mut body = mem::take(&mut req.body);
@@ -456,7 +469,7 @@ pub async fn call(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Response
                 }),
                 Err(err) => {
                     error!(?err, "custom route returns error");
-                    serialize_error(err, false)
+                    serialize_error_for_method(&req.method, err, false)
                 }
             }
         }

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -28,6 +28,9 @@ mod multipart;
 mod tests;
 
 #[cfg(test)]
+mod bodyless_error_tests;
+
+#[cfg(test)]
 mod route_skip_validation_tests;
 
 #[cfg(test)]
@@ -135,13 +138,24 @@ fn build_s3_request<T>(input: T, req: &mut Request) -> S3Request<T> {
 pub(crate) fn serialize_error(mut e: S3Error, no_decl: bool) -> S3Result<Response> {
     let status = e.status_code().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
     let mut res = Response::with_status(status);
-    if no_decl {
-        http::set_xml_body_no_decl(&mut res, &e)?;
-    } else {
-        http::set_xml_body(&mut res, &e)?;
+    let bodyless = http::is_bodyless_status(status);
+    if !bodyless {
+        if no_decl {
+            http::set_xml_body_no_decl(&mut res, &e)?;
+        } else {
+            http::set_xml_body(&mut res, &e)?;
+        }
     }
     if let Some(headers) = e.take_headers() {
         res.headers = headers;
+    }
+    if bodyless {
+        // RFC 9110 §6.4.1: 1xx/204/205/304 responses MUST NOT carry a body. The
+        // XML body is skipped above; drop any body-describing headers too
+        // (e.g. `content-type` from a custom error or the error's own headers).
+        res.headers.remove(hyper::header::CONTENT_LENGTH);
+        res.headers.remove(hyper::header::CONTENT_TYPE);
+        http::strip_body(&mut res);
     }
     drop(e);
     Ok(res)

--- a/crates/s3s/src/ops/tests.rs
+++ b/crates/s3s/src/ops/tests.rs
@@ -4432,6 +4432,11 @@ mod virtual_hosted_style_hint_tests {
             assert!(result.is_ok(), "call failed for {method}");
             let resp = result.unwrap();
             assert_eq!(resp.status, http::StatusCode::NOT_IMPLEMENTED, "wrong status for {method}");
+            if method == Method::HEAD {
+                // RFC 9110 §9.3.2: HEAD responses must not carry a body.
+                assert!(http_body::Body::is_end_stream(&resp.body), "HEAD response must be bodyless");
+                continue;
+            }
             let text = body_str(&resp);
             assert!(
                 text.contains("virtual-hosted-style"),


### PR DESCRIPTION
### Problem

Error responses violate RFC 9110 in two related ways:

1. Bodyless statuses. `ops::serialize_error` serialized every `S3Error` as an XML body regardless of its status code, including 1xx/204/205/304 which MUST NOT carry a body (RFC 9110 §6.4.1). HTTP/1.1 tolerated this because hyper strips the body and Content-Length (leaving a stray content-type header); HTTP/2 sent the XML body as DATA frames after a HEADERS frame that should have carried END_STREAM, surfacing as connection-level failures (GOAWAY) with strict clients and reverse proxies.

2. HEAD requests. The service layer never looked at the request method: a failing `head_object` or `head_bucket` produced a 404 with a serialized XML body. HTTP/1.1 tolerated this (hyper suppresses the body but keeps Content-Length), while HTTP/2 sent the XML as DATA frames on a HEAD response, a protocol error for strict clients (RFC 9110 §9.3.2).

### Changes

- Add `http::is_bodyless_status` (1xx/204/205/304 per RFC 9110 §6.4.1) and `http::strip_body` (clears the body and `Transfer-Encoding`, keeping metadata headers such as `Content-Length` and `Content-Type`).
- `ops::serialize_error` now skips XML serialization for bodyless statuses and drops body-describing headers (`Content-Length`/`Content-Type`/`Transfer-Encoding`) while preserving custom error headers (such as `x-amz-request-id`).
- Add `ops::serialize_error_for_method`; all four error exits in `ops::call` now serialize through it, stripping the body (and `Transfer-Encoding`) from HEAD responses while preserving `Content-Length` and `Content-Type`.

### Breaking change

- Error responses with bodyless statuses (reachable via `S3ErrorCode::NotModified` or `S3Error::set_status_code`) no longer carry an XML body or content-type header; previously HTTP/1.1 received a stray content-type and HTTP/2 a protocol-violating DATA frame.
- Error responses to HEAD requests no longer carry an XML body; headers describing the equivalent GET response are preserved.

### Tests

- `ops::bodyless_error_tests` (7 cases): 304/204/205/1xx serialization is bodyless with no body-describing headers, custom error headers preserved, `to_http_response` path, and a 404 control case keeping the XML body.
- `ops::head_error_tests` (3 cases): HEAD error responses are bodyless with `Transfer-Encoding` removed, GET control case keeps the XML body, HEAD + 304 interplay.
- `http::response::tests`: `is_bodyless_status` RFC 9110 matrix and `strip_body` header semantics.
- Existing assertion updated: `actionable_501_for_virtual_hosted_style_without_s3_host` now expects a bodyless HEAD response.
- `just dev` (fmt / codegen idempotency / clippy strict / full test suite) green; `just semver-checks`: 196 pass, no API break.
