### PR TITLE
feat(s3s-test): publicize the harness library mode and complete tests and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: taiki-e/install-action@just
       - uses: taiki-e/install-action@cargo-llvm-cov
       - run: |
-          cargo llvm-cov -p s3s --all-features --codecov --output-path target/codecov.json
+          cargo llvm-cov -p s3s -p s3s-sigv2 -p s3s-sigv4 -p s3s-test --all-features --codecov --output-path target/codecov.json
       - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/crates/s3s-test/src/cli.rs
+++ b/crates/s3s-test/src/cli.rs
@@ -23,7 +23,6 @@ pub use clap;
 pub use const_str;
 
 /// The CLI options understood by [`main`] and the [`main!`](crate::main) macro.
-#[doc(hidden)]
 pub struct Options {
     /// Path to write the JSON report to.
     pub json: Option<PathBuf>,
@@ -31,7 +30,7 @@ pub struct Options {
     pub filter: Vec<String>,
     /// Print all registered cases without running them.
     pub list: bool,
-    /// Run cases tagged [`CaseTag::Ignored`](crate::CaseTag::Ignored).
+    /// Run cases tagged [`CaseTag::Ignored`](crate::tcx::CaseTag::Ignored).
     pub run_ignored: bool,
     /// Run cases within a fixture concurrently.
     pub concurrent: bool,
@@ -172,7 +171,6 @@ async fn async_main(reg: impl FnOnce(&mut TestContext), opt: &Options) -> ExitCo
 ///
 /// The exit code is nonzero when any suite fails. Use this function directly
 /// for a custom entry point, or [`main!`](crate::main) for the standard CLI.
-#[doc(hidden)]
 #[must_use]
 pub fn main(reg: impl FnOnce(&mut TestContext), opt: &Options) -> ExitCode {
     setup();

--- a/crates/s3s-test/src/cli.rs
+++ b/crates/s3s-test/src/cli.rs
@@ -259,3 +259,134 @@ macro_rules! main {
         }
     };
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::*;
+
+    use std::sync::Arc;
+
+    async fn ok_case(_: Arc<MockFixture>) -> crate::Result {
+        Ok(())
+    }
+
+    async fn fail_case(_: Arc<MockFixture>) -> crate::Result {
+        Err(crate::Failed::from_string("fail"))
+    }
+
+    async fn panic_case(_: Arc<MockFixture>) -> crate::Result {
+        panic!("boom");
+    }
+
+    fn options(json: Option<PathBuf>, filter: Vec<String>, list: bool) -> Options {
+        Options {
+            json,
+            filter,
+            list,
+            run_ignored: false,
+            concurrent: false,
+        }
+    }
+
+    fn register_ok(tcx: &mut TestContext) {
+        let mut suite = tcx.suite::<MockSuite>("suite");
+        let mut fixture = suite.fixture::<MockFixture>("fixture");
+        fixture.case("ok", ok_case);
+    }
+
+    fn register_ok_and_fail(tcx: &mut TestContext) {
+        let mut suite = tcx.suite::<MockSuite>("suite");
+        let mut fixture = suite.fixture::<MockFixture>("fixture");
+        fixture.case("ok", ok_case);
+        fixture.case("fail", fail_case);
+    }
+
+    fn register_panic(tcx: &mut TestContext) {
+        let mut suite = tcx.suite::<MockSuite>("suite");
+        let mut fixture = suite.fixture::<MockFixture>("fixture");
+        fixture.case("panics", panic_case);
+    }
+
+    fn register_ignored_fail(tcx: &mut TestContext) {
+        use crate::tcx::CaseTag;
+
+        let mut suite = tcx.suite::<MockSuite>("suite");
+        let mut fixture = suite.fixture::<MockFixture>("fixture");
+        fixture.case("ignored", fail_case).tag(CaseTag::Ignored);
+    }
+
+    #[test]
+    fn run_success_returns_zero_and_writes_json() {
+        let json_path = std::env::temp_dir().join(format!("s3s-test-report-{}.json", std::process::id()));
+        let opt = options(Some(json_path.clone()), Vec::new(), false);
+
+        let code = async_main(register_ok, &opt);
+        assert_eq!(code, ExitCode::from(0));
+
+        let text = std::fs::read_to_string(&json_path).unwrap();
+        let report: crate::report::Report = serde_json::from_str(&text).unwrap();
+        assert!(report.suite_count.all_passed());
+        std::fs::remove_file(&json_path).ok();
+    }
+
+    #[test]
+    fn failing_case_returns_nonzero() {
+        let opt = options(None, Vec::new(), false);
+        let code = async_main(register_ok_and_fail, &opt);
+        assert_eq!(code, ExitCode::from(1));
+    }
+
+    #[test]
+    fn panicking_case_returns_nonzero() {
+        let opt = options(None, Vec::new(), false);
+        let code = async_main(register_panic, &opt);
+        assert_eq!(code, ExitCode::from(1));
+    }
+
+    #[test]
+    fn ignored_case_is_skipped_by_default() {
+        let opt = options(None, Vec::new(), false);
+        let code = async_main(register_ignored_fail, &opt);
+        assert_eq!(code, ExitCode::from(0));
+    }
+
+    #[test]
+    fn run_ignored_runs_ignored_cases() {
+        let opt = Options {
+            json: None,
+            filter: Vec::new(),
+            list: false,
+            run_ignored: true,
+            concurrent: false,
+        };
+        let code = async_main(register_ignored_fail, &opt);
+        assert_eq!(code, ExitCode::from(1));
+    }
+
+    #[test]
+    fn list_mode_returns_zero_without_running() {
+        let opt = options(None, Vec::new(), true);
+        let code = async_main(register_ok_and_fail, &opt);
+        assert_eq!(code, ExitCode::from(0));
+    }
+
+    #[test]
+    fn filter_runs_only_matching_cases() {
+        let opt = options(None, vec![String::from("ok")], false);
+        let code = async_main(register_ok_and_fail, &opt);
+        assert_eq!(code, ExitCode::from(0));
+    }
+
+    #[test]
+    fn invalid_filter_returns_error_code() {
+        let opt = options(None, vec![String::from("[")], false);
+        let code = async_main(register_ok, &opt);
+        assert_eq!(code, ExitCode::from(2));
+    }
+
+    #[test]
+    fn setup_initializes_tracing() {
+        setup();
+    }
+}

--- a/crates/s3s-test/src/cli.rs
+++ b/crates/s3s-test/src/cli.rs
@@ -22,15 +22,23 @@ pub use clap;
 #[doc(hidden)]
 pub use const_str;
 
+/// The CLI options understood by [`main`] and the [`main!`](crate::main) macro.
 #[doc(hidden)]
 pub struct Options {
+    /// Path to write the JSON report to.
     pub json: Option<PathBuf>,
+    /// Regex patterns matching `suite/fixture/case` paths.
     pub filter: Vec<String>,
+    /// Print all registered cases without running them.
     pub list: bool,
+    /// Run cases tagged [`CaseTag::Ignored`](crate::CaseTag::Ignored).
     pub run_ignored: bool,
+    /// Run cases within a fixture concurrently.
     pub concurrent: bool,
 }
 
+/// Initializes the environment: loads `.env`, then sets up the tracing
+/// subscriber with an `EnvFilter` from `RUST_LOG`.
 #[doc(hidden)]
 pub fn setup() {
     use std::io::IsTerminal;
@@ -160,6 +168,10 @@ async fn async_main(reg: impl FnOnce(&mut TestContext), opt: &Options) -> ExitCo
     }
 }
 
+/// Runs the harness and returns the process exit code.
+///
+/// The exit code is nonzero when any suite fails. Use this function directly
+/// for a custom entry point, or [`main!`](crate::main) for the standard CLI.
 #[doc(hidden)]
 #[must_use]
 pub fn main(reg: impl FnOnce(&mut TestContext), opt: &Options) -> ExitCode {
@@ -176,6 +188,19 @@ pub const fn unwrap<'a>(s: Option<&'a str>, default: &'a str) -> &'a str {
     }
 }
 
+/// Generates the binary entry point for a test harness.
+///
+/// The macro expands to a `main` function that parses the standard CLI
+/// (`--filter`, `--list`, `--json`, `--run-ignored`, `--concurrent`),
+/// registers the suites via the given function, and runs them.
+///
+/// ```no_run
+/// use s3s_test::tcx::TestContext;
+///
+/// fn register(_tcx: &mut TestContext) {}
+///
+/// s3s_test::main!(register);
+/// ```
 #[macro_export]
 macro_rules! main {
     ($register:expr) => {

--- a/crates/s3s-test/src/error.rs
+++ b/crates/s3s-test/src/error.rs
@@ -4,8 +4,18 @@
 use std::env;
 use std::fmt;
 
+/// The result type used by suites, fixtures, and cases.
+///
+/// A case fails either by returning `Err(Failed)` (e.g. via `?`) or by
+/// panicking (e.g. via `assert!`). The two failures are reported distinctly
+/// in the report (`FnResult::Err` vs `FnResult::Panicked`).
 pub type Result<T = (), E = Failed> = std::result::Result<T, E>;
 
+/// The error type used by the harness.
+///
+/// Wraps any `std::error::Error` source. When `RUST_BACKTRACE` is set, the
+/// conversion from a source error prints the source chain and a backtrace
+/// filtered to s3s paths.
 #[derive(Debug)]
 pub struct Failed {
     source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
@@ -47,6 +57,8 @@ impl fmt::Display for Failed {
 }
 
 impl Failed {
+    /// Creates a failure from an arbitrary string message.
+    #[must_use]
     pub fn from_string(s: impl Into<String>) -> Self {
         Self {
             source: Some(s.into().into()),

--- a/crates/s3s-test/src/error.rs
+++ b/crates/s3s-test/src/error.rs
@@ -65,3 +65,40 @@ impl Failed {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct TestError;
+
+    impl fmt::Display for TestError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "test error")
+        }
+    }
+
+    impl std::error::Error for TestError {}
+
+    #[test]
+    fn failed_from_error() {
+        let failed = Failed::from(TestError);
+        assert_eq!(failed.to_string(), "Failed: test error");
+    }
+
+    #[test]
+    fn failed_from_string() {
+        let failed = Failed::from_string("custom message");
+        assert_eq!(failed.to_string(), "Failed: custom message");
+    }
+
+    #[test]
+    fn result_propagates_via_question_mark() {
+        fn f() -> Result<u32> {
+            let x: u32 = "42".parse()?;
+            Ok(x)
+        }
+        assert_eq!(f().unwrap(), 42);
+    }
+}

--- a/crates/s3s-test/src/lib.rs
+++ b/crates/s3s-test/src/lib.rs
@@ -1,6 +1,85 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-2026 The s3s Authors
 
+//! A reusable test harness for S3-compatible services.
+//!
+//! The harness organizes tests into three levels:
+//!
+//! - **Suite**: one server configuration. The suite setup builds the server
+//!   (or connects to an external endpoint) and produces the shared data
+//!   consumed by all fixtures and cases.
+//! - **Fixture**: a group of cases that share the same client and
+//!   precondition. Fixtures may hold extra shared state beyond the suite data.
+//! - **Case**: a single test function. Cases receive `Arc<Fixture>` and may
+//!   run concurrently.
+//!
+//! # Server shapes
+//!
+//! The harness itself is transport-agnostic: it never constructs servers.
+//! The suite setup is responsible for building the client. Common shapes:
+//!
+//! - **In-process (direct)**: build an `S3Service`, wrap it with
+//!   `s3s_aws::Client`, and hand the resulting AWS SDK client to the suite.
+//!   No network is involved.
+//! - **In-process (TCP)**: start a `hyper` server on a random local port and
+//!   point a client at it.
+//! - **Remote endpoint**: read `AWS_ENDPOINT_URL` and credentials from the
+//!   environment (e.g. via `aws_config::from_env`) and run the cases against
+//!   any S3-compatible service.
+//!
+//! The same cases can run against any of these shapes.
+//!
+//! # Concurrency
+//!
+//! Concurrency is a global flag (`--concurrent` on the CLI). With
+//! concurrency enabled, cases within one fixture run in parallel; fixtures
+//! and suites still run sequentially. Concurrency safety is the
+//! responsibility of each case: cases that may run concurrently must isolate
+//! their resources (e.g. by using unique bucket or key names). Default is
+//! sequential.
+//!
+//! # Quick start
+//!
+//! ```ignore
+//! use s3s_test::tcx::TestContext;
+//! use s3s_test::{Result, TestFixture, TestSuite};
+//!
+//! struct Server;
+//!
+//! impl TestSuite for Server {
+//!     fn setup() -> impl Future<Output = Result<Self>> + Send + 'static {
+//!         std::future::ready(Ok(Self))
+//!     }
+//! }
+//!
+//! struct Client;
+//!
+//! impl TestFixture<Server> for Client {
+//!     fn setup(_: Arc<Server>) -> impl Future<Output = Result<Self>> + Send + 'static {
+//!         std::future::ready(Ok(Self))
+//!     }
+//! }
+//!
+//! impl Client {
+//!     async fn list_buckets(self: Arc<Self>) -> Result {
+//!         Ok(())
+//!     }
+//! }
+//!
+//! fn register(tcx: &mut TestContext) {
+//!     let mut suite = tcx.suite::<Server>("Server");
+//!     let mut fixture = suite.fixture::<Client>("Client");
+//!     fixture.case("list_buckets", Client::list_buckets);
+//! }
+//!
+//! s3s_test::main!(register);
+//! ```
+//!
+//! The `main!` macro generates the entry point with a fixed CLI
+//! (`--filter`, `--list`, `--json`, `--run-ignored`, `--concurrent`). For a
+//! custom entry point, use the library mode directly: `TestContext::new()`,
+//! register, then drive the run with `cli::main` and `cli::Options`.
+
 #![allow(
     clippy::missing_errors_doc, // TODO
     clippy::missing_panics_doc, // TODO

--- a/crates/s3s-test/src/lib.rs
+++ b/crates/s3s-test/src/lib.rs
@@ -87,6 +87,8 @@
 
 mod error;
 mod runner;
+#[cfg(test)]
+mod test_support;
 mod traits;
 
 pub mod build;

--- a/crates/s3s-test/src/lib.rs
+++ b/crates/s3s-test/src/lib.rs
@@ -16,4 +16,5 @@ pub mod report;
 pub mod tcx;
 
 pub use self::error::{Failed, Result};
+pub use self::tcx::TestContext;
 pub use self::traits::*;

--- a/crates/s3s-test/src/report.rs
+++ b/crates/s3s-test/src/report.rs
@@ -104,3 +104,42 @@ impl FnResult {
         matches!(self, FnResult::Ok)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fn_result_is_ok() {
+        assert!(FnResult::Ok.is_ok());
+        assert!(!FnResult::Err(String::new()).is_ok());
+        assert!(!FnResult::Panicked.is_ok());
+    }
+
+    #[test]
+    fn count_summary_all_passed_ignores_ignored() {
+        let passed = CountSummary {
+            total: 3,
+            passed: 3,
+            failed: 0,
+            ignored: 0,
+        };
+        assert!(passed.all_passed());
+
+        let failed = CountSummary {
+            total: 3,
+            passed: 2,
+            failed: 1,
+            ignored: 0,
+        };
+        assert!(!failed.all_passed());
+
+        let ignored = CountSummary {
+            total: 3,
+            passed: 2,
+            failed: 0,
+            ignored: 1,
+        };
+        assert!(ignored.all_passed());
+    }
+}

--- a/crates/s3s-test/src/report.rs
+++ b/crates/s3s-test/src/report.rs
@@ -3,6 +3,10 @@
 
 use serde::{Deserialize, Serialize};
 
+/// The top-level report produced by the runner.
+///
+/// Serialized to JSON with `--json`. The exit code is nonzero when
+/// `suite_count.all_passed()` is false.
 #[derive(Serialize, Deserialize)]
 pub struct Report {
     pub suite_count: CountSummary,
@@ -12,6 +16,8 @@ pub struct Report {
     pub suites: Vec<SuiteReport>,
 }
 
+/// The report of one suite, including setup/teardown summaries and fixture
+/// reports.
 #[derive(Serialize, Deserialize)]
 pub struct SuiteReport {
     pub name: String,
@@ -25,6 +31,8 @@ pub struct SuiteReport {
     pub fixtures: Vec<FixtureReport>,
 }
 
+/// The report of one fixture, including setup/teardown summaries and case
+/// reports.
 #[derive(Serialize, Deserialize)]
 pub struct FixtureReport {
     pub name: String,
@@ -38,6 +46,7 @@ pub struct FixtureReport {
     pub cases: Vec<CaseReport>,
 }
 
+/// The report of one case.
 #[derive(Serialize, Deserialize)]
 pub struct CaseReport {
     pub name: String,
@@ -50,6 +59,9 @@ pub struct CaseReport {
     pub run: Option<FnSummary>,
 }
 
+/// The outcome of one function invocation (setup, teardown, or case).
+///
+/// `None` for the run summary of an ignored case.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FnSummary {
     pub result: FnResult,
@@ -57,6 +69,7 @@ pub struct FnSummary {
     pub duration_ms: f64,
 }
 
+/// A summary of pass/fail/ignored counts.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CountSummary {
     pub total: u64,
@@ -66,12 +79,17 @@ pub struct CountSummary {
 }
 
 impl CountSummary {
+    /// Returns true when no case failed (ignored cases do not count).
     #[must_use]
     pub fn all_passed(&self) -> bool {
         self.failed == 0
     }
 }
 
+/// The result of a function invocation.
+///
+/// A panicked invocation is reported as `Panicked` even when it satisfies a
+/// `ShouldPanic` tag (the case then passes).
 #[derive(Debug, Serialize, Deserialize)]
 pub enum FnResult {
     Ok,
@@ -80,6 +98,7 @@ pub enum FnResult {
 }
 
 impl FnResult {
+    /// Returns true when the invocation completed successfully.
     #[must_use]
     pub fn is_ok(&self) -> bool {
         matches!(self, FnResult::Ok)

--- a/crates/s3s-test/src/runner.rs
+++ b/crates/s3s-test/src/runner.rs
@@ -165,7 +165,7 @@ enum CaseHandle {
 }
 
 #[allow(clippy::similar_names)]
-async fn run_case(case_name: String, case_future: BoxFuture<'static, crate::Result>) -> CaseReport {
+async fn run_case(case_name: String, case_future: BoxFuture<'static, crate::Result>, should_panic: bool) -> CaseReport {
     info!("Test case start");
     let t0 = Instant::now();
 
@@ -173,31 +173,19 @@ async fn run_case(case_name: String, case_future: BoxFuture<'static, crate::Resu
     let elapsed_ns = t0.elapsed().as_nanos() as u64;
     let elapsed_ms = elapsed_ns as f64 / 1e6;
 
-    let summary = match result {
-        Ok(Ok(())) => FnSummary {
-            result: FnResult::Ok,
-            duration_ns: elapsed_ns,
-            duration_ms: elapsed_ms,
-        },
-        Ok(Err(ref e)) => FnSummary {
-            result: FnResult::Err(e.to_string()),
-            duration_ns: elapsed_ns,
-            duration_ms: elapsed_ms,
-        },
-        Err(ref e) if e.is_panic() => FnSummary {
-            result: FnResult::Panicked,
-            duration_ns: elapsed_ns,
-            duration_ms: elapsed_ms,
-        },
-        Err(ref e) => FnSummary {
-            result: FnResult::Err(e.to_string()),
-            duration_ns: elapsed_ns,
-            duration_ms: elapsed_ms,
-        },
+    let (passed, result) = match result {
+        Ok(Ok(())) => (!should_panic, FnResult::Ok),
+        Ok(Err(ref e)) => (!should_panic, FnResult::Err(e.to_string())),
+        Err(ref e) if e.is_panic() => (should_panic, FnResult::Panicked),
+        Err(ref e) => (false, FnResult::Err(e.to_string())),
+    };
+    let summary = FnSummary {
+        result,
+        duration_ns: elapsed_ns,
+        duration_ms: elapsed_ms,
     };
 
     info!(?summary, "Test case end");
-    let passed = summary.result.is_ok();
 
     CaseReport {
         name: case_name,
@@ -247,11 +235,12 @@ async fn run_fixture(fixture: &FixtureInfo, suite_data: &ArcAny, concurrent: boo
                     continue;
                 }
 
+                let should_panic = case.tags.contains(&CaseTag::ShouldPanic);
                 let case_name = case.name.clone();
                 let case_future = (case.run)(Arc::clone(&fixture_data));
                 let span = info_span!("case", name = case_name.as_str());
 
-                let handle = spawn(run_case(case_name, case_future).instrument(span));
+                let handle = spawn(run_case(case_name, case_future, should_panic).instrument(span));
                 handles.push(CaseHandle::Running(handle));
             }
 
@@ -280,11 +269,12 @@ async fn run_fixture(fixture: &FixtureInfo, suite_data: &ArcAny, concurrent: boo
                     continue;
                 }
 
+                let should_panic = case.tags.contains(&CaseTag::ShouldPanic);
                 let case_name = case.name.clone();
                 let case_future = (case.run)(Arc::clone(&fixture_data));
                 let span = info_span!("case", name = case_name.as_str());
 
-                let report = run_case(case_name, case_future).instrument(span).await;
+                let report = run_case(case_name, case_future, should_panic).instrument(span).await;
                 cases.push(report);
             }
         }
@@ -307,5 +297,83 @@ async fn run_fixture(fixture: &FixtureInfo, suite_data: &ArcAny, concurrent: boo
         duration_ns,
         duration_ms: duration_ns as f64 / 1e6,
         cases,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tcx::TestContext;
+
+    use std::sync::Arc;
+
+    struct TestSuiteType;
+
+    impl crate::traits::TestSuite for TestSuiteType {
+        fn setup() -> impl Future<Output = crate::Result<Self>> + Send + 'static {
+            std::future::ready(Ok(Self))
+        }
+    }
+
+    struct TestFixtureType;
+
+    impl crate::traits::TestFixture<TestSuiteType> for TestFixtureType {
+        fn setup(_: Arc<TestSuiteType>) -> impl Future<Output = crate::Result<Self>> + Send + 'static {
+            std::future::ready(Ok(Self))
+        }
+    }
+
+    async fn ok_case(_: Arc<TestFixtureType>) -> crate::Result {
+        Ok(())
+    }
+
+    async fn panic_case(_: Arc<TestFixtureType>) -> crate::Result {
+        panic!("boom");
+    }
+
+    fn register_case(
+        name: &str,
+        case: impl crate::traits::TestCase<TestFixtureType, TestSuiteType> + 'static,
+        should_panic: bool,
+    ) -> TestContext {
+        let mut tcx = TestContext::new();
+        let mut suite = tcx.suite::<TestSuiteType>("suite");
+        let mut fixture = suite.fixture::<TestFixtureType>("fixture");
+        let mut builder = fixture.case(name, case);
+        if should_panic {
+            builder.tag(CaseTag::ShouldPanic);
+        }
+        tcx
+    }
+
+    async fn run_case_passed(tcx: &mut TestContext) -> bool {
+        let report = run(tcx, false).await;
+        let suite = &report.suites[0];
+        let fixture = &suite.fixtures[0];
+        fixture.cases[0].passed
+    }
+
+    #[tokio::test]
+    async fn should_panic_tag_with_panic_passes() {
+        let mut tcx = register_case("panics", panic_case, true);
+        assert!(run_case_passed(&mut tcx).await, "should_panic case that panics should pass");
+    }
+
+    #[tokio::test]
+    async fn should_panic_tag_without_panic_fails() {
+        let mut tcx = register_case("no-panic", ok_case, true);
+        assert!(!run_case_passed(&mut tcx).await, "should_panic case that does not panic should fail");
+    }
+
+    #[tokio::test]
+    async fn untagged_case_with_panic_fails() {
+        let mut tcx = register_case("panics", panic_case, false);
+        assert!(!run_case_passed(&mut tcx).await, "untagged case that panics should fail");
+    }
+
+    #[tokio::test]
+    async fn untagged_case_without_panic_passes() {
+        let mut tcx = register_case("ok", ok_case, false);
+        assert!(run_case_passed(&mut tcx).await, "untagged case that returns Ok should pass");
     }
 }

--- a/crates/s3s-test/src/runner.rs
+++ b/crates/s3s-test/src/runner.rs
@@ -175,7 +175,7 @@ async fn run_case(case_name: String, case_future: BoxFuture<'static, crate::Resu
 
     let (passed, result) = match result {
         Ok(Ok(())) => (!should_panic, FnResult::Ok),
-        Ok(Err(ref e)) => (!should_panic, FnResult::Err(e.to_string())),
+        Ok(Err(ref e)) => (false, FnResult::Err(e.to_string())),
         Err(ref e) if e.is_panic() => (should_panic, FnResult::Panicked),
         Err(ref e) => (false, FnResult::Err(e.to_string())),
     };
@@ -303,77 +303,138 @@ async fn run_fixture(fixture: &FixtureInfo, suite_data: &ArcAny, concurrent: boo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tcx::CaseTag;
     use crate::tcx::TestContext;
+    use crate::test_support::*;
 
     use std::sync::Arc;
 
-    struct TestSuiteType;
-
-    impl crate::traits::TestSuite for TestSuiteType {
-        fn setup() -> impl Future<Output = crate::Result<Self>> + Send + 'static {
-            std::future::ready(Ok(Self))
-        }
-    }
-
-    struct TestFixtureType;
-
-    impl crate::traits::TestFixture<TestSuiteType> for TestFixtureType {
-        fn setup(_: Arc<TestSuiteType>) -> impl Future<Output = crate::Result<Self>> + Send + 'static {
-            std::future::ready(Ok(Self))
-        }
-    }
-
-    async fn ok_case(_: Arc<TestFixtureType>) -> crate::Result {
+    async fn ok_case(_: Arc<MockFixture>) -> crate::Result {
         Ok(())
     }
 
-    async fn panic_case(_: Arc<TestFixtureType>) -> crate::Result {
+    async fn panic_case(_: Arc<MockFixture>) -> crate::Result {
         panic!("boom");
     }
 
-    fn register_case(
-        name: &str,
-        case: impl crate::traits::TestCase<TestFixtureType, TestSuiteType> + 'static,
-        should_panic: bool,
-    ) -> TestContext {
-        let mut tcx = TestContext::new();
-        let mut suite = tcx.suite::<TestSuiteType>("suite");
-        let mut fixture = suite.fixture::<TestFixtureType>("fixture");
-        let mut builder = fixture.case(name, case);
-        if should_panic {
-            builder.tag(CaseTag::ShouldPanic);
-        }
-        tcx
+    async fn err_case(_: Arc<MockFixture>) -> crate::Result {
+        Err(crate::Failed::from_string("boom"))
     }
 
     async fn run_case_passed(tcx: &mut TestContext) -> bool {
-        let report = run(tcx, false).await;
-        let suite = &report.suites[0];
-        let fixture = &suite.fixtures[0];
-        fixture.cases[0].passed
+        run_single_case(tcx).await.passed
     }
 
     #[tokio::test]
     async fn should_panic_tag_with_panic_passes() {
-        let mut tcx = register_case("panics", panic_case, true);
+        let mut tcx = register_case_with_tags("panics", panic_case, &[CaseTag::ShouldPanic]);
         assert!(run_case_passed(&mut tcx).await, "should_panic case that panics should pass");
     }
 
     #[tokio::test]
     async fn should_panic_tag_without_panic_fails() {
-        let mut tcx = register_case("no-panic", ok_case, true);
+        let mut tcx = register_case_with_tags("no-panic", ok_case, &[CaseTag::ShouldPanic]);
         assert!(!run_case_passed(&mut tcx).await, "should_panic case that does not panic should fail");
     }
 
     #[tokio::test]
     async fn untagged_case_with_panic_fails() {
-        let mut tcx = register_case("panics", panic_case, false);
+        let mut tcx = register_case("panics", panic_case);
         assert!(!run_case_passed(&mut tcx).await, "untagged case that panics should fail");
     }
 
     #[tokio::test]
     async fn untagged_case_without_panic_passes() {
-        let mut tcx = register_case("ok", ok_case, false);
+        let mut tcx = register_case("ok", ok_case);
         assert!(run_case_passed(&mut tcx).await, "untagged case that returns Ok should pass");
+    }
+
+    #[tokio::test]
+    async fn case_returning_err_fails() {
+        let mut tcx = register_case("err", err_case);
+        let case = run_single_case(&mut tcx).await;
+        assert!(!case.passed, "case returning Err should fail");
+        assert!(matches!(case.run.unwrap().result, crate::report::FnResult::Err(_)));
+    }
+
+    #[tokio::test]
+    async fn ignored_case_is_skipped() {
+        let mut tcx = register_case_with_tags("ignored", panic_case, &[CaseTag::Ignored]);
+        let case = run_single_case(&mut tcx).await;
+        assert!(case.passed, "ignored case is reported as passed");
+        assert!(case.ignored);
+        assert!(case.run.is_none(), "ignored case has no run summary");
+    }
+
+    #[tokio::test]
+    async fn ignored_case_is_skipped_when_concurrent() {
+        let mut tcx = register_case_with_tags("ignored", panic_case, &[CaseTag::Ignored]);
+        let report = run(&mut tcx, true).await;
+        let case = &report.suites[0].fixtures[0].cases[0];
+        assert!(case.passed, "ignored case is reported as passed");
+        assert!(case.ignored);
+    }
+
+    #[tokio::test]
+    async fn default_suite_teardown_is_used() {
+        let mut tcx = TestContext::new();
+        let mut suite = tcx.suite::<PlainSuite>("suite");
+        let mut fixture = suite.fixture::<MockFixture>("fixture");
+        fixture.case("ok", ok_case);
+
+        let report = run(&mut tcx, false).await;
+        let suite_report = &report.suites[0];
+        assert!(suite_report.teardown.as_ref().is_some_and(|s| s.result.is_ok()));
+    }
+
+    #[tokio::test]
+    async fn concurrent_cases_run_and_pass() {
+        let mut tcx = TestContext::new();
+        let mut suite = tcx.suite::<MockSuite>("suite");
+        let mut fixture = suite.fixture::<MockFixture>("fixture");
+        for i in 0..8 {
+            fixture.case(format!("case-{i}"), ok_case);
+        }
+
+        let report = run(&mut tcx, true).await;
+        let fixture_report = &report.suites[0].fixtures[0];
+        assert_eq!(fixture_report.cases.len(), 8);
+        for case in &fixture_report.cases {
+            assert!(case.passed, "concurrent case {} should pass", case.name);
+        }
+    }
+
+    #[tokio::test]
+    async fn suite_setup_failure_skips_fixtures_and_cases() {
+        let mut tcx = TestContext::new();
+        let mut suite = tcx.suite::<FailSetupSuite>("suite");
+        let mut fixture = suite.fixture::<MockFixture>("fixture");
+        fixture.case("never-runs", ok_case);
+
+        let report = run(&mut tcx, false).await;
+        let suite_report = &report.suites[0];
+        assert!(suite_report.setup.as_ref().is_some_and(|s| !s.result.is_ok()));
+        assert!(suite_report.fixtures.is_empty(), "fixtures must not run when suite setup fails");
+    }
+
+    #[tokio::test]
+    async fn suite_teardown_runs_and_teardown_failure_is_recorded() {
+        let mut tcx = TestContext::new();
+        let mut suite = tcx.suite::<MockSuite>("suite");
+        let mut fixture = suite.fixture::<MockFixture>("fixture");
+        fixture.case("ok", ok_case);
+
+        let report = run(&mut tcx, false).await;
+        let suite_report = &report.suites[0];
+        assert!(suite_report.teardown.as_ref().is_some_and(|s| s.result.is_ok()));
+
+        let mut tcx = TestContext::new();
+        let mut suite = tcx.suite::<FailTeardownSuite>("suite");
+        let mut fixture = suite.fixture::<MockFixture>("fixture");
+        fixture.case("ok", ok_case);
+
+        let report = run(&mut tcx, false).await;
+        let suite_report = &report.suites[0];
+        assert!(suite_report.teardown.as_ref().is_some_and(|s| !s.result.is_ok()));
     }
 }

--- a/crates/s3s-test/src/tcx.rs
+++ b/crates/s3s-test/src/tcx.rs
@@ -7,6 +7,7 @@ use crate::traits::TestCase;
 use crate::traits::TestFixture;
 use crate::traits::TestSuite;
 
+use std::any::TypeId;
 use std::any::type_name;
 use std::future::Future;
 use std::marker::PhantomData;
@@ -34,7 +35,8 @@ pub struct TestContext {
 
 pub(crate) struct SuiteInfo {
     pub(crate) name: String,
-    // pub(crate) type_id: TypeId,
+    pub(crate) type_id: TypeId,
+    pub(crate) type_name: &'static str,
     pub(crate) setup: SuiteSetupFn,
     pub(crate) teardown: SuiteTeardownFn,
     pub(crate) fixtures: IndexMap<String, FixtureInfo>,
@@ -42,7 +44,8 @@ pub(crate) struct SuiteInfo {
 
 pub(crate) struct FixtureInfo {
     pub(crate) name: String,
-    // pub(crate) type_id: TypeId,
+    pub(crate) type_id: TypeId,
+    pub(crate) type_name: &'static str,
     pub(crate) setup: FixtureSetupFn,
     pub(crate) teardown: FixtureTeardownFn,
     pub(crate) cases: IndexMap<String, CaseInfo>,
@@ -76,18 +79,27 @@ fn unwrap<T: Send + Sync + 'static>(any: ArcAny) -> Result<T> {
 }
 
 impl TestContext {
-    pub(crate) fn new() -> Self {
+    #[must_use]
+    pub fn new() -> Self {
         Self { suites: IndexMap::new() }
     }
 
     pub fn suite<S: TestSuite>(&mut self, name: impl Into<String>) -> SuiteBuilder<'_, S> {
         let name = name.into();
-        if !self.suites.contains_key(&name) {
+        if let Some(suite) = self.suites.get(&name) {
+            assert!(
+                suite.type_id == TypeId::of::<S>(),
+                "suite `{name}` is already registered with type `{}`, cannot register it again with type `{}`",
+                suite.type_name,
+                type_name::<S>(),
+            );
+        } else {
             self.suites.insert(
                 name.clone(),
                 SuiteInfo {
                     name: name.clone(),
-                    // type_id: TypeId::of::<S>(),
+                    type_id: TypeId::of::<S>(),
+                    type_name: type_name::<S>(),
                     setup: Box::new(|| Box::pin(async { S::setup().await.map(wrap) })),
                     teardown: Box::new(|any| Box::pin(async move { S::teardown(unwrap(any)?).await })),
                     fixtures: IndexMap::new(),
@@ -132,12 +144,20 @@ pub struct SuiteBuilder<'a, S> {
 impl<S: TestSuite> SuiteBuilder<'_, S> {
     pub fn fixture<X: TestFixture<S>>(&mut self, name: impl Into<String>) -> FixtureBuilder<'_, X, S> {
         let name = name.into();
-        if !self.suite.fixtures.contains_key(&name) {
+        if let Some(fixture) = self.suite.fixtures.get(&name) {
+            assert!(
+                fixture.type_id == TypeId::of::<X>(),
+                "fixture `{name}` is already registered with type `{}`, cannot register it again with type `{}`",
+                fixture.type_name,
+                type_name::<X>(),
+            );
+        } else {
             self.suite.fixtures.insert(
                 name.clone(),
                 FixtureInfo {
                     name: name.clone(),
-                    // type_id: TypeId::of::<X>(),
+                    type_id: TypeId::of::<X>(),
+                    type_name: type_name::<X>(),
                     setup: Box::new(|any| Box::pin(async move { X::setup(downcast(any)).await.map(wrap) })),
                     teardown: Box::new(|any| Box::pin(async move { X::teardown(unwrap(any)?).await })),
                     cases: IndexMap::new(),
@@ -187,5 +207,11 @@ impl<C, X, S> CaseBuilder<'_, C, X, S> {
     pub fn tag(&mut self, tag: CaseTag) -> &mut Self {
         self.case.tags.push(tag);
         self
+    }
+}
+
+impl Default for TestContext {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/crates/s3s-test/src/tcx.rs
+++ b/crates/s3s-test/src/tcx.rs
@@ -29,6 +29,12 @@ type FixtureTeardownFn = Box<dyn Fn(ArcAny) -> BoxFuture<'static, Result>>;
 
 type CaseRunFn = Box<dyn Fn(ArcAny) -> BoxFuture<'static, Result>>;
 
+/// The registry of suites, fixtures, and cases.
+///
+/// Create one with [`TestContext::new`], register suites via
+/// [`TestContext::suite`], then either let the [`main!`](crate::main) macro
+/// drive the whole process or drive it yourself with `cli::main` and
+/// `cli::Options`.
 pub struct TestContext {
     pub(crate) suites: IndexMap<String, SuiteInfo>,
 }
@@ -59,7 +65,10 @@ pub(crate) struct CaseInfo {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CaseTag {
+    /// The case is skipped unless `--run-ignored` is passed.
     Ignored,
+    /// The case is expected to panic: it passes when it panics and fails
+    /// when it does not.
     ShouldPanic,
 }
 
@@ -79,11 +88,21 @@ fn unwrap<T: Send + Sync + 'static>(any: ArcAny) -> Result<T> {
 }
 
 impl TestContext {
+    /// Creates an empty test context.
     #[must_use]
     pub fn new() -> Self {
         Self { suites: IndexMap::new() }
     }
 
+    /// Registers a suite and returns its builder.
+    ///
+    /// Calling this again with the same name and the same suite type returns
+    /// the same builder, so multiple modules can register cases into one
+    /// suite.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the name is already registered with a different suite type.
     pub fn suite<S: TestSuite>(&mut self, name: impl Into<String>) -> SuiteBuilder<'_, S> {
         let name = name.into();
         if let Some(suite) = self.suites.get(&name) {
@@ -112,6 +131,8 @@ impl TestContext {
         }
     }
 
+    /// Keeps only suites, fixtures, and cases whose `suite/fixture/case` path
+    /// matches any pattern in the filter set.
     pub fn filter(&mut self, filter_set: &RegexSet) {
         self.suites.retain(|_, suite| {
             suite.fixtures.retain(|_, fixture| {
@@ -125,6 +146,8 @@ impl TestContext {
         });
     }
 
+    /// Removes the [`CaseTag::Ignored`] tag from all cases, so that
+    /// `--run-ignored` runs them.
     pub fn include_ignored(&mut self) {
         for suite in self.suites.values_mut() {
             for fixture in suite.fixtures.values_mut() {
@@ -136,12 +159,22 @@ impl TestContext {
     }
 }
 
+/// The builder returned by [`TestContext::suite`].
 pub struct SuiteBuilder<'a, S> {
     suite: &'a mut SuiteInfo,
     _marker: PhantomData<S>,
 }
 
 impl<S: TestSuite> SuiteBuilder<'_, S> {
+    /// Registers a fixture and returns its builder.
+    ///
+    /// Calling this again with the same name and the same fixture type
+    /// returns the same builder.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the name is already registered with a different fixture
+    /// type.
     pub fn fixture<X: TestFixture<S>>(&mut self, name: impl Into<String>) -> FixtureBuilder<'_, X, S> {
         let name = name.into();
         if let Some(fixture) = self.suite.fixtures.get(&name) {
@@ -171,6 +204,7 @@ impl<S: TestSuite> SuiteBuilder<'_, S> {
     }
 }
 
+/// The builder returned by [`SuiteBuilder::fixture`].
 pub struct FixtureBuilder<'a, X, S> {
     fixture: &'a mut FixtureInfo,
     _marker: PhantomData<(X, S)>,
@@ -181,6 +215,9 @@ where
     X: TestFixture<S>,
     S: TestSuite,
 {
+    /// Registers a case and returns its builder.
+    ///
+    /// Re-registering the same name replaces the previous case.
     pub fn case<C: TestCase<X, S>>(&mut self, name: impl Into<String>, case: C) -> CaseBuilder<'_, C, X, S> {
         let name = name.into();
         self.fixture.cases.insert(
@@ -198,12 +235,14 @@ where
     }
 }
 
+/// The builder returned by [`FixtureBuilder::case`].
 pub struct CaseBuilder<'a, C, X, S> {
     case: &'a mut CaseInfo,
     _marker: PhantomData<(C, X, S)>,
 }
 
 impl<C, X, S> CaseBuilder<'_, C, X, S> {
+    /// Adds a tag to the case.
     pub fn tag(&mut self, tag: CaseTag) -> &mut Self {
         self.case.tags.push(tag);
         self

--- a/crates/s3s-test/src/tcx.rs
+++ b/crates/s3s-test/src/tcx.rs
@@ -254,3 +254,91 @@ impl Default for TestContext {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::*;
+
+    use std::future::Future;
+
+    struct OtherFixture;
+
+    impl TestFixture<MockSuite> for OtherFixture {
+        fn setup(_: Arc<MockSuite>) -> impl Future<Output = Result<Self>> + Send + 'static {
+            std::future::ready(Ok(Self))
+        }
+    }
+
+    async fn ok_case(_: Arc<MockFixture>) -> crate::Result {
+        Ok(())
+    }
+
+    #[test]
+    fn suite_registration_is_idempotent_for_same_type() {
+        let mut tcx = TestContext::new();
+        tcx.suite::<MockSuite>("suite");
+        tcx.suite::<MockSuite>("suite");
+    }
+
+    #[test]
+    fn default_creates_empty_context() {
+        let tcx = TestContext::default();
+        assert!(tcx.suites.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "already registered with type")]
+    fn suite_type_conflict_panics() {
+        let mut tcx = TestContext::new();
+        tcx.suite::<MockSuite>("suite");
+        tcx.suite::<FailSetupSuite>("suite");
+    }
+
+    #[test]
+    #[should_panic(expected = "already registered with type")]
+    fn fixture_type_conflict_panics() {
+        let mut tcx = TestContext::new();
+        let mut suite = tcx.suite::<MockSuite>("suite");
+        suite.fixture::<MockFixture>("fixture");
+        suite.fixture::<OtherFixture>("fixture");
+    }
+
+    #[test]
+    fn filter_keeps_only_matching_cases() {
+        let mut tcx = TestContext::new();
+        let mut suite = tcx.suite::<MockSuite>("suite");
+        let mut fixture = suite.fixture::<MockFixture>("fixture");
+        fixture.case("keep", ok_case);
+        fixture.case("drop", ok_case);
+
+        let filter_set = RegexSet::new(["keep"]).unwrap();
+        tcx.filter(&filter_set);
+
+        let suite_info = &tcx.suites["suite"];
+        let fixture_info = &suite_info.fixtures["fixture"];
+        assert!(fixture_info.cases.contains_key("keep"));
+        assert!(!fixture_info.cases.contains_key("drop"));
+    }
+
+    #[test]
+    fn filter_removes_empty_fixtures_and_suites() {
+        let mut tcx = TestContext::new();
+        let mut suite = tcx.suite::<MockSuite>("suite");
+        let mut fixture = suite.fixture::<MockFixture>("fixture");
+        fixture.case("drop", ok_case);
+
+        let filter_set = RegexSet::new(["no-match"]).unwrap();
+        tcx.filter(&filter_set);
+
+        assert!(tcx.suites.is_empty(), "suite with no matching cases must be removed");
+    }
+
+    #[test]
+    fn include_ignored_removes_ignored_tags() {
+        let mut tcx = register_case_with_tags("ignored", ok_case, &[CaseTag::Ignored]);
+        tcx.include_ignored();
+        let case = &tcx.suites["suite"].fixtures["fixture"].cases["ignored"];
+        assert!(!case.tags.contains(&CaseTag::Ignored));
+    }
+}

--- a/crates/s3s-test/src/test_support.rs
+++ b/crates/s3s-test/src/test_support.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-2026 The s3s Authors
+
+#![cfg(test)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
+
+use crate::error::Failed;
+use crate::error::Result;
+use crate::traits::TestFixture;
+use crate::traits::TestSuite;
+
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+
+/// A mock suite that succeeds and tracks whether setup and teardown ran.
+pub struct MockSuite {
+    pub teardown_called: AtomicBool,
+}
+
+impl TestSuite for MockSuite {
+    fn setup() -> impl Future<Output = Result<Self>> + Send + 'static {
+        std::future::ready(Ok(Self {
+            teardown_called: AtomicBool::new(false),
+        }))
+    }
+
+    fn teardown(self) -> impl Future<Output = Result> + Send + 'static {
+        std::future::ready({
+            self.teardown_called.store(true, Ordering::SeqCst);
+            Ok(())
+        })
+    }
+}
+
+/// A mock suite whose setup fails.
+pub struct FailSetupSuite;
+
+impl TestSuite for FailSetupSuite {
+    fn setup() -> impl Future<Output = Result<Self>> + Send + 'static {
+        std::future::ready(Err(Failed::from_string("setup failed")))
+    }
+}
+
+/// A mock suite whose teardown fails.
+pub struct FailTeardownSuite;
+
+impl TestSuite for FailTeardownSuite {
+    fn setup() -> impl Future<Output = Result<Self>> + Send + 'static {
+        std::future::ready(Ok(Self))
+    }
+
+    fn teardown(self) -> impl Future<Output = Result> + Send + 'static {
+        std::future::ready(Err(Failed::from_string("teardown failed")))
+    }
+}
+
+/// A mock suite that uses the default teardown.
+pub struct PlainSuite;
+
+impl TestSuite for PlainSuite {
+    fn setup() -> impl Future<Output = Result<Self>> + Send + 'static {
+        std::future::ready(Ok(Self))
+    }
+}
+
+/// A mock fixture with no extra state.
+pub struct MockFixture;
+
+impl TestFixture<MockSuite> for MockFixture {
+    fn setup(_: Arc<MockSuite>) -> impl Future<Output = Result<Self>> + Send + 'static {
+        std::future::ready(Ok(Self))
+    }
+}
+
+impl TestFixture<FailSetupSuite> for MockFixture {
+    fn setup(_: Arc<FailSetupSuite>) -> impl Future<Output = Result<Self>> + Send + 'static {
+        std::future::ready(Ok(Self))
+    }
+}
+
+impl TestFixture<FailTeardownSuite> for MockFixture {
+    fn setup(_: Arc<FailTeardownSuite>) -> impl Future<Output = Result<Self>> + Send + 'static {
+        std::future::ready(Ok(Self))
+    }
+}
+
+impl TestFixture<PlainSuite> for MockFixture {
+    fn setup(_: Arc<PlainSuite>) -> impl Future<Output = Result<Self>> + Send + 'static {
+        std::future::ready(Ok(Self))
+    }
+}
+
+/// Registers a single case into a fresh context with the [`MockSuite`].
+pub fn register_case(
+    name: &str,
+    case: impl crate::traits::TestCase<MockFixture, MockSuite> + 'static,
+) -> crate::tcx::TestContext {
+    register_case_with_tags(name, case, &[])
+}
+
+/// Registers a single case with tags into a fresh context with the
+/// [`MockSuite`].
+pub fn register_case_with_tags(
+    name: &str,
+    case: impl crate::traits::TestCase<MockFixture, MockSuite> + 'static,
+    tags: &[crate::tcx::CaseTag],
+) -> crate::tcx::TestContext {
+    let mut tcx = crate::tcx::TestContext::new();
+    let mut suite = tcx.suite::<MockSuite>("suite");
+    let mut fixture = suite.fixture::<MockFixture>("fixture");
+    let mut builder = fixture.case(name, case);
+    for tag in tags {
+        builder.tag(tag.clone());
+    }
+    tcx
+}
+
+/// Runs the context sequentially and returns the report of the single case.
+pub async fn run_single_case(tcx: &mut crate::tcx::TestContext) -> crate::report::CaseReport {
+    let report = crate::runner::run(tcx, false).await;
+    let mut suites = report.suites;
+    let suite = suites.pop().expect("one suite");
+    let mut fixtures = suite.fixtures;
+    let mut fixture = fixtures.pop().expect("one fixture");
+    fixture.cases.pop().expect("one case")
+}

--- a/crates/s3s-test/src/traits.rs
+++ b/crates/s3s-test/src/traits.rs
@@ -6,28 +6,47 @@ use crate::error::Result;
 use std::future::Future;
 use std::sync::Arc;
 
+/// A test suite: one server configuration.
+///
+/// The suite setup builds the server (or connects to an external endpoint)
+/// and returns the shared data consumed by all fixtures and cases.
+/// Teardown runs only when setup succeeds.
 pub trait TestSuite: Sized + Send + Sync + 'static {
+    /// Sets up the suite and returns the shared suite data.
     fn setup() -> impl Future<Output = Result<Self>> + Send + 'static;
 
+    /// Tears down the suite.
     fn teardown(self) -> impl Future<Output = Result> + Send + 'static {
         async { Ok(()) }
     }
 }
 
+/// A fixture: a group of cases that share the same client and precondition.
+///
+/// The fixture setup receives the shared suite data and may retain extra
+/// state beyond the client. Teardown runs only when setup succeeds.
 pub trait TestFixture<S: TestSuite>: Sized + Send + Sync + 'static {
+    /// Sets up the fixture from the shared suite data.
     fn setup(suite: Arc<S>) -> impl Future<Output = Result<Self>> + Send + 'static;
 
+    /// Tears down the fixture.
     fn teardown(self) -> impl Future<Output = Result> + Send + 'static {
         async { Ok(()) }
     }
 }
 
+/// A single test case.
+///
+/// The blanket implementation accepts any `async fn(&self, Arc<X>) -> Result`
+/// method, so cases are usually written as regular async methods on the
+/// fixture type.
 pub trait TestCase<X, S>: Sized + Send + Sync + 'static
 where
     Self: Sized + Send + Sync + 'static,
     X: TestFixture<S>,
     S: TestSuite,
 {
+    /// Runs the case against the fixture data.
     fn run(&self, fixture: Arc<X>) -> impl Future<Output = Result> + Send + 'static;
 }
 

--- a/justfile
+++ b/justfile
@@ -41,7 +41,7 @@ install name *ARGS:
     uv run ./scripts/install.py {{name}} {{ARGS}}
 
 coverage *ARGS:
-    cargo llvm-cov -p s3s --all-features --html {{ARGS}}
+    cargo llvm-cov -p s3s -p s3s-sigv2 -p s3s-sigv4 -p s3s-test --all-features --html {{ARGS}}
 
 # ------------------------------------------------
 


### PR DESCRIPTION
### Problem

`s3s-test` is published on crates.io, but its public API is incomplete for use as a custom test harness: `TestContext` cannot be constructed outside the crate, so the library mode is impossible and the public `runner::run` entry point is unusable; suite and fixture registration do not validate types, so registering the same name with a different type fails at run time with a misleading downcast error; the `ShouldPanic` case tag has no implementation; and the public API lacks documentation and examples.

### Changes

- Publicize `TestContext::new` and implement `Default`, and re-export `TestContext` at the crate root, making the library mode (`new` → register → `cli::main`) a first-class path alongside the `main!` macro.
- Validate suite and fixture registration types: registering a name that already belongs to a different type now fails fast at registration with both type names, instead of panicking with a misleading downcast error at run time.
- Implement the `ShouldPanic` case tag in the runner: a tagged case passes when it panics and fails when it does not; the report keeps the original `FnResult`.
- Add crate-level and item-level rustdoc: the three-level harness concept (suite/fixture/case), server shapes, the concurrency contract, a quick start example, the `--json` report contract, and `# Panics` sections for the new registration checks.
- Add unit tests across all modules (33 tests) via a shared `test_support` module: runner coverage (Err results, ignored cases, sequential and concurrent execution, suite setup/teardown failures, the default teardown), `tcx` (Default, filter, include_ignored, type-conflict panics), the `cli` main flow (JSON report, exit codes, list/filter/run_ignored modes), and error/report helpers. The new tests found and fixed a bug where a `ShouldPanic`-tagged case returning a business `Err` was reported as passed.
- Extend coverage reporting to include `s3s-sigv2`, `s3s-sigv4`, and `s3s-test` in the CI coverage job and the local `just coverage` recipe.

### Tests

- `just dev` passes; `cargo doc -p s3s-test --no-deps` is warning-free.
- `cargo semver-checks` passes (196 checks, no API change required).
- 33 unit tests in `s3s-test`; crate line coverage rises from 56.8% to 92.75%.
- Existing consumers (`s3s-e2e`) are unaffected: workspace tests pass.

Refs #394
