### PR TITLE
fix(s3s-sigv2): confine panics to audited helper functions

### DIFF
--- a/crates/s3s-sigv2/src/authorization.rs
+++ b/crates/s3s-sigv2/src/authorization.rs
@@ -38,6 +38,7 @@ impl<'a> AuthorizationV2<'a> {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::indexing_slicing, clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/s3s-sigv2/src/lib.rs
+++ b/crates/s3s-sigv2/src/lib.rs
@@ -4,6 +4,13 @@
 //! AWS Signature Version 2 — parsing, canonicalization, and signing.
 
 #![deny(missing_docs)]
+#![deny(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unreachable,
+    clippy::unwrap_used
+)]
 
 mod authorization;
 pub use self::authorization::*;

--- a/crates/s3s-sigv2/src/methods.rs
+++ b/crates/s3s-sigv2/src/methods.rs
@@ -76,6 +76,13 @@ fn get_unique_header_str<'a>(headers: &'a [(&'a str, &'a str)], name: &str) -> O
 ///
 /// The query pairs must be sorted by name (the `OrderedQs` contract) for the
 /// binary search to be valid; repeated names are treated as absent.
+///
+/// # Panics
+///
+/// The `qs[lower_bound..]` access cannot panic: `partition_point` returns a
+/// `lower_bound ≤ qs.len()`. clippy cannot prove this statically, so the lint
+/// is allowed here and the invariant is documented.
+#[allow(clippy::indexing_slicing)]
 fn get_unique_qs<'a>(qs: &'a [(String, String)], name: &str) -> Option<&'a str> {
     let lower_bound = qs.partition_point(|x| x.0.as_str() < name);
 
@@ -168,25 +175,7 @@ pub fn create_string_to_sign(
         }
         amz_headers.sort_by(|lhs, rhs| lhs.0.cmp(rhs.0));
 
-        let mut i = 0;
-        while i < amz_headers.len() {
-            let (name, value) = amz_headers[i];
-
-            ans.push_str(name);
-            ans.push(':');
-
-            ans.push_str(value.trim());
-
-            let mut j = i + 1;
-            while j < amz_headers.len() && amz_headers[j].0 == name {
-                ans.push(',');
-                ans.push_str(amz_headers[j].1.trim());
-                j += 1;
-            }
-
-            ans.push('\n');
-            i = j;
-        }
+        push_canonicalized_amz_headers(&mut ans, &amz_headers);
     }
 
     {
@@ -222,6 +211,37 @@ pub fn create_string_to_sign(
     ans
 }
 
+/// Appends the canonicalized `x-amz-*` headers: each group of adjacent
+/// same-named headers becomes `name:v1,v2\n`.
+///
+/// # Panics
+///
+/// The index accesses are guarded by the loop conditions (`i < len`,
+/// `j < len`); clippy cannot prove this statically, so the lint is allowed
+/// here and the invariants are documented.
+#[allow(clippy::indexing_slicing)]
+fn push_canonicalized_amz_headers(ans: &mut String, amz_headers: &[(&str, &str)]) {
+    let mut i = 0;
+    while i < amz_headers.len() {
+        let (name, value) = amz_headers[i];
+
+        ans.push_str(name);
+        ans.push(':');
+
+        ans.push_str(value.trim());
+
+        let mut j = i + 1;
+        while j < amz_headers.len() && amz_headers[j].0 == name {
+            ans.push(',');
+            ans.push_str(amz_headers[j].1.trim());
+            j += 1;
+        }
+
+        ans.push('\n');
+        i = j;
+    }
+}
+
 /// Computes the `SigV2` request signature: HMAC-SHA1 of the `StringToSign`
 /// under the secret key, encoded as standard Base64.
 ///
@@ -230,13 +250,26 @@ pub fn create_string_to_sign(
 /// `HMAC-SHA1` accepts keys of any length, so this never panics in practice.
 #[must_use]
 pub fn calculate_signature(secret_key: impl AsRef<[u8]>, string_to_sign: &str) -> String {
-    let mut m = <Hmac<Sha1>>::new_from_slice(secret_key.as_ref()).expect("Hmac accepts keys of any length");
+    let mut m = new_hmac_sha1(secret_key.as_ref());
     m.update(string_to_sign.as_bytes());
     let digest = m.finalize().into_bytes();
     STANDARD.encode_to_string(digest)
 }
 
+/// `HMAC-SHA1` accepts keys of any length, so `new_from_slice` never fails.
+///
+/// # Panics
+///
+/// This `expect` is a structural invariant of the `hmac` crate API; no
+/// request input can influence it. The lint is allowed here and the
+/// invariant is documented.
+#[allow(clippy::expect_used)]
+fn new_hmac_sha1(key: &[u8]) -> Hmac<Sha1> {
+    <Hmac<Sha1>>::new_from_slice(key).expect("Hmac accepts keys of any length")
+}
+
 #[cfg(test)]
+#[allow(clippy::indexing_slicing, clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/s3s-sigv2/src/post_signature.rs
+++ b/crates/s3s-sigv2/src/post_signature.rs
@@ -52,6 +52,7 @@ impl<'a> PostSignatureV2<'a> {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::indexing_slicing, clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/s3s-sigv2/src/presigned_url.rs
+++ b/crates/s3s-sigv2/src/presigned_url.rs
@@ -68,6 +68,7 @@ fn parse_unix_timestamp(s: &str) -> Option<Timestamp> {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::indexing_slicing, clippy::unwrap_used)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
### Problem

Issue #169 asks for panic usage to be reviewed and constrained. In `s3s-sigv2`, the five production panic sites (two index loops in `create_string_to_sign`, a slice in `get_unique_qs`, one `expect` in `calculate_signature`) were spread across public functions with no lint coverage: they are structural invariants (loop bounds, `partition_point`, HMAC's any-length key guarantee), but nothing prevents future edits from adding request-influenced panics silently.

### Changes

- Deny the panic-related restriction lints at the crate level (`clippy::unwrap_used`, `expect_used`, `indexing_slicing`, `panic`, `unreachable`).
- Converge the five accesses into three small helper functions that carry the lint allow plus a documented invariant:
  - `get_unique_qs`: the `qs[lower_bound..]` access is bounded because `partition_point` returns `lower_bound ≤ qs.len()`;
  - `push_canonicalized_amz_headers`: the index accesses are guarded by the loop conditions (`i < len`, `j < len`); the merge loop is moved verbatim out of `create_string_to_sign`, so the output sequence is unchanged;
  - `new_hmac_sha1`: `new_from_slice` cannot fail for any key length (structural invariant of the `hmac` crate API).
- Test modules keep their unwraps under a scoped `#[allow]` (test property, not production surface).

This is minimization rather than elimination: the panic semantics are preserved, but every production panic now lives in an audited, allow-carrying helper whose invariant is documented, so the audit surface is small and stable.

### Tests

- `cargo clippy -p s3s-sigv2 --all-targets -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::indexing_slicing -D clippy::panic -D clippy::unreachable`: zero warnings
- `cargo test -p s3s-sigv2`: 24 tests pass unchanged (no behavior change)
- `cargo fmt --all --check`: clean
- `just dev`: green (s3s signature paths depending on sigv2 covered)
