### PR TITLE
fix(s3s-sigv4): confine panics to audited helpers or type guarantees

### DIFF
--- a/crates/s3s-sigv4/src/amz_content_sha256.rs
+++ b/crates/s3s-sigv4/src/amz_content_sha256.rs
@@ -105,6 +105,13 @@ fn parse_checksum(header: &str) -> Option<[u8; 32]> {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unreachable,
+    clippy::unwrap_used
+)]
 mod tests {
     use super::*;
 

--- a/crates/s3s-sigv4/src/amz_date.rs
+++ b/crates/s3s-sigv4/src/amz_date.rs
@@ -39,7 +39,14 @@ impl AmzDate {
     }
 
     /// `{YYYY}{MM}{DD}T{HH}{MM}{SS}Z`
+    ///
+    /// # Panics
+    ///
+    /// `ArrayString<16>` has fixed capacity and the formatted value is exactly
+    /// 16 bytes; `fmt::Write` cannot fail here. The lint is allowed so that a
+    /// capacity regression panics instead of silently truncating.
     #[must_use]
+    #[allow(clippy::unwrap_used)]
     pub fn fmt_iso8601(&self) -> ArrayString<16> {
         let mut buf = <ArrayString<16>>::new();
         let (y, m, d, hh, mm, ss) = (self.year, self.month, self.day, self.hour, self.minute, self.second);
@@ -48,7 +55,14 @@ impl AmzDate {
     }
 
     /// `{YYYY}{MM}{DD}`
+    ///
+    /// # Panics
+    ///
+    /// `ArrayString<8>` has fixed capacity and the formatted value is exactly
+    /// 8 bytes; `fmt::Write` cannot fail here. The lint is allowed so that a
+    /// capacity regression panics instead of silently truncating.
     #[must_use]
+    #[allow(clippy::unwrap_used)]
     pub fn fmt_date(&self) -> ArrayString<8> {
         let mut buf = <ArrayString<8>>::new();
         write!(&mut buf, "{:04}{:02}{:02}", self.year, self.month, self.day).unwrap();
@@ -86,9 +100,23 @@ mod parser {
     }
 
     pub fn parse(input: &str) -> Result<AmzDate, Error> {
-        let x = input.as_bytes();
-        ensure!(x.len() == 16);
+        let x: &[u8; 16] = input.as_bytes().try_into().map_err(|_| Error)?;
+        let (year, month, day, hour, minute, second) = parse_date_bytes(x)?;
+        Ok(AmzDate {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+        })
+    }
 
+    /// Parses the sixteen fixed bytes of an ISO 8601 date string.
+    ///
+    /// The length is guaranteed by the `&[u8; 16]` reference type; all byte
+    /// accesses are array indexing, checked at compile time.
+    fn parse_date_bytes(x: &[u8; 16]) -> Result<(u16, u8, u8, u8, u8, u8), Error> {
         let year = digit4([x[0], x[1], x[2], x[3]])?;
         let month = digit2([x[4], x[5]])?;
         let day = digit2([x[6], x[7]])?;
@@ -99,18 +127,18 @@ mod parser {
         let second = digit2([x[13], x[14]])?;
         ensure!(x[15] == b'Z');
 
-        Ok(AmzDate {
-            year,
-            month,
-            day,
-            hour,
-            minute,
-            second,
-        })
+        Ok((year, month, day, hour, minute, second))
     }
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unreachable,
+    clippy::unwrap_used
+)]
 mod tests {
     use super::*;
 

--- a/crates/s3s-sigv4/src/authorization.rs
+++ b/crates/s3s-sigv4/src/authorization.rs
@@ -181,10 +181,7 @@ mod parser {
     }
 
     fn verify_date(s: &str) -> Result<(), Error> {
-        let x = s.as_bytes();
-        if x.len() != 8 {
-            return Err(Error);
-        }
+        let x: &[u8; 8] = s.as_bytes().try_into().map_err(|_| Error)?;
 
         let yyyy = digit4([x[0], x[1], x[2], x[3]])?;
         let mm = digit2([x[4], x[5]])?;
@@ -201,6 +198,13 @@ mod parser {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unreachable,
+    clippy::unwrap_used
+)]
 mod tests {
     use super::*;
 

--- a/crates/s3s-sigv4/src/crypto.rs
+++ b/crates/s3s-sigv4/src/crypto.rs
@@ -30,6 +30,13 @@ fn sha256(data: &[u8]) -> [u8; 32] {
 }
 
 #[cfg(all(feature = "openssl", not(windows)))]
+///
+/// # Panics
+///
+/// `openssl` hash operations fail only on invalid internal state; a digest
+/// over in-memory data cannot trigger it. The lint is allowed here and the
+/// invariant is documented.
+#[allow(clippy::unwrap_used)]
 fn sha256(data: &[u8]) -> [u8; 32] {
     use openssl::hash::{Hasher, MessageDigest};
     let mut h = Hasher::new(MessageDigest::sha256()).unwrap();
@@ -50,6 +57,13 @@ fn sha256_chunk(chunk: &[impl AsRef<[u8]>]) -> [u8; 32] {
 }
 
 #[cfg(all(feature = "openssl", not(windows)))]
+///
+/// # Panics
+///
+/// `openssl` hash operations fail only on invalid internal state; a digest
+/// over in-memory data cannot trigger it. The lint is allowed here and the
+/// invariant is documented.
+#[allow(clippy::unwrap_used)]
 fn sha256_chunk(chunk: &[impl AsRef<[u8]>]) -> [u8; 32] {
     use openssl::hash::{Hasher, MessageDigest};
     let mut h = Hasher::new(MessageDigest::sha256()).unwrap();
@@ -73,6 +87,13 @@ pub(crate) fn hex_sha256_chunk<R>(chunk: &[impl AsRef<[u8]>], f: impl FnOnce(&st
 }
 
 /// `hmac_sha256(key, data)`
+///
+/// # Panics
+///
+/// `HMAC-SHA256` accepts keys of any length, so `new_from_slice` never
+/// fails. This `expect` is a structural invariant of the `hmac` crate API;
+/// no request input can influence it.
+#[allow(clippy::expect_used)]
 pub(crate) fn hmac_sha256(key: impl AsRef<[u8]>, data: impl AsRef<[u8]>) -> [u8; 32] {
     let mut m = <Hmac<Sha256>>::new_from_slice(key.as_ref()).expect("Hmac accepts keys of any length");
     m.update(data.as_ref());

--- a/crates/s3s-sigv4/src/lib.rs
+++ b/crates/s3s-sigv4/src/lib.rs
@@ -4,6 +4,13 @@
 //! AWS Signature Version 4 — parsing, canonicalization, and signing.
 
 #![deny(missing_docs)]
+#![deny(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unreachable,
+    clippy::unwrap_used
+)]
 #![allow(
     clippy::multiple_crate_versions,
     clippy::module_name_repetitions,

--- a/crates/s3s-sigv4/src/methods.rs
+++ b/crates/s3s-sigv4/src/methods.rs
@@ -121,6 +121,74 @@ where
     v.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
 }
 
+/// Appends the canonicalized headers: each group of adjacent same-named
+/// headers becomes `name:value1,value2\n` (skipped headers are omitted).
+///
+/// # Panics
+///
+/// The index accesses are guarded by the loop conditions (`i < len`,
+/// `j < len`); clippy cannot prove this statically, so the lint is allowed
+/// here and the invariants are documented.
+#[allow(clippy::indexing_slicing)]
+fn push_canonical_headers(ans: &mut String, headers: &[(&str, &str)]) {
+    let mut i = 0;
+    while i < headers.len() {
+        let (name, value) = headers[i];
+        if is_skipped_header(name) {
+            i += 1;
+            continue;
+        }
+
+        ans.push_str(name);
+        ans.push(':');
+        normalize_header_value(ans, value);
+
+        // Combine values for headers with the same name (comma-separated)
+        let mut j = i + 1;
+        while j < headers.len() && headers[j].0 == name {
+            ans.push(',');
+            normalize_header_value(ans, headers[j].1);
+            j += 1;
+        }
+
+        ans.push('\n');
+        i = j;
+    }
+}
+
+/// Appends the signed header names, each appearing once even if the header
+/// has multiple values (skipped headers are omitted).
+///
+/// # Panics
+///
+/// The index accesses are guarded by the loop conditions (`i < len`);
+/// clippy cannot prove this statically, so the lint is allowed here and
+/// the invariants are documented.
+#[allow(clippy::indexing_slicing)]
+fn push_signed_headers(ans: &mut String, headers: &[(&str, &str)]) {
+    let mut first_flag = true;
+    let mut i = 0;
+    while i < headers.len() {
+        let (name, _) = headers[i];
+        if is_skipped_header(name) {
+            i += 1;
+            continue;
+        }
+
+        if first_flag {
+            first_flag = false;
+        } else {
+            ans.push(';');
+        }
+        ans.push_str(name);
+
+        // Skip duplicate header names
+        while i < headers.len() && headers[i].0 == name {
+            i += 1;
+        }
+    }
+}
+
 fn create_canonical_request_with_uri_mode<'a>(
     method: &str,
     uri_path: &str,
@@ -185,59 +253,14 @@ fn create_canonical_request_with_uri_mode<'a>(
 
         // FIXME: check HOST, Content-Type, x-amz-security-token, x-amz-content-sha256
 
-        let headers_slice = signed_headers.as_ref();
-        let mut i = 0;
-        while i < headers_slice.len() {
-            let (name, value) = headers_slice[i];
-            if is_skipped_header(name) {
-                i += 1;
-                continue;
-            }
-
-            ans.push_str(name);
-            ans.push(':');
-            normalize_header_value(&mut ans, value);
-
-            // Combine values for headers with the same name (comma-separated)
-            let mut j = i + 1;
-            while j < headers_slice.len() && headers_slice[j].0 == name {
-                ans.push(',');
-                normalize_header_value(&mut ans, headers_slice[j].1);
-                j += 1;
-            }
-
-            ans.push('\n');
-            i = j;
-        }
+        push_canonical_headers(&mut ans, signed_headers.as_ref());
         ans.push('\n');
     }
 
     {
         // <SignedHeaders>\n
         // Each header name should only appear once, even if the header has multiple values
-        let headers_slice = signed_headers.as_ref();
-        let mut first_flag = true;
-        let mut i = 0;
-        while i < headers_slice.len() {
-            let (name, _) = headers_slice[i];
-            if is_skipped_header(name) {
-                i += 1;
-                continue;
-            }
-
-            if first_flag {
-                first_flag = false;
-            } else {
-                ans.push(';');
-            }
-            ans.push_str(name);
-
-            // Skip duplicate header names
-            while i < headers_slice.len() && headers_slice[i].0 == name {
-                i += 1;
-            }
-        }
-
+        push_signed_headers(&mut ans, signed_headers.as_ref());
         ans.push('\n');
     }
 
@@ -505,58 +528,13 @@ fn create_presigned_canonical_request_with_uri_mode<'a>(
         // According to AWS SigV4 spec, multiple headers with the same name should be
         // combined into a single header with values separated by commas.
 
-        let headers_slice = signed_headers.as_ref();
-        let mut i = 0;
-        while i < headers_slice.len() {
-            let (name, value) = headers_slice[i];
-            if is_skipped_header(name) {
-                i += 1;
-                continue;
-            }
-
-            ans.push_str(name);
-            ans.push(':');
-            normalize_header_value(&mut ans, value);
-
-            // Combine values for headers with the same name (comma-separated)
-            let mut j = i + 1;
-            while j < headers_slice.len() && headers_slice[j].0 == name {
-                ans.push(',');
-                normalize_header_value(&mut ans, headers_slice[j].1);
-                j += 1;
-            }
-
-            ans.push('\n');
-            i = j;
-        }
+        push_canonical_headers(&mut ans, signed_headers.as_ref());
         ans.push('\n');
     }
     {
         // <SignedHeaders>\n
         // Each header name should only appear once, even if the header has multiple values
-        let headers_slice = signed_headers.as_ref();
-        let mut first_flag = true;
-        let mut i = 0;
-        while i < headers_slice.len() {
-            let (name, _) = headers_slice[i];
-            if is_skipped_header(name) {
-                i += 1;
-                continue;
-            }
-
-            if first_flag {
-                first_flag = false;
-            } else {
-                ans.push(';');
-            }
-            ans.push_str(name);
-
-            // Skip duplicate header names
-            while i < headers_slice.len() && headers_slice[i].0 == name {
-                i += 1;
-            }
-        }
-
+        push_signed_headers(&mut ans, signed_headers.as_ref());
         ans.push('\n');
     }
     {
@@ -589,6 +567,13 @@ pub fn create_presigned_canonical_request_with_raw_uri_path<'a>(
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unreachable,
+    clippy::unwrap_used
+)]
 mod tests {
     use super::*;
 

--- a/crates/s3s-sigv4/src/parser.rs
+++ b/crates/s3s-sigv4/src/parser.rs
@@ -27,6 +27,13 @@ fn digit(c: u8) -> Result<u8, Error> {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unreachable,
+    clippy::unwrap_used
+)]
 mod tests {
     use super::*;
 

--- a/crates/s3s-sigv4/src/post_signature.rs
+++ b/crates/s3s-sigv4/src/post_signature.rs
@@ -59,6 +59,13 @@ impl<'a> PostSignatureV4<'a> {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unreachable,
+    clippy::unwrap_used
+)]
 mod tests {
     use super::*;
 

--- a/crates/s3s-sigv4/src/presigned_url.rs
+++ b/crates/s3s-sigv4/src/presigned_url.rs
@@ -110,6 +110,13 @@ fn parse_expires(s: &str, max_expires_secs: u32) -> Option<jiff::SignedDuration>
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unreachable,
+    clippy::unwrap_used
+)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
### Problem

Issue #169 asks for panic usage to be reviewed and constrained. In `s3s-sigv4`, the production panic sites (fixed-length date byte indexing in `parse` / `verify_date`, `ArrayString` writes, the header merge loops in both canonical-request builders, and the hash/HMAC constructions) were structural invariants, but they were spread across public functions with no lint coverage, so nothing prevented future edits from adding request-influenced panics silently.

### Changes

- Deny the panic-related restriction lints at the crate level (`clippy::unwrap_used`, `expect_used`, `indexing_slicing`, `panic`, `unreachable`).
- Date parsing: `parse` and `verify_date` now convert the input to `&[u8; 16]` / `&[u8; 8]` via `try_into`, absorbing the length check; every byte access becomes compile-time-checked array indexing, so this site needs no allow and no invariant comment — the type is the proof. The parsing body moves into a private `parse_date_bytes` helper.
- `ArrayString` writes (`fmt_iso8601` / `fmt_date`) keep their `unwrap` with a method-level allow: the fixed-capacity invariant is documented, and a capacity regression panics instead of silently truncating.
- Header canonicalization: the merge loops in `create_canonical_request_with_uri_mode` and `create_presigned_canonical_request_with_uri_mode` are moved verbatim into `push_canonical_headers` and `push_signed_headers`, each carrying an allow plus the loop-bound invariant documentation.
- Crypto: `hmac_sha256` and the `openssl`-feature `sha256` / `sha256_chunk` constructions carry an allow for their structural invariants (any-length HMAC keys; hashing over in-memory data cannot fail).
- Test modules keep their unwraps under a scoped allow (test property, not production surface).

This is minimization rather than elimination: the panic semantics are preserved, but each production panic now lives in a small audited surface — either a compile-time type guarantee (date parsing) or an allow-carrying helper whose invariant is documented.

### Tests

- `cargo clippy --workspace --all-features --all-targets -p s3s-sigv4 -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::indexing_slicing -D clippy::panic -D clippy::unreachable`: zero warnings (includes the openssl feature variant)
- `cargo test -p s3s-sigv4`: 71 tests pass unchanged (no behavior change)
- `cargo fmt --all --check`: clean
- `just dev`: green (s3s signature and aws-chunked paths depending on sigv4 covered)
