### PR TITLE
fix(s3s-aws): tolerate MinIO uppercase booleans in response XML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3409,6 +3409,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-types-convert",
  "futures",
+ "http-body 1.1.0",
  "hyper",
  "minio",
  "s3s",

--- a/crates/s3s-aws/Cargo.toml
+++ b/crates/s3s-aws/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 workspace = true
 
 [features]
-minio = ["s3s/minio", "dep:minio"]
+minio = ["s3s/minio", "dep:minio", "dep:http-body"]
 
 [dependencies]
 async-trait.workspace = true
@@ -23,6 +23,7 @@ aws-smithy-runtime-api = { workspace = true, features = ["client", "http-1x"] }
 aws-smithy-types = { workspace = true, features = ["http-body-1-x"] }
 aws-smithy-types-convert = { workspace = true, features = ["convert-time"] }
 futures.workspace = true
+http-body = { workspace = true, optional = true }
 hyper.workspace = true
 minio = { workspace = true, optional = true }
 s3s = { version = "0.15.0", path = "../s3s", default-features = false }

--- a/crates/s3s-aws/src/error.rs
+++ b/crates/s3s-aws/src/error.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023-2026 The s3s Authors
 
+use hyper::StatusCode;
+
 macro_rules! wrap_sdk_error {
     ($e:expr) => {{
         use aws_sdk_s3::error::SdkError;
@@ -40,7 +42,17 @@ pub struct SetStatusCode<'a, 'b, E, R>(
 impl<E> SetStatusCode<'_, '_, E, aws_smithy_runtime_api::client::orchestrator::HttpResponse> {
     pub fn call(self) {
         let Self(err, e) = self;
-        err.set_status_code(hyper_status_code_from_aws(e.raw().status()));
+        let status = hyper_status_code_from_aws(e.raw().status());
+        // A successful raw status paired with an error body is a protocol
+        // violation. It can only originate from a failed response
+        // deserialization (e.g. `XmlDecodeError` on a 200 response), which
+        // carries no error code; force 500 in that case instead of echoing
+        // the 2xx status to the client.
+        if status.is_success() {
+            err.set_status_code(StatusCode::INTERNAL_SERVER_ERROR);
+        } else {
+            err.set_status_code(status);
+        }
         // TODO: headers?
     }
 }

--- a/crates/s3s-aws/src/lib.rs
+++ b/crates/s3s-aws/src/lib.rs
@@ -23,3 +23,6 @@ pub use self::connector::{Client, Connector};
 
 mod proxy;
 pub use self::proxy::Proxy;
+
+#[cfg(feature = "minio")]
+pub mod minio_compat;

--- a/crates/s3s-aws/src/minio_compat/mod.rs
+++ b/crates/s3s-aws/src/minio_compat/mod.rs
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-2026 The s3s Authors
+
+//! Compatibility shims for `MinIO`-specific response quirks.
+//!
+//! `MinIO` serializes some XML response bodies with Go's `encoding/xml`, which
+//! renders booleans as uppercase `TRUE`/`FALSE` instead of the lowercase
+//! `true`/`false` expected by the Rust AWS SDK (`aws-smithy-xml` only accepts
+//! the lowercase forms). `GetBucketPolicyStatus` is the known offender:
+//! `PolicyStatus.IsPublic` is emitted as `<IsPublic>FALSE</IsPublic>`, which
+//! makes `aws-sdk-s3` fail deserialization and turns a perfectly fine 200
+//! response into an error at the proxy layer.
+//!
+//! [`MinioBoolCompatInterceptor`] normalizes these elements back to lowercase
+//! before the SDK parses the response body. The scan is cheap and only fires
+//! on an exact element match, so non-MinIO backends (which already emit
+//! lowercase) are unaffected. Other operations are skipped by input type, so
+//! streaming payloads (e.g. `GetObject`) are never touched.
+
+use aws_sdk_s3::operation::get_bucket_policy_status::GetBucketPolicyStatusInput;
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::context::{
+    BeforeDeserializationInterceptorContextMut, BeforeSerializationInterceptorContextRef,
+};
+use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
+use aws_smithy_types::body::SdkBody;
+use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
+use http_body::Body;
+use std::pin::Pin;
+use std::task::{Context, Poll, Waker};
+
+#[cfg(test)]
+mod tests;
+
+/// An `aws-sdk-s3` interceptor that normalizes `MinIO`'s uppercase boolean XML
+/// elements to lowercase before response deserialization.
+///
+/// Mount it on the client configuration, e.g.:
+///
+/// ```ignore
+/// aws_sdk_s3::config::Builder::from(&sdk_conf)
+///     .interceptor(MinioBoolCompatInterceptor::new())
+///     .build()
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MinioBoolCompatInterceptor;
+
+impl MinioBoolCompatInterceptor {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+/// Marks the current operation as `GetBucketPolicyStatus` in the interceptor
+/// state so that the deserialization hook can recognize it (the operation
+/// input is consumed before that point).
+#[derive(Debug, Clone, Copy)]
+struct GetBucketPolicyStatusRequest;
+
+impl Storable for GetBucketPolicyStatusRequest {
+    type Storer = StoreReplace<Self>;
+}
+
+impl Intercept for MinioBoolCompatInterceptor {
+    fn name(&self) -> &'static str {
+        "minio_bool_compat"
+    }
+
+    fn read_before_serialization(
+        &self,
+        context: &BeforeSerializationInterceptorContextRef<'_>,
+        _runtime_components: &RuntimeComponents,
+        cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        if context.input().downcast_ref::<GetBucketPolicyStatusInput>().is_some() {
+            cfg.interceptor_state().store_put(GetBucketPolicyStatusRequest);
+        }
+        Ok(())
+    }
+
+    fn modify_before_deserialization(
+        &self,
+        context: &mut BeforeDeserializationInterceptorContextMut<'_>,
+        _runtime_components: &RuntimeComponents,
+        cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        // Only `GetBucketPolicyStatus` is affected; every other operation
+        // (including streaming payloads) is skipped without touching the
+        // response body.
+        if cfg.load::<GetBucketPolicyStatusRequest>().is_none() {
+            return Ok(());
+        }
+
+        let response = context.response_mut();
+        // Buffered body (e.g. on retry): normalize in place.
+        if let Some(new_body) = normalize_minio_bools(response.body().bytes()) {
+            *response.body_mut() = SdkBody::from(new_body);
+            return Ok(());
+        }
+        // Streaming body: the orchestrator has not collected it yet, and all
+        // interceptor hooks are synchronous. `GetBucketPolicyStatus` responses
+        // are tiny XML documents (a few hundred bytes) that hyper has already
+        // buffered in memory, so polling the stream synchronously with a
+        // no-op waker completes without actually blocking. If the first frame
+        // is not ready, we leave the body untouched and let the SDK handle it
+        // (it would fail deserialization exactly as before this interceptor).
+        let mut old_body = std::mem::replace(response.body_mut(), SdkBody::empty());
+        match collect_body_sync(&mut old_body) {
+            Ok(Some(bytes)) => {
+                let body = normalize_minio_bools(Some(&bytes)).unwrap_or(bytes);
+                *response.body_mut() = SdkBody::from(body);
+            }
+            Ok(None) => {
+                // Not ready; put the (possibly partially consumed) body back.
+                *response.body_mut() = old_body;
+            }
+            Err(err) => return Err(err),
+        }
+        Ok(())
+    }
+}
+
+/// Collects a [`SdkBody`] into memory using synchronous polling.
+/// Returns `Ok(Some(bytes))` when the stream has been fully read, `Ok(None)`
+/// when the first frame was not ready (data not yet received), and `Err` on a
+/// stream error. Only intended for tiny response bodies that are already
+/// buffered by the HTTP client in memory.
+fn collect_body_sync(body: &mut SdkBody) -> Result<Option<Vec<u8>>, BoxError> {
+    let waker = Waker::noop();
+    let mut cx = Context::from_waker(waker);
+    let mut pinned = Pin::new(body);
+    let mut out = Vec::new();
+    loop {
+        match pinned.as_mut().poll_frame(&mut cx) {
+            Poll::Ready(Some(Ok(frame))) => {
+                if let Ok(data) = frame.into_data() {
+                    out.extend_from_slice(&data);
+                }
+            }
+            Poll::Ready(Some(Err(err))) => return Err(err),
+            Poll::Ready(None) => return Ok(Some(out)),
+            Poll::Pending => return Ok(None),
+        }
+    }
+}
+
+/// `<Name>TRUE<` / `<Name>FALSE<` → lowercase pairs for each XML element in
+/// `MINIO_BOOL_ELEMENTS`. The trailing `<` anchors the match to the element
+/// content only (a value like `<IsPublic>TRUEISH<` is left alone).
+///
+/// The element list is derived from the Smithy model's XML-body boolean
+/// members, verified against a live `MinIO` server: currently only `IsPublic`
+/// is affected (`IsTruncated` and friends are hand-written lowercase by
+/// `MinIO`).
+const BOOL_REPLACEMENTS: &[(&[u8], &[u8])] = &[
+    (b"<IsPublic>TRUE<", b"<IsPublic>true<"),
+    (b"<IsPublic>FALSE<", b"<IsPublic>false<"),
+];
+
+/// Replaces `MinIO`'s uppercase boolean element content with lowercase.
+///
+/// Returns `None` when nothing needs to change. A `None` body (streaming
+/// response) is also `None`.
+#[must_use]
+pub fn normalize_minio_bools(body: Option<&[u8]>) -> Option<Vec<u8>> {
+    let body = body?;
+    let mut out = Vec::with_capacity(body.len());
+    let mut rest = body;
+    let mut changed = false;
+    while !rest.is_empty() {
+        // Pick the earliest match among all replacement pairs.
+        let mut best: Option<(usize, &[u8], &[u8])> = None;
+        for (needle, replacement) in BOOL_REPLACEMENTS {
+            if let Some(offset) = find_subslice(rest, needle)
+                && best.is_none_or(|(best_offset, _, _)| offset < best_offset)
+            {
+                best = Some((offset, needle, replacement));
+            }
+        }
+        let Some((offset, needle, replacement)) = best else {
+            out.extend_from_slice(rest);
+            break;
+        };
+        out.extend_from_slice(&rest[..offset]);
+        out.extend_from_slice(replacement);
+        rest = &rest[offset + needle.len()..];
+        changed = true;
+    }
+    changed.then_some(out)
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.len() > haystack.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|window| window == needle)
+}

--- a/crates/s3s-aws/src/minio_compat/tests.rs
+++ b/crates/s3s-aws/src/minio_compat/tests.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-2026 The s3s Authors
+
+use super::normalize_minio_bools;
+
+#[test]
+fn uppercase_true_is_normalized() {
+    let body = b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<PolicyStatus xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><IsPublic>TRUE</IsPublic></PolicyStatus>";
+    let expected = b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<PolicyStatus xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><IsPublic>true</IsPublic></PolicyStatus>";
+    assert_eq!(normalize_minio_bools(Some(body)).as_deref(), Some(&expected[..]));
+}
+
+#[test]
+fn uppercase_false_is_normalized() {
+    let body = b"<PolicyStatus><IsPublic>FALSE</IsPublic></PolicyStatus>";
+    let expected = b"<PolicyStatus><IsPublic>false</IsPublic></PolicyStatus>";
+    assert_eq!(normalize_minio_bools(Some(body)).as_deref(), Some(&expected[..]));
+}
+
+#[test]
+fn lowercase_body_is_untouched() {
+    let body = b"<PolicyStatus><IsPublic>false</IsPublic></PolicyStatus>";
+    assert_eq!(normalize_minio_bools(Some(body)), None);
+}
+
+#[test]
+fn body_without_boolean_elements_is_untouched() {
+    let body = b"<ListBucketResult><Name>bucket</Name></ListBucketResult>";
+    assert_eq!(normalize_minio_bools(Some(body)), None);
+}
+
+#[test]
+fn multiple_occurrences_are_all_normalized() {
+    let body = b"<a><IsPublic>TRUE</IsPublic></a><b><IsPublic>FALSE</IsPublic></b>";
+    let expected = b"<a><IsPublic>true</IsPublic></a><b><IsPublic>false</IsPublic></b>";
+    assert_eq!(normalize_minio_bools(Some(body)).as_deref(), Some(&expected[..]));
+}
+
+#[test]
+fn longer_prefix_values_are_left_alone() {
+    let body = b"<IsPublic>TRUEISH</IsPublic>";
+    assert_eq!(normalize_minio_bools(Some(body)), None);
+}
+
+#[test]
+fn empty_body_is_untouched() {
+    assert_eq!(normalize_minio_bools(Some(b"")), None);
+}
+
+#[test]
+fn streaming_body_is_untouched() {
+    assert_eq!(normalize_minio_bools(None), None);
+}

--- a/crates/s3s-proxy/src/main.rs
+++ b/crates/s3s-proxy/src/main.rs
@@ -61,7 +61,12 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
     // Setup S3 provider
     let sdk_conf = aws_config::from_env().endpoint_url(&opt.endpoint_url).load().await;
-    let client = aws_sdk_s3::Client::from_conf(aws_sdk_s3::config::Builder::from(&sdk_conf).force_path_style(true).build());
+    let client = {
+        let builder = aws_sdk_s3::config::Builder::from(&sdk_conf).force_path_style(true);
+        #[cfg(feature = "minio")]
+        let builder = builder.interceptor(s3s_aws::minio_compat::MinioBoolCompatInterceptor::new());
+        aws_sdk_s3::Client::from_conf(builder.build())
+    };
 
     #[cfg(feature = "minio")]
     let proxy = {


### PR DESCRIPTION
### Problem

The mint E2E job (`e2e (mint, s3s-proxy, minio)`) fails the `aws-sdk-php` group whenever the error-default-message changes are in the merge queue, blocking those merges. The failure is deterministic, not a flake: the failing `GetBucketPolicyStatus` step inside `testBucketPolicy` had actually never worked through the proxy — it was a false pass.

Root cause chain:

1. MinIO serializes the `GetBucketPolicyStatus` response with Go's `encoding/xml`, which renders booleans as uppercase `TRUE`/`FALSE` (AWS emits lowercase `true`/`false`).
2. The Rust AWS SDK (`aws-smithy-xml`) only accepts the lowercase forms, so `aws-sdk-s3` fails deserialization with `XmlDecodeError` on a perfectly valid 200 response.
3. `wrap_sdk_error!` cannot extract an error code from a failed response deserialization (`meta.code()` is `None`), so it keeps `InternalError` and `SetStatusCode` echoes the upstream 2xx status — the client receives an HTTP 200 response carrying an `Error` XML body, a protocol violation.
4. The aws-sdk-php `S3Parser::parse200Error` logic only throws on 200 responses whose error body has both `Code` and `Message`. Before the error-message changes the body had no `<Message>`, so the client silently tolerated the malformed response and mint recorded a pass; the new default `<Message>` made the client throw, turning the false pass into a hard failure.

### Changes

- Add `MinioBoolCompatInterceptor` to a new `s3s_aws::minio_compat` module (enabled by the existing `minio` feature): it normalizes MinIO's uppercase boolean elements (`<IsPublic>TRUE<` / `<IsPublic>FALSE<`) back to lowercase before the SDK parses the response body. The operation is identified by input type in `read_before_serialization` and marked in the interceptor state; only `GetBucketPolicyStatus` responses are ever touched, so streaming payloads and every other operation are unaffected. For non-MinIO backends the scan finds no match and the body is left untouched.
- Mount the interceptor on the `s3s-proxy` client.
- Harden `SetStatusCode` in `wrap_sdk_error!`: a success status paired with an error body is a protocol violation (it can only originate from a failed response deserialization), so it is now forced to 500 instead of echoing the 2xx status to the client.

### Behavior change

- `GetBucketPolicyStatus` through the proxy against MinIO changes from a malformed `200 + Error` response to a genuine `200 + PolicyStatus` document — a bug fix. Against AWS S3 (already lowercase) nothing changes.
- Service errors without a recognizable error code (e.g. response deserialization failures) change from echoing the upstream 2xx status to returning 500 — closing the protocol violation.
- No public API is removed; `minio_compat` is a new additive module.

### Tests

- 8 unit tests for the normalization logic: uppercase `TRUE`/`FALSE` conversion, lowercase/no-match bodies untouched, multiple occurrences, longer-prefix values left alone, streaming bodies skipped.
- Local mint `aws-sdk-php` group: fails on the broken code, passes with this branch (`All tests ran successfully`).
- Full local mint run: 427 pass / 15 fail / 12 na, identical to the passing baseline (the 15 failures are pre-existing chronic ones, unchanged by this PR).
- `just dev` green, codegen idempotent.

Refs #778
