### PR TITLE
feat(data): add UpdateObjectEncryption operation to S3 model

### DIFF
--- a/codegen/src/v1/aws_conv.rs
+++ b/codegen/src/v1/aws_conv.rs
@@ -163,7 +163,8 @@ pub fn codegen(ops: &Operations, rust_types: &RustTypes) {
             rust::Type::StructEnum(ty) => {
                 g!("Ok(match x {{");
                 for variant in &ty.variants {
-                    g!("{aws_path}::{0}(v) => Self::{0}(try_from_aws(v)?),", variant.name);
+                    let aws_variant_name = variant.name.to_upper_camel_case();
+                    g!("{aws_path}::{aws_variant_name}(v) => Self::{0}(try_from_aws(v)?),", variant.name);
                 }
                 g!("_ => unimplemented!(\"unknown variant of {aws_path}: {{x:?}}\"),");
                 g!("}})");
@@ -235,7 +236,8 @@ pub fn codegen(ops: &Operations, rust_types: &RustTypes) {
             rust::Type::StructEnum(ty) => {
                 g!("Ok(match x {{");
                 for variant in &ty.variants {
-                    g!("Self::{0}(v) => {aws_path}::{0}(try_into_aws(v)?),", variant.name);
+                    let aws_variant_name = variant.name.to_upper_camel_case();
+                    g!("Self::{0}(v) => {aws_path}::{aws_variant_name}(try_into_aws(v)?),", variant.name);
                 }
                 g!("_ => unimplemented!(\"unknown variant of {}: {{x:?}}\"),", ty.name);
                 g!("}})");
@@ -265,6 +267,7 @@ fn aws_ty_name(name: &str) -> &str {
         "SSEKMS" => "Ssekms",
         "SSES3" => "Sses3",
         "SelectObjectContentEvent" => "SelectObjectContentEventStream",
+        "SSEKMSEncryption" => "SsekmsEncryption",
         _ => name,
     }
 }

--- a/codegen/src/v1/dto.rs
+++ b/codegen/src/v1/dto.rs
@@ -278,6 +278,7 @@ pub fn collect_rust_types(model: &smithy::Model, ops: &Operations) -> RustTypes 
                         name: variant_name.clone(),
                         type_: to_type_name(&variant.target).to_owned(),
                         doc: variant.traits.doc().map(o),
+                        xml_name: variant.traits.xml_name().map(o),
                     };
                     variants.push(variant);
                 }
@@ -497,14 +498,25 @@ fn unify_operation_types(ops: &Operations, space: &mut RustTypes) {
             if op.smithy_output == op.output {
                 continue;
             }
-            assert_eq!(op.name, "GetBucketNotificationConfiguration");
-            assert_eq!(op.output, "GetBucketNotificationConfigurationOutput");
-            let rust::Type::Struct(ref origin) = space[&op.smithy_output] else { panic!() };
-            let mut ty = origin.clone();
-            ty.name.clone_from(&op.output); // duplicate type
-            assert!(origin.xml_name.is_none());
-            ty.xml_name = Some(origin.name.clone());
-            ty
+            if op.smithy_output.ends_with("Response") {
+                // `{Op}Response` output shape: rename it in place to the `<Op>Output`
+                // convention. The shape is exclusive to the operation (no other
+                // shape references it), so it can be moved out of the space.
+                let Some(rust::Type::Struct(mut ty)) = space.remove(&op.smithy_output) else { panic!() };
+                ty.name.clone_from(&op.output); // rename type
+                ty
+            } else {
+                // Shared payload shape (e.g. `NotificationConfiguration`): duplicate it
+                // under the `<Op>Output` name, keeping the original type for other uses.
+                assert_eq!(op.name, "GetBucketNotificationConfiguration");
+                assert_eq!(op.output, "GetBucketNotificationConfigurationOutput");
+                let rust::Type::Struct(ref origin) = space[&op.smithy_output] else { panic!() };
+                let mut ty = origin.clone();
+                ty.name.clone_from(&op.output); // duplicate type
+                assert!(origin.xml_name.is_none());
+                ty.xml_name = Some(origin.name.clone());
+                ty
+            }
         };
         assert!(space.insert(op.output.clone(), rust::Type::Struct(output_ty)).is_none());
     }

--- a/codegen/src/v1/ops.rs
+++ b/codegen/src/v1/ops.rs
@@ -81,7 +81,13 @@ pub fn collect_operations(model: &smithy::Model) -> Operations {
 
         let output = {
             if smithy_output != "Unit" && smithy_output != "NotificationConfiguration" {
-                assert_eq!(smithy_output.strip_suffix("Output").unwrap(), op_name);
+                // The upstream model mostly names op outputs `<Op>Output`, but a few
+                // use `<Op>Response`; both are normalized to the `<Op>Output` convention.
+                let op_base = smithy_output
+                    .strip_suffix("Output")
+                    .or_else(|| smithy_output.strip_suffix("Response"))
+                    .unwrap();
+                assert_eq!(op_base, op_name);
             }
             f!("{op_name}Output")
         };

--- a/codegen/src/v1/rust.rs
+++ b/codegen/src/v1/rust.rs
@@ -129,6 +129,7 @@ pub struct StructEnumVariant {
     pub name: String,
     pub type_: String,
     pub doc: Option<String>,
+    pub xml_name: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/codegen/src/v1/xml.rs
+++ b/codegen/src/v1/xml.rs
@@ -236,12 +236,20 @@ fn s3_unwrapped_xml_output(ops: &Operations, ty_name: &str) -> bool {
 
 fn codegen_xml_serde(ops: &Operations, rust_types: &RustTypes, root_type_names: &BTreeMap<&str, Option<&str>>) {
     for (rust_type, xml_name) in root_type_names.iter().map(|(&name, xml_name)| (&rust_types[name], xml_name)) {
-        let rust::Type::Struct(ty) = rust_type else { panic!("{rust_type:#?}") };
+        match rust_type {
+            rust::Type::Struct(ty) => codegen_xml_serde_root_struct(ops, rust_types, ty, *xml_name),
+            rust::Type::StructEnum(ty) => codegen_xml_serde_root_struct_enum(rust_types, ty, *xml_name),
+            _ => panic!("{rust_type:#?}"),
+        }
+    }
+}
 
+fn codegen_xml_serde_root_struct(ops: &Operations, rust_types: &RustTypes, ty: &rust::Struct, xml_name: Option<&str>) {
+    {
         // https://github.com/Nugine/s3s/pull/127
         if s3_unwrapped_xml_output(ops, &ty.name) {
             assert_eq!(ty.name, "GetBucketLocationOutput");
-            continue; // manually implemented
+            return; // manually implemented
         }
 
         // https://github.com/Nugine/s3s/issues/2
@@ -280,6 +288,39 @@ fn codegen_xml_serde(ops: &Operations, rust_types: &RustTypes, root_type_names: 
             g!("}}");
             g!();
         }
+    }
+}
+
+fn codegen_xml_serde_root_struct_enum(rust_types: &RustTypes, ty: &rust::StructEnum, xml_name: Option<&str>) {
+    let xml_name = xml_name.unwrap_or(&ty.name);
+
+    if can_impl_serialize(rust_types, &ty.name) {
+        g!("impl Serialize for {} {{", ty.name);
+        g!("fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {{");
+        g!("s.element(\"{xml_name}\", |s| match self {{");
+        for variant in &ty.variants {
+            let xml_name = variant.xml_name.as_deref().unwrap_or(&variant.name);
+            g!("Self::{0}(x) => s.content(\"{xml_name}\", x),", variant.name);
+        }
+        g!("}})");
+        g!("}}");
+        g!("}}");
+        g!();
+    }
+
+    if can_impl_deserialize(rust_types, &ty.name) {
+        g!("impl<'xml> Deserialize<'xml> for {} {{", ty.name);
+        g!("fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {{");
+        g!("d.named_element(\"{xml_name}\", |d| d.element(|d, x| match x {{");
+        for variant in &ty.variants {
+            let xml_name = variant.xml_name.as_deref().unwrap_or(&variant.name);
+            g!("b\"{xml_name}\" => Ok(Self::{0}(d.content()?)),", variant.name);
+        }
+        g!("_ => Err(DeError::UnexpectedTagName)");
+        g!("}}))");
+        g!("}}");
+        g!("}}");
+        g!();
     }
 }
 
@@ -331,7 +372,8 @@ fn codegen_xml_serde_content(
                     g!("match self {{");
 
                     for variant in &ty.variants {
-                        g!("Self::{0}(x) => s.content(\"{0}\", x),", variant.name);
+                        let xml_name = variant.xml_name.as_deref().unwrap_or(&variant.name);
+                        g!("Self::{0}(x) => s.content(\"{xml_name}\", x),", variant.name);
                     }
 
                     g!("}}");
@@ -345,7 +387,8 @@ fn codegen_xml_serde_content(
 
                     g!("d.element(|d, x| match x {{");
                     for variant in &ty.variants {
-                        g!("b\"{0}\" => Ok(Self::{0}(d.content()?)),", variant.name);
+                        let xml_name = variant.xml_name.as_deref().unwrap_or(&variant.name);
+                        g!("b\"{xml_name}\" => Ok(Self::{0}(d.content()?)),", variant.name);
                     }
                     g!("_ => Err(DeError::UnexpectedTagName)");
                     g!("}})");

--- a/crates/s3s-aws/src/conv/generated.rs
+++ b/crates/s3s-aws/src/conv/generated.rs
@@ -136,6 +136,22 @@ impl AwsConversion for s3s::dto::AccessControlTranslation {
     }
 }
 
+impl AwsConversion for s3s::dto::AccessDenied {
+    type Target = aws_sdk_s3::types::error::AccessDenied;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
+    }
+}
+
 impl AwsConversion for s3s::dto::AnalyticsAndOperator {
     type Target = aws_sdk_s3::types::AnalyticsAndOperator;
     type Error = S3Error;
@@ -355,6 +371,23 @@ impl AwsConversion for s3s::dto::ArchiveStatus {
 
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         Ok(aws_sdk_s3::types::ArchiveStatus::from(x.as_str()))
+    }
+}
+
+impl AwsConversion for s3s::dto::BlockedEncryptionTypes {
+    type Target = aws_sdk_s3::types::BlockedEncryptionTypes;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            encryption_type: try_from_aws(x.encryption_type)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_encryption_type(try_into_aws(x.encryption_type)?);
+        Ok(y.build())
     }
 }
 
@@ -2682,6 +2715,23 @@ impl AwsConversion for s3s::dto::EncryptionConfiguration {
         let mut y = Self::Target::builder();
         y = y.set_replica_kms_key_id(try_into_aws(x.replica_kms_key_id)?);
         Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::EncryptionType {
+    type Target = aws_sdk_s3::types::EncryptionType;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(match x {
+            aws_sdk_s3::types::EncryptionType::None => Self::from_static(Self::NONE),
+            aws_sdk_s3::types::EncryptionType::SseC => Self::from_static(Self::SSE_C),
+            _ => Self::from(x.as_str().to_owned()),
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        Ok(aws_sdk_s3::types::EncryptionType::from(x.as_str()))
     }
 }
 
@@ -6675,6 +6725,25 @@ impl AwsConversion for s3s::dto::ObjectCannedACL {
     }
 }
 
+impl AwsConversion for s3s::dto::ObjectEncryption {
+    type Target = aws_sdk_s3::types::ObjectEncryption;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(match x {
+            aws_sdk_s3::types::ObjectEncryption::Ssekms(v) => Self::SSEKMS(try_from_aws(v)?),
+            _ => unimplemented!("unknown variant of aws_sdk_s3::types::ObjectEncryption: {x:?}"),
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        Ok(match x {
+            Self::SSEKMS(v) => aws_sdk_s3::types::ObjectEncryption::Ssekms(try_into_aws(v)?),
+            _ => unimplemented!("unknown variant of ObjectEncryption: {x:?}"),
+        })
+    }
+}
+
 impl AwsConversion for s3s::dto::ObjectIdentifier {
     type Target = aws_sdk_s3::types::ObjectIdentifier;
     type Error = S3Error;
@@ -9392,6 +9461,25 @@ impl AwsConversion for s3s::dto::SSEKMS {
     }
 }
 
+impl AwsConversion for s3s::dto::SSEKMSEncryption {
+    type Target = aws_sdk_s3::types::SsekmsEncryption;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            bucket_key_enabled: try_from_aws(x.bucket_key_enabled)?,
+            kms_key_arn: try_from_aws(x.kms_key_arn)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_bucket_key_enabled(try_into_aws(x.bucket_key_enabled)?);
+        y = y.set_kms_key_arn(Some(try_into_aws(x.kms_key_arn)?));
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
 impl AwsConversion for s3s::dto::SSES3 {
     type Target = aws_sdk_s3::types::Sses3;
     type Error = S3Error;
@@ -9500,6 +9588,8 @@ impl AwsConversion for s3s::dto::ServerSideEncryption {
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(match x {
             aws_sdk_s3::types::ServerSideEncryption::Aes256 => Self::from_static(Self::AES256),
+            aws_sdk_s3::types::ServerSideEncryption::AwsBackup => Self::from_static(Self::AWS_BACKUP),
+            aws_sdk_s3::types::ServerSideEncryption::AwsFsx => Self::from_static(Self::AWS_FSX),
             aws_sdk_s3::types::ServerSideEncryption::AwsKms => Self::from_static(Self::AWS_KMS),
             aws_sdk_s3::types::ServerSideEncryption::AwsKmsDsse => Self::from_static(Self::AWS_KMS_DSSE),
             _ => Self::from(x.as_str().to_owned()),
@@ -9554,6 +9644,7 @@ impl AwsConversion for s3s::dto::ServerSideEncryptionRule {
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(Self {
             apply_server_side_encryption_by_default: try_from_aws(x.apply_server_side_encryption_by_default)?,
+            blocked_encryption_types: try_from_aws(x.blocked_encryption_types)?,
             bucket_key_enabled: try_from_aws(x.bucket_key_enabled)?,
         })
     }
@@ -9561,6 +9652,7 @@ impl AwsConversion for s3s::dto::ServerSideEncryptionRule {
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         let mut y = Self::Target::builder();
         y = y.set_apply_server_side_encryption_by_default(try_into_aws(x.apply_server_side_encryption_by_default)?);
+        y = y.set_blocked_encryption_types(try_into_aws(x.blocked_encryption_types)?);
         y = y.set_bucket_key_enabled(try_into_aws(x.bucket_key_enabled)?);
         Ok(y.build())
     }
@@ -10160,6 +10252,54 @@ impl AwsConversion for s3s::dto::UpdateBucketMetadataJournalTableConfigurationOu
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         let _ = x;
         let y = Self::Target::builder();
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::UpdateObjectEncryptionInput {
+    type Target = aws_sdk_s3::operation::update_object_encryption::UpdateObjectEncryptionInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            checksum_algorithm: try_from_aws(x.checksum_algorithm)?,
+            content_md5: try_from_aws(x.content_md5)?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+            key: unwrap_from_aws(x.key, "key")?,
+            object_encryption: unwrap_from_aws(x.object_encryption, "object_encryption")?,
+            request_payer: try_from_aws(x.request_payer)?,
+            version_id: try_from_aws(x.version_id)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_checksum_algorithm(try_into_aws(x.checksum_algorithm)?);
+        y = y.set_content_md5(try_into_aws(x.content_md5)?);
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y = y.set_key(Some(try_into_aws(x.key)?));
+        y = y.set_object_encryption(Some(try_into_aws(x.object_encryption)?));
+        y = y.set_request_payer(try_into_aws(x.request_payer)?);
+        y = y.set_version_id(try_into_aws(x.version_id)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::UpdateObjectEncryptionOutput {
+    type Target = aws_sdk_s3::operation::update_object_encryption::UpdateObjectEncryptionOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            request_charged: try_from_aws(x.request_charged)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_request_charged(try_into_aws(x.request_charged)?);
         Ok(y.build())
     }
 }

--- a/crates/s3s-aws/src/proxy/generated.rs
+++ b/crates/s3s-aws/src/proxy/generated.rs
@@ -2715,6 +2715,34 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, req))]
+    async fn update_object_encryption(
+        &self,
+        req: S3Request<s3s::dto::UpdateObjectEncryptionInput>,
+    ) -> S3Result<S3Response<s3s::dto::UpdateObjectEncryptionOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.client.update_object_encryption();
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_checksum_algorithm(try_into_aws(input.checksum_algorithm)?);
+        b = b.set_content_md5(try_into_aws(input.content_md5)?);
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        b = b.set_key(Some(try_into_aws(input.key)?));
+        b = b.set_object_encryption(Some(try_into_aws(input.object_encryption)?));
+        b = b.set_request_payer(try_into_aws(input.request_payer)?);
+        b = b.set_version_id(try_into_aws(input.version_id)?);
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
     async fn upload_part(&self, req: S3Request<s3s::dto::UploadPartInput>) -> S3Result<S3Response<s3s::dto::UploadPartOutput>> {
         let input = req.input;
         debug!(?input);

--- a/crates/s3s/src/access/generated.rs
+++ b/crates/s3s/src/access/generated.rs
@@ -857,6 +857,13 @@ pub trait S3Access: Send + Sync + 'static {
         Ok(())
     }
 
+    /// Checks whether the UpdateObjectEncryption request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn update_object_encryption(&self, _req: &mut S3Request<UpdateObjectEncryptionInput>) -> S3Result<()> {
+        Ok(())
+    }
+
     /// Checks whether the UploadPart request has accesses to the resources.
     ///
     /// This method returns `Ok(())` by default.

--- a/crates/s3s/src/dto/generated.rs
+++ b/crates/s3s/src/dto/generated.rs
@@ -251,6 +251,19 @@ impl DtoExt for AccessControlTranslation {
     fn ignore_empty_strings(&mut self) {}
 }
 
+/// <p>
+/// You might receive this error for several reasons. For details, see the description of this API
+/// operation.</p>
+#[derive(Clone, Default, PartialEq)]
+pub struct AccessDenied {}
+
+impl fmt::Debug for AccessDenied {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("AccessDenied");
+        d.finish_non_exhaustive()
+    }
+}
+
 pub type AccessKeyIdType = String;
 
 pub type AccessKeyIdValue = String;
@@ -568,6 +581,12 @@ impl From<DeleteMarkerReplicationStatus> for Cow<'static, str> {
 
 impl From<EncodingType> for Cow<'static, str> {
     fn from(s: EncodingType) -> Self {
+        s.0
+    }
+}
+
+impl From<EncryptionType> for Cow<'static, str> {
+    fn from(s: EncryptionType) -> Self {
         s.0
     }
 }
@@ -1202,6 +1221,54 @@ impl fmt::Debug for AssumedRoleUser {
     }
 }
 impl DtoExt for AssumedRoleUser {
+    fn ignore_empty_strings(&mut self) {}
+}
+
+/// <p>A bucket-level setting for Amazon S3 general purpose buckets used to prevent the upload of new objects encrypted with the specified server-side encryption type. For example, blocking an encryption type will block <code>PutObject</code>, <code>CopyObject</code>, <code>PostObject</code>, multipart upload, and replication requests to the bucket for objects with the specified encryption type. However, you can continue to read and list any pre-existing objects already encrypted with the specified encryption type. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/blocking-unblocking-s3-c-encryption-gpb.html">Blocking or unblocking SSE-C for a general purpose bucket</a>.</p>
+/// <p>This data type is used with the following actions:</p>
+/// <ul>
+/// <li>
+/// <p>
+/// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketEncryption.html">PutBucketEncryption</a>
+/// </p>
+/// </li>
+/// <li>
+/// <p>
+/// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketEncryption.html">GetBucketEncryption</a>
+/// </p>
+/// </li>
+/// <li>
+/// <p>
+/// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketEncryption.html">DeleteBucketEncryption</a>
+/// </p>
+/// </li>
+/// </ul>
+/// <dl>
+/// <dt>Permissions</dt>
+/// <dd>
+/// <p>You must have the <code>s3:PutEncryptionConfiguration</code> permission to block or unblock an encryption type for a bucket. </p>
+/// <p>You must have the <code>s3:GetEncryptionConfiguration</code> permission to view a bucket's encryption type. </p>
+/// </dd>
+/// </dl>
+#[derive(Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct BlockedEncryptionTypes {
+    /// <p>The object encryption type that you want to block or unblock for an Amazon S3 general purpose bucket.</p>
+    /// <note>
+    /// <p>Currently, this parameter only supports blocking or unblocking server side encryption with customer-provided keys (SSE-C). For more information about SSE-C, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html">Using server-side encryption with customer-provided keys (SSE-C)</a>.</p>
+    /// </note>
+    pub encryption_type: Option<EncryptionTypeList>,
+}
+
+impl fmt::Debug for BlockedEncryptionTypes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("BlockedEncryptionTypes");
+        if let Some(ref val) = self.encryption_type {
+            d.field("encryption_type", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+impl DtoExt for BlockedEncryptionTypes {
     fn ignore_empty_strings(&mut self) {}
 }
 
@@ -9121,6 +9188,40 @@ impl DtoExt for EncryptionConfiguration {
         }
     }
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EncryptionType(Cow<'static, str>);
+
+impl EncryptionType {
+    pub const NONE: &'static str = "NONE";
+
+    pub const SSE_C: &'static str = "SSE-C";
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn from_static(s: &'static str) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<String> for EncryptionType {
+    fn from(s: String) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl FromStr for EncryptionType {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s.to_owned()))
+    }
+}
+
+pub type EncryptionTypeList = List<EncryptionType>;
 
 /// <p>
 /// The existing object was created with a different encryption type.
@@ -20407,6 +20508,8 @@ impl fmt::Debug for NoSuchUpload {
     }
 }
 
+pub type NonEmptyKmsKeyArnString = String;
+
 pub type NonNegativeIntegerType = i32;
 
 /// <p>Specifies when noncurrent object versions expire. Upon expiration, Amazon S3 permanently
@@ -20808,6 +20911,22 @@ impl FromStr for ObjectCannedACL {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self::from(s.to_owned()))
     }
+}
+
+/// <p>
+/// The updated server-side encryption type for this object. The <code>UpdateObjectEncryption</code>
+/// operation supports the SSE-S3 and SSE-KMS encryption types.
+/// </p>
+/// <p>Valid Values: <code>SSES3</code> | <code>SSEKMS</code>
+/// </p>
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum ObjectEncryption {
+    /// <p>
+    /// Specifies to update the object encryption type to server-side encryption with Key Management Service (KMS) keys
+    /// (SSE-KMS).
+    /// </p>
+    SSEKMS(SSEKMSEncryption),
 }
 
 /// <p>Object Identifier is unique value to identify objects.</p>
@@ -29485,6 +29604,50 @@ impl DtoExt for SSEKMS {
     fn ignore_empty_strings(&mut self) {}
 }
 
+/// <p>
+/// If <code>SSEKMS</code> is specified for <code>ObjectEncryption</code>, this data type specifies
+/// the Amazon Web Services KMS key Amazon Resource Name (ARN) to use and whether to use an S3 Bucket Key for
+/// server-side encryption using Key Management Service (KMS) keys (SSE-KMS).
+/// </p>
+#[derive(Clone, Default, PartialEq)]
+pub struct SSEKMSEncryption {
+    /// <p>
+    /// Specifies whether Amazon S3 should use an S3 Bucket Key for object encryption with server-side encryption
+    /// using Key Management Service (KMS) keys (SSE-KMS). If this value isn't specified, it defaults to <code>false</code>.
+    /// Setting this value to <code>true</code> causes Amazon S3 to use an S3 Bucket Key for object encryption with
+    /// SSE-KMS. For more information, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html">
+    /// Using Amazon S3 Bucket Keys</a> in the <i>Amazon S3 User Guide</i>.
+    /// </p>
+    /// <p>Valid Values: <code>true</code> | <code>false</code>
+    /// </p>
+    pub bucket_key_enabled: Option<BucketKeyEnabled>,
+    /// <p>
+    /// Specifies the Amazon Web Services KMS key Amazon Resource Name (ARN) to use for the updated server-side encryption
+    /// type. Required if <code>ObjectEncryption</code> specifies <code>SSEKMS</code>.
+    /// </p>
+    /// <note>
+    /// <p>You must specify the full Amazon Web Services KMS key ARN. The KMS key ID and KMS key alias aren't
+    /// supported.</p>
+    /// </note>
+    /// <p>Pattern: (<code>arn:aws[-a-z0-9]*:kms:[-a-z0-9]*:[0-9]{12}:key/.+</code>)</p>
+    pub kms_key_arn: NonEmptyKmsKeyArnString,
+}
+
+impl fmt::Debug for SSEKMSEncryption {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("SSEKMSEncryption");
+        if let Some(ref val) = self.bucket_key_enabled {
+            d.field("bucket_key_enabled", val);
+        }
+        d.field("kms_key_arn", &self.kms_key_arn);
+        d.finish_non_exhaustive()
+    }
+}
+impl DtoExt for SSEKMSEncryption {
+    fn ignore_empty_strings(&mut self) {}
+}
+
 pub type SSEKMSEncryptionContext = String;
 
 pub type SSEKMSKeyId = String;
@@ -29778,6 +29941,10 @@ pub struct ServerSideEncryption(Cow<'static, str>);
 impl ServerSideEncryption {
     pub const AES256: &'static str = "AES256";
 
+    pub const AWS_BACKUP: &'static str = "aws:backup";
+
+    pub const AWS_FSX: &'static str = "aws:fsx";
+
     pub const AWS_KMS: &'static str = "aws:kms";
 
     pub const AWS_KMS_DSSE: &'static str = "aws:kms:dsse";
@@ -29945,11 +30112,11 @@ impl DtoExt for ServerSideEncryptionConfiguration {
 /// <ul>
 /// <li>
 /// <p>
-/// <b>General purpose buckets</b> - If you're specifying
-/// a customer managed KMS key, we recommend using a fully qualified KMS key ARN.
-/// If you use a KMS key alias instead, then KMS resolves the key within the
-/// requester’s account. This behavior can result in data that's encrypted with a
-/// KMS key that belongs to the requester, and not the bucket owner.</p>
+/// <b>General purpose buckets</b> - If you're specifying a customer
+/// managed KMS key, we recommend using a fully qualified KMS key ARN. If you use a KMS key
+/// alias instead, then KMS resolves the key within the requester’s account. This behavior can
+/// result in data that's encrypted with a KMS key that belongs to the requester, and not the bucket
+/// owner.</p>
 /// </li>
 /// <li>
 /// <p>
@@ -29960,20 +30127,23 @@ impl DtoExt for ServerSideEncryptionConfiguration {
 /// </note>
 #[derive(Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ServerSideEncryptionRule {
-    /// <p>Specifies the default server-side encryption to apply to new objects in the bucket. If a
-    /// PUT Object request doesn't specify any server-side encryption, this default encryption will
-    /// be applied.</p>
+    /// <p>Specifies the default server-side encryption to apply to new objects in the bucket. If a PUT Object
+    /// request doesn't specify any server-side encryption, this default encryption will be applied.</p>
     pub apply_server_side_encryption_by_default: Option<ServerSideEncryptionByDefault>,
-    /// <p>Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS
-    /// (SSE-KMS) for new objects in the bucket. Existing objects are not affected. Setting the
-    /// <code>BucketKeyEnabled</code> element to <code>true</code> causes Amazon S3 to use an S3
-    /// Bucket Key. </p>
+    /// <p>A bucket-level setting for Amazon S3 general purpose buckets used to prevent the upload of new objects encrypted with the specified server-side encryption type. For example, blocking an encryption type will block <code>PutObject</code>, <code>CopyObject</code>, <code>PostObject</code>, multipart upload, and replication requests to the bucket for objects with the specified encryption type. However, you can continue to read and list any pre-existing objects already encrypted with the specified encryption type. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/blocking-unblocking-s3-c-encryption-gpb.html">Blocking or unblocking SSE-C for a general purpose bucket</a>.</p>
+    /// <note>
+    /// <p>Currently, this parameter only supports blocking or unblocking server-side encryption with customer-provided keys (SSE-C). For more information about SSE-C, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html">Using server-side encryption with customer-provided keys (SSE-C)</a>.</p>
+    /// </note>
+    pub blocked_encryption_types: Option<BlockedEncryptionTypes>,
+    /// <p>Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS)
+    /// for new objects in the bucket. Existing objects are not affected. Setting the
+    /// <code>BucketKeyEnabled</code> element to <code>true</code> causes Amazon S3 to use an S3 Bucket Key. </p>
     /// <note>
     /// <ul>
     /// <li>
     /// <p>
-    /// <b>General purpose buckets</b> - By default, S3
-    /// Bucket Key is not enabled. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the
+    /// <b>General purpose buckets</b> - By default, S3 Bucket Key is not
+    /// enabled. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the
     /// <i>Amazon S3 User Guide</i>.</p>
     /// </li>
     /// <li>
@@ -29994,6 +30164,9 @@ impl fmt::Debug for ServerSideEncryptionRule {
         if let Some(ref val) = self.apply_server_side_encryption_by_default {
             d.field("apply_server_side_encryption_by_default", val);
         }
+        if let Some(ref val) = self.blocked_encryption_types {
+            d.field("blocked_encryption_types", val);
+        }
         if let Some(ref val) = self.bucket_key_enabled {
             d.field("bucket_key_enabled", val);
         }
@@ -30003,6 +30176,9 @@ impl fmt::Debug for ServerSideEncryptionRule {
 impl DtoExt for ServerSideEncryptionRule {
     fn ignore_empty_strings(&mut self) {
         if let Some(ref mut val) = self.apply_server_side_encryption_by_default {
+            val.ignore_empty_strings();
+        }
+        if let Some(ref mut val) = self.blocked_encryption_types {
             val.ignore_empty_strings();
         }
     }
@@ -31115,6 +31291,140 @@ impl fmt::Debug for UpdateBucketMetadataJournalTableConfigurationOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("UpdateBucketMetadataJournalTableConfigurationOutput");
         d.finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub struct UpdateObjectEncryptionInput {
+    /// <p>
+    /// The name of the general purpose bucket that contains the specified object key name.
+    /// </p>
+    /// <p>When you use this operation with an access point attached to a general purpose bucket, you
+    /// must either provide the alias of the access point in place of the bucket name or you must specify
+    /// the access point Amazon Resource Name (ARN). When using the access point ARN, you must direct
+    /// requests to the access point hostname. The access point hostname takes the form
+    /// <code>
+    /// <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com</code>.
+    /// When using this operation with an access point through the Amazon Web Services SDKs, you provide the access point
+    /// ARN in place of the bucket name. For more information about access point ARNs, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points-naming.html">
+    /// Referencing access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+    pub bucket: BucketName,
+    /// <p>
+    /// Indicates the algorithm used to create the checksum for the object when you use an Amazon Web Services SDK. This header
+    /// doesn't provide any additional functionality if you don't use the SDK. When you send this header,
+    /// there must be a corresponding <code>x-amz-checksum</code> or <code>x-amz-trailer</code> header sent.
+    /// Otherwise, Amazon S3 fails the request with the HTTP status code <code>400 Bad Request</code>. For more
+    /// information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">
+    /// Checking object integrity </a> in the <i>Amazon S3 User Guide</i>.  
+    /// </p>
+    /// <p>If you provide an individual checksum, Amazon S3 ignores any provided <code>ChecksumAlgorithm</code>
+    /// parameter.</p>
+    pub checksum_algorithm: Option<ChecksumAlgorithm>,
+    /// <p>
+    /// The MD5 hash for the request body. For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.
+    /// </p>
+    pub content_md5: Option<ContentMD5>,
+    /// <p>
+    /// The account ID of the expected bucket owner. If the account ID that you provide doesn't match the
+    /// actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code>
+    /// (access denied).
+    /// </p>
+    pub expected_bucket_owner: Option<AccountId>,
+    /// <p>
+    /// The key name of the object that you want to update the server-side encryption type for.
+    /// </p>
+    pub key: ObjectKey,
+    /// <p>
+    /// The updated server-side encryption type for this object. The <code>UpdateObjectEncryption</code>
+    /// operation supports the SSE-S3 and SSE-KMS encryption types.
+    /// </p>
+    /// <p>Valid Values: <code>SSES3</code> | <code>SSEKMS</code>
+    /// </p>
+    pub object_encryption: ObjectEncryption,
+    pub request_payer: Option<RequestPayer>,
+    /// <p>
+    /// The version ID of the object that you want to update the server-side encryption type for.
+    /// </p>
+    pub version_id: Option<ObjectVersionId>,
+}
+
+impl fmt::Debug for UpdateObjectEncryptionInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("UpdateObjectEncryptionInput");
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.checksum_algorithm {
+            d.field("checksum_algorithm", val);
+        }
+        if let Some(ref val) = self.content_md5 {
+            d.field("content_md5", val);
+        }
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.field("key", &self.key);
+        d.field("object_encryption", &self.object_encryption);
+        if let Some(ref val) = self.request_payer {
+            d.field("request_payer", val);
+        }
+        if let Some(ref val) = self.version_id {
+            d.field("version_id", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl UpdateObjectEncryptionInput {
+    #[must_use]
+    pub fn builder() -> builders::UpdateObjectEncryptionInputBuilder {
+        default()
+    }
+}
+impl DtoExt for UpdateObjectEncryptionInput {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref val) = self.checksum_algorithm
+            && val.as_str() == ""
+        {
+            self.checksum_algorithm = None;
+        }
+        if self.content_md5.as_deref() == Some("") {
+            self.content_md5 = None;
+        }
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+        if let Some(ref val) = self.request_payer
+            && val.as_str() == ""
+        {
+            self.request_payer = None;
+        }
+        if self.version_id.as_deref() == Some("") {
+            self.version_id = None;
+        }
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct UpdateObjectEncryptionOutput {
+    pub request_charged: Option<RequestCharged>,
+}
+
+impl fmt::Debug for UpdateObjectEncryptionOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("UpdateObjectEncryptionOutput");
+        if let Some(ref val) = self.request_charged {
+            d.field("request_charged", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+impl DtoExt for UpdateObjectEncryptionOutput {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref val) = self.request_charged
+            && val.as_str() == ""
+        {
+            self.request_charged = None;
+        }
     }
 }
 
@@ -32701,6 +33011,7 @@ mod tests {
         require_default::<UpdateBucketMetadataAnnotationTableConfigurationOutput>();
         require_default::<UpdateBucketMetadataInventoryTableConfigurationOutput>();
         require_default::<UpdateBucketMetadataJournalTableConfigurationOutput>();
+        require_default::<UpdateObjectEncryptionOutput>();
         require_default::<UploadPartOutput>();
         require_default::<UploadPartCopyOutput>();
         require_default::<WriteGetObjectResponseOutput>();
@@ -32911,6 +33222,8 @@ mod tests {
         require_clone::<UpdateBucketMetadataInventoryTableConfigurationOutput>();
         require_clone::<UpdateBucketMetadataJournalTableConfigurationInput>();
         require_clone::<UpdateBucketMetadataJournalTableConfigurationOutput>();
+        require_clone::<UpdateObjectEncryptionInput>();
+        require_clone::<UpdateObjectEncryptionOutput>();
         require_clone::<UploadPartOutput>();
         require_clone::<UploadPartCopyInput>();
         require_clone::<UploadPartCopyOutput>();
@@ -33034,6 +33347,7 @@ mod tests {
         require_default::<UpdateBucketMetadataAnnotationTableConfigurationOutput>();
         require_default::<UpdateBucketMetadataInventoryTableConfigurationOutput>();
         require_default::<UpdateBucketMetadataJournalTableConfigurationOutput>();
+        require_default::<UpdateObjectEncryptionOutput>();
         require_default::<UploadPartOutput>();
         require_default::<UploadPartCopyOutput>();
         require_default::<WriteGetObjectResponseOutput>();
@@ -33245,6 +33559,8 @@ mod tests {
         require_clone::<UpdateBucketMetadataInventoryTableConfigurationOutput>();
         require_clone::<UpdateBucketMetadataJournalTableConfigurationInput>();
         require_clone::<UpdateBucketMetadataJournalTableConfigurationOutput>();
+        require_clone::<UpdateObjectEncryptionInput>();
+        require_clone::<UpdateObjectEncryptionOutput>();
         require_clone::<UploadPartOutput>();
         require_clone::<UploadPartCopyInput>();
         require_clone::<UploadPartCopyOutput>();
@@ -44518,6 +44834,139 @@ pub mod builders {
                 content_md5,
                 expected_bucket_owner,
                 journal_table_configuration,
+            })
+        }
+    }
+
+    /// A builder for [`UpdateObjectEncryptionInput`]
+    #[derive(Default)]
+    pub struct UpdateObjectEncryptionInputBuilder {
+        bucket: Option<BucketName>,
+
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+
+        content_md5: Option<ContentMD5>,
+
+        expected_bucket_owner: Option<AccountId>,
+
+        key: Option<ObjectKey>,
+
+        object_encryption: Option<ObjectEncryption>,
+
+        request_payer: Option<RequestPayer>,
+
+        version_id: Option<ObjectVersionId>,
+    }
+
+    impl UpdateObjectEncryptionInputBuilder {
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_algorithm(&mut self, field: Option<ChecksumAlgorithm>) -> &mut Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        pub fn set_content_md5(&mut self, field: Option<ContentMD5>) -> &mut Self {
+            self.content_md5 = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn set_key(&mut self, field: ObjectKey) -> &mut Self {
+            self.key = Some(field);
+            self
+        }
+
+        pub fn set_object_encryption(&mut self, field: ObjectEncryption) -> &mut Self {
+            self.object_encryption = Some(field);
+            self
+        }
+
+        pub fn set_request_payer(&mut self, field: Option<RequestPayer>) -> &mut Self {
+            self.request_payer = field;
+            self
+        }
+
+        pub fn set_version_id(&mut self, field: Option<ObjectVersionId>) -> &mut Self {
+            self.version_id = field;
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_algorithm(mut self, field: Option<ChecksumAlgorithm>) -> Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        #[must_use]
+        pub fn content_md5(mut self, field: Option<ContentMD5>) -> Self {
+            self.content_md5 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn key(mut self, field: ObjectKey) -> Self {
+            self.key = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn object_encryption(mut self, field: ObjectEncryption) -> Self {
+            self.object_encryption = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn request_payer(mut self, field: Option<RequestPayer>) -> Self {
+            self.request_payer = field;
+            self
+        }
+
+        #[must_use]
+        pub fn version_id(mut self, field: Option<ObjectVersionId>) -> Self {
+            self.version_id = field;
+            self
+        }
+
+        pub fn build(self) -> Result<UpdateObjectEncryptionInput, BuildError> {
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_algorithm = self.checksum_algorithm;
+            let content_md5 = self.content_md5;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            let key = self.key.ok_or_else(|| BuildError::missing_field("key"))?;
+            let object_encryption = self
+                .object_encryption
+                .ok_or_else(|| BuildError::missing_field("object_encryption"))?;
+            let request_payer = self.request_payer;
+            let version_id = self.version_id;
+            Ok(UpdateObjectEncryptionInput {
+                bucket,
+                checksum_algorithm,
+                content_md5,
+                expected_bucket_owner,
+                key,
+                object_encryption,
+                request_payer,
+                version_id,
             })
         }
     }
@@ -57288,6 +57737,139 @@ pub mod builders {
                 content_md5,
                 expected_bucket_owner,
                 journal_table_configuration,
+            })
+        }
+    }
+
+    /// A builder for [`UpdateObjectEncryptionInput`]
+    #[derive(Default)]
+    pub struct UpdateObjectEncryptionInputBuilder {
+        bucket: Option<BucketName>,
+
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+
+        content_md5: Option<ContentMD5>,
+
+        expected_bucket_owner: Option<AccountId>,
+
+        key: Option<ObjectKey>,
+
+        object_encryption: Option<ObjectEncryption>,
+
+        request_payer: Option<RequestPayer>,
+
+        version_id: Option<ObjectVersionId>,
+    }
+
+    impl UpdateObjectEncryptionInputBuilder {
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_algorithm(&mut self, field: Option<ChecksumAlgorithm>) -> &mut Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        pub fn set_content_md5(&mut self, field: Option<ContentMD5>) -> &mut Self {
+            self.content_md5 = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn set_key(&mut self, field: ObjectKey) -> &mut Self {
+            self.key = Some(field);
+            self
+        }
+
+        pub fn set_object_encryption(&mut self, field: ObjectEncryption) -> &mut Self {
+            self.object_encryption = Some(field);
+            self
+        }
+
+        pub fn set_request_payer(&mut self, field: Option<RequestPayer>) -> &mut Self {
+            self.request_payer = field;
+            self
+        }
+
+        pub fn set_version_id(&mut self, field: Option<ObjectVersionId>) -> &mut Self {
+            self.version_id = field;
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_algorithm(mut self, field: Option<ChecksumAlgorithm>) -> Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        #[must_use]
+        pub fn content_md5(mut self, field: Option<ContentMD5>) -> Self {
+            self.content_md5 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn key(mut self, field: ObjectKey) -> Self {
+            self.key = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn object_encryption(mut self, field: ObjectEncryption) -> Self {
+            self.object_encryption = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn request_payer(mut self, field: Option<RequestPayer>) -> Self {
+            self.request_payer = field;
+            self
+        }
+
+        #[must_use]
+        pub fn version_id(mut self, field: Option<ObjectVersionId>) -> Self {
+            self.version_id = field;
+            self
+        }
+
+        pub fn build(self) -> Result<UpdateObjectEncryptionInput, BuildError> {
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_algorithm = self.checksum_algorithm;
+            let content_md5 = self.content_md5;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            let key = self.key.ok_or_else(|| BuildError::missing_field("key"))?;
+            let object_encryption = self
+                .object_encryption
+                .ok_or_else(|| BuildError::missing_field("object_encryption"))?;
+            let request_payer = self.request_payer;
+            let version_id = self.version_id;
+            Ok(UpdateObjectEncryptionInput {
+                bucket,
+                checksum_algorithm,
+                content_md5,
+                expected_bucket_owner,
+                key,
+                object_encryption,
+                request_payer,
+                version_id,
             })
         }
     }

--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -108,6 +108,7 @@
 // UpdateBucketMetadataAnnotationTableConfiguration
 // UpdateBucketMetadataInventoryTableConfiguration
 // UpdateBucketMetadataJournalTableConfiguration
+// UpdateObjectEncryption
 // UploadPart
 // UploadPartCopy
 // WriteGetObjectResponse
@@ -8868,6 +8869,80 @@ impl super::Operation for UpdateBucketMetadataJournalTableConfiguration {
     }
 }
 
+pub struct UpdateObjectEncryption;
+
+impl UpdateObjectEncryption {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<UpdateObjectEncryptionInput> {
+        let (bucket, key) = http::unwrap_object(req);
+
+        let checksum_algorithm: Option<ChecksumAlgorithm> = http::parse_checksum_algorithm_header(req)?;
+
+        let content_md5: Option<ContentMD5> = http::parse_opt_header(req, &CONTENT_MD5)?;
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        let object_encryption: ObjectEncryption = http::take_xml_body(req)?;
+
+        let request_payer: Option<RequestPayer> = http::parse_opt_header(req, &X_AMZ_REQUEST_PAYER)?;
+
+        let version_id: Option<ObjectVersionId> = http::parse_opt_query(req, "versionId")?;
+
+        Ok(UpdateObjectEncryptionInput {
+            bucket,
+            checksum_algorithm,
+            content_md5,
+            expected_bucket_owner,
+            key,
+            object_encryption,
+            request_payer,
+            version_id,
+        })
+    }
+
+    pub fn serialize_http(x: UpdateObjectEncryptionOutput) -> S3Result<http::Response> {
+        let mut res = http::Response::with_status(http::StatusCode::OK);
+        http::add_opt_header(&mut res, X_AMZ_REQUEST_CHARGED, x.request_charged)?;
+        Ok(res)
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for UpdateObjectEncryption {
+    fn name(&self) -> &'static str {
+        "UpdateObjectEncryption"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        true
+    }
+
+    fn has_request_payload(&self) -> bool {
+        true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.update_object_encryption(&mut s3_req).await?;
+        }
+        let result = s3.update_object_encryption(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
 pub struct UploadPart;
 
 impl UploadPart {
@@ -9763,6 +9838,9 @@ pub fn resolve_route(
                     if qs.has("tagging") {
                         return Ok(&PutObjectTagging as &'static dyn super::Operation);
                     }
+                    if qs.has("encryption") {
+                        return Ok(&UpdateObjectEncryption as &'static dyn super::Operation);
+                    }
                 }
                 if let Some(qs) = qs
                     && qs.has("partNumber")
@@ -10144,6 +10222,9 @@ pub fn resolve_route(
                     }
                     if qs.has("tagging") {
                         return Ok(&PutObjectTagging as &'static dyn super::Operation);
+                    }
+                    if qs.has("encryption") {
+                        return Ok(&UpdateObjectEncryption as &'static dyn super::Operation);
                     }
                 }
                 if let Some(qs) = qs

--- a/crates/s3s/src/ops/route_fixtures.json
+++ b/crates/s3s/src/ops/route_fixtures.json
@@ -3679,5 +3679,37 @@
     "zz"
    ]
   ]
+ },
+ {
+  "expect": "UpdateObjectEncryption",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "if:qs.has(\"encryption\")",
+  "path": "Object",
+  "qs": [
+   [
+    "encryption",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "UpdateObjectEncryption",
+  "headers": {},
+  "method": "PUT",
+  "nfb": true,
+  "note": "noise:qs.has(\"encryption\")",
+  "path": "Object",
+  "qs": [
+   [
+    "encryption",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
  }
 ]

--- a/crates/s3s/src/s3_trait.rs
+++ b/crates/s3s/src/s3_trait.rs
@@ -7314,6 +7314,170 @@ pub trait S3: Send + Sync + 'static {
         ))
     }
 
+    /// <note>
+    /// <p>This operation is not supported for directory buckets or Amazon S3 on Outposts buckets.
+    /// </p>
+    /// </note>
+    /// <p>
+    /// Updates the server-side encryption type of an existing encrypted object in a general purpose bucket.
+    /// You can use the <code>UpdateObjectEncryption</code> operation to change encrypted objects from
+    /// server-side encryption with Amazon S3 managed keys (SSE-S3) to server-side encryption with Key Management Service (KMS)
+    /// keys (SSE-KMS), or to apply S3 Bucket Keys. You can also use the <code>UpdateObjectEncryption</code> operation
+    /// to change the customer-managed KMS key used to encrypt your data so that you can comply with custom
+    /// key-rotation standards.
+    /// </p>
+    /// <p>Using the <code>UpdateObjectEncryption</code> operation, you can atomically update the server-side
+    /// encryption type of an existing object in a general purpose bucket without any data movement. The
+    /// <code>UpdateObjectEncryption</code> operation uses envelope encryption to re-encrypt the data key used to
+    /// encrypt and decrypt your object with your newly specified server-side encryption type. In other words,
+    /// when you use the <code>UpdateObjectEncryption</code> operation, your data isn't copied, archived
+    /// objects in the S3 Glacier Flexible Retrieval and S3 Glacier Deep Archive storage classes aren't
+    /// restored, and objects in the S3 Intelligent-Tiering storage class aren't moved between tiers.
+    /// Additionally, the <code>UpdateObjectEncryption</code> operation preserves all object metadata
+    /// properties, including the storage class, creation date, last modified date, ETag, and checksum
+    /// properties. For more information, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/update-sse-encryption.html">
+    /// Updating server-side encryption for existing objects</a> in the
+    /// <i>Amazon S3 User Guide</i>.</p>
+    /// <p>By default, all <code>UpdateObjectEncryption</code> requests that specify a  customer-managed
+    /// KMS key are restricted to KMS keys that are owned by the  bucket owner's Amazon Web Services account. If you're
+    /// using Organizations, you can request the ability to use KMS keys owned by other member
+    /// accounts  within your organization by contacting Amazon Web Services Support.</p>
+    /// <note>
+    /// <p>Source objects that are unencrypted, or encrypted with either dual-layer server-side encryption
+    /// with KMS keys (DSSE-KMS) or server-side encryption with customer-provided keys (SSE-C) aren't
+    /// supported by this operation. Additionally, you cannot specify SSE-S3 encryption as the requested
+    /// new encryption type <code>UpdateObjectEncryption</code> request.</p>
+    /// </note>
+    /// <dl>
+    /// <dt>Permissions</dt>
+    /// <dd>
+    /// <ul>
+    /// <li>
+    /// <p>To use the <code>UpdateObjectEncryption</code> operation, you must have the following
+    /// permissions:</p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <code>s3:UpdateObjectEncryption</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>kms:Encrypt</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>kms:Decrypt</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>kms:GenerateDataKey</code>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <code>kms:ReEncrypt*</code>
+    /// </p>
+    /// </li>
+    /// </ul>
+    /// </li>
+    /// <li>
+    /// <p>If you're using Organizations, to use this operation with customer-managed
+    /// KMS keys from other Amazon Web Services accounts within your organization, you must have the
+    /// <code>organizations:DescribeAccount</code> permission.</p>
+    /// </li>
+    /// </ul>
+    /// </dd>
+    /// </dl>
+    /// <dl>
+    /// <dt>Errors</dt>
+    /// <dd>
+    /// <ul>
+    /// <li>
+    /// <p>You might receive an <code>InvalidRequest</code> error for several reasons. Depending
+    /// on the reason for the error, you might receive one of the following messages:</p>
+    /// <ul>
+    /// <li>
+    /// <p>The <code>UpdateObjectEncryption</code> operation doesn't supported unencrypted
+    /// source objects. Only source objects encrypted with SSE-S3 or SSE-KMS are supported.</p>
+    /// </li>
+    /// <li>
+    /// <p>The <code>UpdateObjectEncryption</code> operation doesn't support source objects
+    /// with the encryption type DSSE-KMS or SSE-C. Only source objects encrypted with SSE-S3
+    /// or SSE-KMS are supported.</p>
+    /// </li>
+    /// <li>
+    /// <p>The <code>UpdateObjectEncryption</code> operation doesn't support updating the
+    /// encryption type to DSSE-KMS or SSE-C. Modify the request to specify SSE-KMS
+    /// for the updated encryption type, and then try again.</p>
+    /// </li>
+    /// <li>
+    /// <p>Requests that modify an object encryption configuration require Amazon Web Services Signature
+    /// Version 4. Modify the request to use Amazon Web Services Signature Version 4, and then try again.</p>
+    /// </li>
+    /// <li>
+    /// <p>Requests that modify an object encryption configuration require a valid new
+    /// encryption type. Valid values are <code>SSEKMS</code>. Modify the request to specify
+    /// SSE-KMS for the updated encryption type, and then try again.</p>
+    /// </li>
+    /// <li>
+    /// <p>Requests that modify an object's encryption type to SSE-KMS require an Amazon Web Services KMS key
+    /// Amazon Resource Name (ARN). Modify the request to specify a KMS key ARN, and then
+    /// try again.</p>
+    /// </li>
+    /// <li>
+    /// <p>Requests that modify an object's encryption type to SSE-KMS require a valid
+    /// Amazon Web Services KMS key Amazon Resource Name (ARN). Confirm that you have a correctly formatted
+    /// KMS key ARN in your request, and then try again.</p>
+    /// </li>
+    /// <li>
+    /// <p>The <code>BucketKeyEnabled</code> value isn't valid. Valid values are
+    /// <code>true</code> or <code>false</code>. Modify the request to specify a valid value,
+    /// and then try again.</p>
+    /// </li>
+    /// </ul>
+    /// </li>
+    /// <li>
+    /// <p>You might receive an <code>AccessDenied</code> error for several reasons. Depending on
+    /// the reason for the error, you might receive one of the following messages:</p>
+    /// <ul>
+    /// <li>
+    /// <p>The Amazon Web Services KMS key in the request must be owned by the same account as the bucket. Modify
+    /// the request to specify a KMS key from the same account, and then try again.</p>
+    /// </li>
+    /// <li>
+    /// <p>The bucket owner's account was approved to make <code>UpdateObjectEncryption</code> requests
+    /// that use any Amazon Web Services KMS key in their organization, but the bucket owner's account isn't part of
+    /// an organization in Organizations. Make sure that the bucket owner's account and the
+    /// specified KMS key belong to the same organization, and then try again. </p>
+    /// </li>
+    /// <li>
+    /// <p>The specified Amazon Web Services KMS key must be from the same organization in Organizations as
+    /// the bucket. Specify a KMS key that belongs to the same organization as the bucket, and then
+    /// try again. </p>
+    /// </li>
+    /// <li>
+    /// <p>The encryption type for the specified object can’t be updated because that object is
+    /// protected by S3 Object Lock. If the object has a governance-mode retention period or a legal
+    /// hold, you must first remove the Object Lock status on the object before you issue your
+    /// <code>UpdateObjectEncryption</code> request. You can't use the <code>UpdateObjectEncryption</code>
+    /// operation with objects that have an Object Lock compliance mode retention period applied to them.</p>
+    /// </li>
+    /// </ul>
+    /// </li>
+    /// </ul>
+    /// </dd>
+    /// </dl>
+    async fn update_object_encryption(
+        &self,
+        _req: S3Request<UpdateObjectEncryptionInput>,
+    ) -> S3Result<S3Response<UpdateObjectEncryptionOutput>> {
+        Err(s3_error!(NotImplemented, "UpdateObjectEncryption is not implemented yet"))
+    }
+
     /// <p>Uploads a part in a multipart upload.</p>
     /// <note>
     /// <p>In this operation, you provide new data as a part of an object in your request.

--- a/crates/s3s/src/xml/generated.rs
+++ b/crates/s3s/src/xml/generated.rs
@@ -101,6 +101,8 @@ use std::io::Write;
 // Deserialize: MetricsConfiguration
 //   Serialize: NotificationConfiguration
 // Deserialize: NotificationConfiguration
+//   Serialize: ObjectEncryption
+// Deserialize: ObjectEncryption
 //   Serialize: ObjectLockConfiguration
 // Deserialize: ObjectLockConfiguration
 //   Serialize: ObjectLockLegalHold "LegalHold"
@@ -192,6 +194,8 @@ use std::io::Write;
 // DeserializeContent: AssumedRoleIdType
 //   SerializeContent: AssumedRoleUser
 // DeserializeContent: AssumedRoleUser
+//   SerializeContent: BlockedEncryptionTypes
+// DeserializeContent: BlockedEncryptionTypes
 //   SerializeContent: Bucket
 // DeserializeContent: Bucket
 //   SerializeContent: BucketAbacStatus
@@ -336,6 +340,8 @@ use std::io::Write;
 // DeserializeContent: Encryption
 //   SerializeContent: EncryptionConfiguration
 // DeserializeContent: EncryptionConfiguration
+//   SerializeContent: EncryptionType
+// DeserializeContent: EncryptionType
 //   SerializeContent: End
 // DeserializeContent: End
 //   SerializeContent: Error
@@ -613,6 +619,8 @@ use std::io::Write;
 // DeserializeContent: NextUploadIdMarker
 //   SerializeContent: NextVersionIdMarker
 // DeserializeContent: NextVersionIdMarker
+//   SerializeContent: NonEmptyKmsKeyArnString
+// DeserializeContent: NonEmptyKmsKeyArnString
 //   SerializeContent: NonNegativeIntegerType
 // DeserializeContent: NonNegativeIntegerType
 //   SerializeContent: NoncurrentVersionExpiration
@@ -629,6 +637,8 @@ use std::io::Write;
 // DeserializeContent: Object
 //   SerializeContent: ObjectCannedACL
 // DeserializeContent: ObjectCannedACL
+//   SerializeContent: ObjectEncryption
+// DeserializeContent: ObjectEncryption
 //   SerializeContent: ObjectIdentifier
 // DeserializeContent: ObjectIdentifier
 //   SerializeContent: ObjectKey
@@ -791,6 +801,8 @@ use std::io::Write;
 // DeserializeContent: S3TablesNamespace
 //   SerializeContent: SSEKMS
 // DeserializeContent: SSEKMS
+//   SerializeContent: SSEKMSEncryption
+// DeserializeContent: SSEKMSEncryption
 //   SerializeContent: SSEKMSKeyId
 // DeserializeContent: SSEKMSKeyId
 //   SerializeContent: SSES3
@@ -3669,6 +3681,40 @@ impl<'xml> DeserializeContent<'xml> for NotificationConfiguration {
     }
 }
 
+impl Serialize for ObjectEncryption {
+    fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.element("ObjectEncryption", |s| match self {
+            Self::SSEKMS(x) => s.content("SSE-KMS", x),
+        })
+    }
+}
+
+impl<'xml> Deserialize<'xml> for ObjectEncryption {
+    fn deserialize(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.named_element("ObjectEncryption", |d| {
+            d.element(|d, x| match x {
+                b"SSE-KMS" => Ok(Self::SSEKMS(d.content()?)),
+                _ => Err(DeError::UnexpectedTagName),
+            })
+        })
+    }
+}
+impl SerializeContent for ObjectEncryption {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        match self {
+            Self::SSEKMS(x) => s.content("SSE-KMS", x),
+        }
+    }
+}
+impl<'xml> DeserializeContent<'xml> for ObjectEncryption {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.element(|d, x| match x {
+            b"SSE-KMS" => Ok(Self::SSEKMS(d.content()?)),
+            _ => Err(DeError::UnexpectedTagName),
+        })
+    }
+}
+
 impl Serialize for ObjectLockConfiguration {
     fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         s.content("ObjectLockConfiguration", self)
@@ -5128,6 +5174,30 @@ impl<'xml> DeserializeContent<'xml> for AssumedRoleUser {
             arn: arn.ok_or(DeError::MissingField)?,
             assumed_role_id: assumed_role_id.ok_or(DeError::MissingField)?,
         })
+    }
+}
+
+impl SerializeContent for BlockedEncryptionTypes {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(iter) = &self.encryption_type {
+            s.flattened_list("EncryptionType", iter)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for BlockedEncryptionTypes {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut encryption_type: Option<EncryptionTypeList> = None;
+        d.for_each_element(|d, x| match x {
+            b"EncryptionType" => {
+                let ans: EncryptionType = d.content()?;
+                encryption_type.get_or_insert_with(List::new).push(ans);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self { encryption_type })
     }
 }
 
@@ -6642,6 +6712,21 @@ impl<'xml> DeserializeContent<'xml> for EncryptionConfiguration {
             _ => Err(DeError::UnexpectedTagName),
         })?;
         Ok(Self { replica_kms_key_id })
+    }
+}
+
+impl SerializeContent for EncryptionType {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        self.as_str().serialize_content(s)
+    }
+}
+impl<'xml> DeserializeContent<'xml> for EncryptionType {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.text(|s| match s {
+            "NONE" => Ok(Self::from_static(EncryptionType::NONE)),
+            "SSE-C" => Ok(Self::from_static(EncryptionType::SSE_C)),
+            _ => Ok(Self::from(s.to_owned())),
+        })
     }
 }
 
@@ -11491,6 +11576,44 @@ impl<'xml> DeserializeContent<'xml> for SSEKMS {
     }
 }
 
+impl SerializeContent for SSEKMSEncryption {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.bucket_key_enabled {
+            s.content("BucketKeyEnabled", val)?;
+        }
+        s.content("KMSKeyArn", &self.kms_key_arn)?;
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for SSEKMSEncryption {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut bucket_key_enabled: Option<BucketKeyEnabled> = None;
+        let mut kms_key_arn: Option<NonEmptyKmsKeyArnString> = None;
+        d.for_each_element(|d, x| match x {
+            b"BucketKeyEnabled" => {
+                if bucket_key_enabled.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                bucket_key_enabled = Some(d.content()?);
+                Ok(())
+            }
+            b"KMSKeyArn" => {
+                if kms_key_arn.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                kms_key_arn = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            bucket_key_enabled,
+            kms_key_arn: kms_key_arn.ok_or(DeError::MissingField)?,
+        })
+    }
+}
+
 impl SerializeContent for SSES3 {
     fn serialize_content<W: Write>(&self, _: &mut Serializer<W>) -> SerResult {
         Ok(())
@@ -11605,6 +11728,8 @@ impl<'xml> DeserializeContent<'xml> for ServerSideEncryption {
     fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
         d.text(|s| match s {
             "AES256" => Ok(Self::from_static(ServerSideEncryption::AES256)),
+            "aws:backup" => Ok(Self::from_static(ServerSideEncryption::AWS_BACKUP)),
+            "aws:fsx" => Ok(Self::from_static(ServerSideEncryption::AWS_FSX)),
             "aws:kms" => Ok(Self::from_static(ServerSideEncryption::AWS_KMS)),
             "aws:kms:dsse" => Ok(Self::from_static(ServerSideEncryption::AWS_KMS_DSSE)),
             _ => Ok(Self::from(s.to_owned())),
@@ -11655,6 +11780,9 @@ impl SerializeContent for ServerSideEncryptionRule {
         if let Some(ref val) = self.apply_server_side_encryption_by_default {
             s.content("ApplyServerSideEncryptionByDefault", val)?;
         }
+        if let Some(ref val) = self.blocked_encryption_types {
+            s.content("BlockedEncryptionTypes", val)?;
+        }
         if let Some(ref val) = self.bucket_key_enabled {
             s.content("BucketKeyEnabled", val)?;
         }
@@ -11665,6 +11793,7 @@ impl SerializeContent for ServerSideEncryptionRule {
 impl<'xml> DeserializeContent<'xml> for ServerSideEncryptionRule {
     fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
         let mut apply_server_side_encryption_by_default: Option<ServerSideEncryptionByDefault> = None;
+        let mut blocked_encryption_types: Option<BlockedEncryptionTypes> = None;
         let mut bucket_key_enabled: Option<BucketKeyEnabled> = None;
         d.for_each_element(|d, x| match x {
             b"ApplyServerSideEncryptionByDefault" => {
@@ -11672,6 +11801,13 @@ impl<'xml> DeserializeContent<'xml> for ServerSideEncryptionRule {
                     return Err(DeError::DuplicateField);
                 }
                 apply_server_side_encryption_by_default = Some(d.content()?);
+                Ok(())
+            }
+            b"BlockedEncryptionTypes" => {
+                if blocked_encryption_types.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                blocked_encryption_types = Some(d.content()?);
                 Ok(())
             }
             b"BucketKeyEnabled" => {
@@ -11685,6 +11821,7 @@ impl<'xml> DeserializeContent<'xml> for ServerSideEncryptionRule {
         })?;
         Ok(Self {
             apply_server_side_encryption_by_default,
+            blocked_encryption_types,
             bucket_key_enabled,
         })
     }

--- a/crates/s3s/tests/xml.rs
+++ b/crates/s3s/tests/xml.rs
@@ -885,3 +885,55 @@ fn deserialize_structural_errors() {
     let r = deserialize::<s3s::dto::BucketLoggingStatus>(xml.as_bytes());
     assert!(r.is_err());
 }
+
+/// The `ObjectEncryption` union payload must be wrapped in a root element named
+/// after the payload member (`<ObjectEncryption>`), matching the official AWS
+/// wire form (empirically confirmed with aws-sdk-s3 1.144.0):
+/// `<ObjectEncryption><SSE-KMS>...</SSE-KMS></ObjectEncryption>`.
+#[test]
+fn update_object_encryption_union_root() {
+    use s3s::dto::ObjectEncryption;
+
+    // Official wire form (with the S3 namespace; matched by local name).
+    let xml = r#"
+    <ObjectEncryption xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <SSE-KMS>
+            <KMSKeyArn>arn:aws:kms:us-east-1:111122223333:key/abc123</KMSKeyArn>
+            <BucketKeyEnabled>true</BucketKeyEnabled>
+        </SSE-KMS>
+    </ObjectEncryption>
+    "#;
+
+    let val = deserialize::<ObjectEncryption>(xml.as_bytes()).unwrap();
+    match &val {
+        ObjectEncryption::SSEKMS(ssekms) => {
+            assert_eq!(ssekms.kms_key_arn, "arn:aws:kms:us-east-1:111122223333:key/abc123");
+            assert_eq!(ssekms.bucket_key_enabled, Some(true));
+        }
+        _ => unreachable!(),
+    }
+
+    // Serialization must produce the wrapped root element.
+    let ans = serialize(&val).unwrap();
+    assert_eq!(
+        ans,
+        "<ObjectEncryption><SSE-KMS><BucketKeyEnabled>true</BucketKeyEnabled>\
+         <KMSKeyArn>arn:aws:kms:us-east-1:111122223333:key/abc123</KMSKeyArn></SSE-KMS></ObjectEncryption>"
+    );
+
+    test_serde(&val);
+
+    // The unwrapped form is not accepted for the root: the wire form requires
+    // the `<ObjectEncryption>` wrapper (this is the intentional behavior change).
+    let unwrapped = r"<SSE-KMS><KMSKeyArn>arn:aws:kms:us-east-1:111122223333:key/abc123</KMSKeyArn></SSE-KMS>";
+    assert!(deserialize::<ObjectEncryption>(unwrapped.as_bytes()).is_err());
+
+    // Content form (member embedding) stays unwrapped.
+    let content = serialize_content(&val).unwrap();
+    assert_eq!(
+        content,
+        "<SSE-KMS><BucketKeyEnabled>true</BucketKeyEnabled>\
+         <KMSKeyArn>arn:aws:kms:us-east-1:111122223333:key/abc123</KMSKeyArn></SSE-KMS>"
+    );
+    test_serde_content(&val);
+}

--- a/data/s3.json
+++ b/data/s3.json
@@ -222,6 +222,15 @@
                 "smithy.api#documentation": "<p>A container for information about access control for replicas.</p>"
             }
         },
+        "com.amazonaws.s3#AccessDenied": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>\n      You might receive this error for several reasons. For details, see the description of this API \n      operation.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 403
+            }
+        },
         "com.amazonaws.s3#AccessKeyIdValue": {
             "type": "string"
         },
@@ -27393,6 +27402,21 @@
                 }
             }
         },
+        "com.amazonaws.s3#BlockedEncryptionTypes": {
+            "type": "structure",
+            "members": {
+                "EncryptionType": {
+                    "target": "com.amazonaws.s3#EncryptionTypeList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The object encryption type that you want to block or unblock for an Amazon S3 general purpose bucket.</p>\n         <note>\n            <p>Currently, this parameter only supports blocking or unblocking server side encryption with customer-provided keys (SSE-C). For more information about SSE-C, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html\">Using server-side encryption with customer-provided keys (SSE-C)</a>.</p>\n         </note>",
+                        "smithy.api#xmlFlattened": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A bucket-level setting for Amazon S3 general purpose buckets used to prevent the upload of new objects encrypted with the specified server-side encryption type. For example, blocking an encryption type will block <code>PutObject</code>, <code>CopyObject</code>, <code>PostObject</code>, multipart upload, and replication requests to the bucket for objects with the specified encryption type. However, you can continue to read and list any pre-existing objects already encrypted with the specified encryption type. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/blocking-unblocking-s3-c-encryption-gpb.html\">Blocking or unblocking SSE-C for a general purpose bucket</a>.</p>\n         <p>This data type is used with the following actions:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketEncryption.html\">PutBucketEncryption</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketEncryption.html\">GetBucketEncryption</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketEncryption.html\">DeleteBucketEncryption</a>\n               </p>\n            </li>\n         </ul>\n         <dl>\n            <dt>Permissions</dt>\n            <dd>\n               <p>You must have the <code>s3:PutEncryptionConfiguration</code> permission to block or unblock an encryption type for a bucket. </p>\n               <p>You must have the <code>s3:GetEncryptionConfiguration</code> permission to view a bucket's encryption type. </p>\n            </dd>\n         </dl>"
+            }
+        },
         "com.amazonaws.s3#Body": {
             "type": "blob"
         },
@@ -31939,6 +31963,32 @@
             },
             "traits": {
                 "smithy.api#documentation": "<p>Specifies encryption-related information for an Amazon S3 bucket that is a destination for\n         replicated objects.</p>\n         <note>\n            <p>If you're specifying a customer managed KMS key, we recommend using a fully\n            qualified KMS key ARN. If you use a KMS key alias instead, then KMS resolves the\n            key within the requester’s account. This behavior can result in data that's encrypted\n            with a KMS key that belongs to the requester, and not the bucket owner.</p>\n         </note>"
+            }
+        },
+        "com.amazonaws.s3#EncryptionType": {
+            "type": "enum",
+            "members": {
+                "NONE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NONE"
+                    }
+                },
+                "SSE_C": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SSE-C"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3#EncryptionTypeList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.s3#EncryptionType",
+                "traits": {
+                    "smithy.api#xmlName": "EncryptionType"
+                }
             }
         },
         "com.amazonaws.s3#EncryptionTypeMismatch": {
@@ -39710,6 +39760,17 @@
                 "smithy.api#httpError": 404
             }
         },
+        "com.amazonaws.s3#NonEmptyKmsKeyArnString": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 20,
+                    "max": 2048
+                },
+                "smithy.api#pattern": "^arn:aws[a-zA-Z0-9-]*:kms:[a-z0-9-]+:[0-9]{12}:key/[a-zA-Z0-9-]+$",
+                "smithy.api#sensitive": {}
+            }
+        },
         "com.amazonaws.s3#NoncurrentVersionExpiration": {
             "type": "structure",
             "members": {
@@ -39986,6 +40047,21 @@
                         "smithy.api#enumValue": "bucket-owner-full-control"
                     }
                 }
+            }
+        },
+        "com.amazonaws.s3#ObjectEncryption": {
+            "type": "union",
+            "members": {
+                "SSEKMS": {
+                    "target": "com.amazonaws.s3#SSEKMSEncryption",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      Specifies to update the object encryption type to server-side encryption with Key Management Service (KMS) keys \n      (SSE-KMS). \n    </p>",
+                        "smithy.api#xmlName": "SSE-KMS"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n      The updated server-side encryption type for this object. The <code>UpdateObjectEncryption</code> \n      operation supports the SSE-S3 and SSE-KMS encryption types.\n    </p>\n         <p>Valid Values: <code>SSES3</code> | <code>SSEKMS</code>\n         </p>"
             }
         },
         "com.amazonaws.s3#ObjectIdentifier": {
@@ -45054,6 +45130,28 @@
                 "smithy.api#xmlName": "SSE-KMS"
             }
         },
+        "com.amazonaws.s3#SSEKMSEncryption": {
+            "type": "structure",
+            "members": {
+                "KMSKeyArn": {
+                    "target": "com.amazonaws.s3#NonEmptyKmsKeyArnString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      Specifies the Amazon Web Services KMS key Amazon Resource Name (ARN) to use for the updated server-side encryption \n      type. Required if <code>ObjectEncryption</code> specifies <code>SSEKMS</code>. \n    </p>\n         <note>\n            <p>You must specify the full Amazon Web Services KMS key ARN. The KMS key ID and KMS key alias aren't \n        supported.</p>\n         </note>\n         <p>Pattern: (<code>arn:aws[-a-z0-9]*:kms:[-a-z0-9]*:[0-9]{12}:key/.+</code>)</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "BucketKeyEnabled": {
+                    "target": "com.amazonaws.s3#BucketKeyEnabled",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      Specifies whether Amazon S3 should use an S3 Bucket Key for object encryption with server-side encryption \n      using Key Management Service (KMS) keys (SSE-KMS). If this value isn't specified, it defaults to <code>false</code>. \n      Setting this value to <code>true</code> causes Amazon S3 to use an S3 Bucket Key for object encryption with \n      SSE-KMS. For more information, see \n      <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html\">\n        Using Amazon S3 Bucket Keys</a> in the <i>Amazon S3 User Guide</i>.\n    </p>\n         <p>Valid Values: <code>true</code> | <code>false</code>\n         </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n      If <code>SSEKMS</code> is specified for <code>ObjectEncryption</code>, this data type specifies\n      the Amazon Web Services KMS key Amazon Resource Name (ARN) to use and whether to use an S3 Bucket Key for \n      server-side encryption using Key Management Service (KMS) keys (SSE-KMS).\n    </p>",
+                "smithy.api#xmlName": "SSE-KMS"
+            }
+        },
         "com.amazonaws.s3#SSEKMSEncryptionContext": {
             "type": "string",
             "traits": {
@@ -45306,6 +45404,18 @@
                         "smithy.api#enumValue": "AES256"
                     }
                 },
+                "aws_fsx": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "aws:fsx"
+                    }
+                },
+                "aws_backup": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "aws:backup"
+                    }
+                },
                 "aws_kms": {
                     "target": "smithy.api#Unit",
                     "traits": {
@@ -45364,18 +45474,24 @@
                 "ApplyServerSideEncryptionByDefault": {
                     "target": "com.amazonaws.s3#ServerSideEncryptionByDefault",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the default server-side encryption to apply to new objects in the bucket. If a\n         PUT Object request doesn't specify any server-side encryption, this default encryption will\n         be applied.</p>"
+                        "smithy.api#documentation": "<p>Specifies the default server-side encryption to apply to new objects in the bucket. If a PUT Object\n      request doesn't specify any server-side encryption, this default encryption will be applied.</p>"
                     }
                 },
                 "BucketKeyEnabled": {
                     "target": "com.amazonaws.s3#BucketKeyEnabled",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS\n         (SSE-KMS) for new objects in the bucket. Existing objects are not affected. Setting the\n            <code>BucketKeyEnabled</code> element to <code>true</code> causes Amazon S3 to use an S3\n         Bucket Key. </p>\n         <note>\n            <ul>\n               <li>\n                  <p>\n                     <b>General purpose buckets</b> - By default, S3\n                  Bucket Key is not enabled. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html\">Amazon S3 Bucket Keys</a> in the\n                     <i>Amazon S3 User Guide</i>.</p>\n               </li>\n               <li>\n                  <p>\n                     <b>Directory buckets</b> -\n                  S3 Bucket Keys are always enabled for <code>GET</code> and <code>PUT</code> operations in a directory bucket and can’t be disabled. S3 Bucket Keys aren't supported, when you copy SSE-KMS encrypted objects from general purpose buckets  \nto directory buckets, from directory buckets to general purpose buckets, or between directory buckets, through <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html\">CopyObject</a>, <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html\">UploadPartCopy</a>, <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-objects-Batch-Ops\">the Copy operation in Batch Operations</a>, or \n                            <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-import-job\">the import jobs</a>. In this case, Amazon S3 makes a call to KMS every time a copy request is made for a KMS-encrypted object.</p>\n               </li>\n            </ul>\n         </note>"
+                        "smithy.api#documentation": "<p>Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS)\n      for new objects in the bucket. Existing objects are not affected. Setting the\n        <code>BucketKeyEnabled</code> element to <code>true</code> causes Amazon S3 to use an S3 Bucket Key. </p>\n         <note>\n            <ul>\n               <li>\n                  <p>\n                     <b>General purpose buckets</b> - By default, S3 Bucket Key is not\n            enabled. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html\">Amazon S3 Bucket Keys</a> in the\n              <i>Amazon S3 User Guide</i>.</p>\n               </li>\n               <li>\n                  <p>\n                     <b>Directory buckets</b> -\n            S3 Bucket Keys are always enabled for <code>GET</code> and <code>PUT</code> operations in a directory bucket and can’t be disabled. S3 Bucket Keys aren't supported, when you copy SSE-KMS encrypted objects from general purpose buckets  \nto directory buckets, from directory buckets to general purpose buckets, or between directory buckets, through <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html\">CopyObject</a>, <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html\">UploadPartCopy</a>, <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-objects-Batch-Ops\">the Copy operation in Batch Operations</a>, or \n                            <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-import-job\">the import jobs</a>. In this case, Amazon S3 makes a call to KMS every time a copy request is made for a KMS-encrypted object.</p>\n               </li>\n            </ul>\n         </note>"
+                    }
+                },
+                "BlockedEncryptionTypes": {
+                    "target": "com.amazonaws.s3#BlockedEncryptionTypes",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A bucket-level setting for Amazon S3 general purpose buckets used to prevent the upload of new objects encrypted with the specified server-side encryption type. For example, blocking an encryption type will block <code>PutObject</code>, <code>CopyObject</code>, <code>PostObject</code>, multipart upload, and replication requests to the bucket for objects with the specified encryption type. However, you can continue to read and list any pre-existing objects already encrypted with the specified encryption type. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/blocking-unblocking-s3-c-encryption-gpb.html\">Blocking or unblocking SSE-C for a general purpose bucket</a>.</p>\n         <note>\n            <p>Currently, this parameter only supports blocking or unblocking server-side encryption with customer-provided keys (SSE-C). For more information about SSE-C, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html\">Using server-side encryption with customer-provided keys (SSE-C)</a>.</p>\n         </note>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Specifies the default server-side encryption configuration.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>\n                     <b>General purpose buckets</b> - If you're specifying\n                  a customer managed KMS key, we recommend using a fully qualified KMS key ARN.\n                  If you use a KMS key alias instead, then KMS resolves the key within the\n                  requester’s account. This behavior can result in data that's encrypted with a\n                  KMS key that belongs to the requester, and not the bucket owner.</p>\n               </li>\n               <li>\n                  <p>\n                     <b>Directory buckets</b> -\n                  When you specify an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">KMS customer managed key</a> for encryption in your directory bucket, only use the key ID or key ARN. The key alias format of the KMS key isn't supported.</p>\n               </li>\n            </ul>\n         </note>"
+                "smithy.api#documentation": "<p>Specifies the default server-side encryption configuration.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>\n                     <b>General purpose buckets</b> - If you're specifying a customer\n            managed KMS key, we recommend using a fully qualified KMS key ARN. If you use a KMS key\n            alias instead, then KMS resolves the key within the requester’s account. This behavior can\n            result in data that's encrypted with a KMS key that belongs to the requester, and not the bucket\n            owner.</p>\n               </li>\n               <li>\n                  <p>\n                     <b>Directory buckets</b> -\n            When you specify an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">KMS customer managed key</a> for encryption in your directory bucket, only use the key ID or key ARN. The key alias format of the KMS key isn't supported.</p>\n               </li>\n            </ul>\n         </note>"
             }
         },
         "com.amazonaws.s3#ServerSideEncryptionRules": {
@@ -46306,6 +46422,121 @@
             },
             "traits": {
                 "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.s3#UpdateObjectEncryption": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.s3#UpdateObjectEncryptionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.s3#UpdateObjectEncryptionResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.s3#AccessDenied"
+                },
+                {
+                    "target": "com.amazonaws.s3#InvalidRequest"
+                },
+                {
+                    "target": "com.amazonaws.s3#NoSuchKey"
+                }
+            ],
+            "traits": {
+                "aws.protocols#httpChecksum": {
+                    "requestAlgorithmMember": "ChecksumAlgorithm",
+                    "requestChecksumRequired": true
+                },
+                "smithy.api#documentation": "<note>\n            <p>This operation is not supported for directory buckets or Amazon S3 on Outposts buckets.\n      </p>\n         </note>\n         <p>\n      Updates the server-side encryption type of an existing encrypted object in a general purpose bucket. \n      You can use the <code>UpdateObjectEncryption</code> operation to change encrypted objects from \n      server-side encryption with Amazon S3 managed keys (SSE-S3) to server-side encryption with Key Management Service (KMS) \n      keys (SSE-KMS), or to apply S3 Bucket Keys. You can also use the <code>UpdateObjectEncryption</code> operation \n      to change the customer-managed KMS key used to encrypt your data so that you can comply with custom \n      key-rotation standards.\n    </p>\n         <p>Using the <code>UpdateObjectEncryption</code> operation, you can atomically update the server-side \n      encryption type of an existing object in a general purpose bucket without any data movement. The \n      <code>UpdateObjectEncryption</code> operation uses envelope encryption to re-encrypt the data key used to \n      encrypt and decrypt your object with your newly specified server-side encryption type. In other words, \n      when you use the <code>UpdateObjectEncryption</code> operation, your data isn't copied, archived \n      objects in the S3 Glacier Flexible Retrieval and S3 Glacier Deep Archive storage classes aren't \n      restored, and objects in the S3 Intelligent-Tiering storage class aren't moved between tiers. \n      Additionally, the <code>UpdateObjectEncryption</code> operation preserves all object metadata \n      properties, including the storage class, creation date, last modified date, ETag, and checksum \n      properties. For more information, see \n      <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/update-sse-encryption.html\">\n        Updating server-side encryption for existing objects</a> in the \n      <i>Amazon S3 User Guide</i>.</p>\n         <p>By default, all <code>UpdateObjectEncryption</code> requests that specify a  customer-managed \n      KMS key are restricted to KMS keys that are owned by the  bucket owner's Amazon Web Services account. If you're \n      using Organizations, you can request the ability to use KMS keys owned by other member \n      accounts  within your organization by contacting Amazon Web Services Support.</p>\n         <note>\n            <p>Source objects that are unencrypted, or encrypted with either dual-layer server-side encryption \n        with KMS keys (DSSE-KMS) or server-side encryption with customer-provided keys (SSE-C) aren't \n        supported by this operation. Additionally, you cannot specify SSE-S3 encryption as the requested\n        new encryption type <code>UpdateObjectEncryption</code> request.</p>\n         </note>\n         <dl>\n            <dt>Permissions</dt>\n            <dd>\n               <ul>\n                  <li>\n                     <p>To use the <code>UpdateObjectEncryption</code> operation, you must have the following \n                permissions:</p>\n                     <ul>\n                        <li>\n                           <p>\n                              <code>s3:UpdateObjectEncryption</code>\n                           </p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>kms:Encrypt</code>\n                           </p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>kms:Decrypt</code>\n                           </p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>kms:GenerateDataKey</code>\n                           </p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>kms:ReEncrypt*</code>\n                           </p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>If you're using Organizations, to use this operation with customer-managed \n                KMS keys from other Amazon Web Services accounts within your organization, you must have the \n                <code>organizations:DescribeAccount</code> permission.</p>\n                  </li>\n               </ul>\n            </dd>\n         </dl>\n         <dl>\n            <dt>Errors</dt>\n            <dd>\n               <ul>\n                  <li>\n                     <p>You might receive an <code>InvalidRequest</code> error for several reasons. Depending \n                on the reason for the error, you might receive one of the following messages:</p>\n                     <ul>\n                        <li>\n                           <p>The <code>UpdateObjectEncryption</code> operation doesn't supported unencrypted \n                    source objects. Only source objects encrypted with SSE-S3 or SSE-KMS are supported.</p>\n                        </li>\n                        <li>\n                           <p>The <code>UpdateObjectEncryption</code> operation doesn't support source objects \n                    with the encryption type DSSE-KMS or SSE-C. Only source objects encrypted with SSE-S3 \n                    or SSE-KMS are supported.</p>\n                        </li>\n                        <li>\n                           <p>The <code>UpdateObjectEncryption</code> operation doesn't support updating the \n                    encryption type to DSSE-KMS or SSE-C. Modify the request to specify SSE-KMS \n                    for the updated encryption type, and then try again.</p>\n                        </li>\n                        <li>\n                           <p>Requests that modify an object encryption configuration require Amazon Web Services Signature \n                    Version 4. Modify the request to use Amazon Web Services Signature Version 4, and then try again.</p>\n                        </li>\n                        <li>\n                           <p>Requests that modify an object encryption configuration require a valid new \n                    encryption type. Valid values are <code>SSEKMS</code>. Modify the request to specify\n                    SSE-KMS for the updated encryption type, and then try again.</p>\n                        </li>\n                        <li>\n                           <p>Requests that modify an object's encryption type to SSE-KMS require an Amazon Web Services KMS key \n                    Amazon Resource Name (ARN). Modify the request to specify a KMS key ARN, and then \n                    try again.</p>\n                        </li>\n                        <li>\n                           <p>Requests that modify an object's encryption type to SSE-KMS require a valid \n                    Amazon Web Services KMS key Amazon Resource Name (ARN). Confirm that you have a correctly formatted \n                    KMS key ARN in your request, and then try again.</p>\n                        </li>\n                        <li>\n                           <p>The <code>BucketKeyEnabled</code> value isn't valid. Valid values are \n                    <code>true</code> or <code>false</code>. Modify the request to specify a valid value, \n                    and then try again.</p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>You might receive an <code>AccessDenied</code> error for several reasons. Depending on \n                the reason for the error, you might receive one of the following messages:</p>\n                     <ul>\n                        <li>\n                           <p>The Amazon Web Services KMS key in the request must be owned by the same account as the bucket. Modify \n                    the request to specify a KMS key from the same account, and then try again.</p>\n                        </li>\n                        <li>\n                           <p>The bucket owner's account was approved to make <code>UpdateObjectEncryption</code> requests \n                    that use any Amazon Web Services KMS key in their organization, but the bucket owner's account isn't part of \n                    an organization in Organizations. Make sure that the bucket owner's account and the \n                    specified KMS key belong to the same organization, and then try again. </p>\n                        </li>\n                        <li>\n                           <p>The specified Amazon Web Services KMS key must be from the same organization in Organizations as \n                    the bucket. Specify a KMS key that belongs to the same organization as the bucket, and then \n                    try again. </p>\n                        </li>\n                        <li>\n                           <p>The encryption type for the specified object can’t be updated because that object is \n                    protected by S3 Object Lock. If the object has a governance-mode retention period or a legal \n                    hold, you must first remove the Object Lock status on the object before you issue your \n                    <code>UpdateObjectEncryption</code> request. You can't use the <code>UpdateObjectEncryption</code>\n                    operation with objects that have an Object Lock compliance mode retention period applied to them.</p>\n                        </li>\n                     </ul>\n                  </li>\n               </ul>\n            </dd>\n         </dl>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/{Bucket}/{Key+}?encryption",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.s3#UpdateObjectEncryptionRequest": {
+            "type": "structure",
+            "members": {
+                "Bucket": {
+                    "target": "com.amazonaws.s3#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The name of the general purpose bucket that contains the specified object key name.\n    </p>\n         <p>When you use this operation with an access point attached to a general purpose bucket, you \n      must either provide the alias of the access point in place of the bucket name or you must specify \n      the access point Amazon Resource Name (ARN). When using the access point ARN, you must direct \n      requests to the access point hostname. The access point hostname takes the form \n      <code>\n               <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com</code>. \n      When using this operation with an access point through the Amazon Web Services SDKs, you provide the access point \n      ARN in place of the bucket name. For more information about access point ARNs, see \n      <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points-naming.html\">\n        Referencing access points</a> in the <i>Amazon S3 User Guide</i>.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Bucket"
+                        }
+                    }
+                },
+                "Key": {
+                    "target": "com.amazonaws.s3#ObjectKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The key name of the object that you want to update the server-side encryption type for.\n    </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "VersionId": {
+                    "target": "com.amazonaws.s3#ObjectVersionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The version ID of the object that you want to update the server-side encryption type for.\n    </p>",
+                        "smithy.api#httpQuery": "versionId"
+                    }
+                },
+                "ObjectEncryption": {
+                    "target": "com.amazonaws.s3#ObjectEncryption",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The updated server-side encryption type for this object. The <code>UpdateObjectEncryption</code> \n      operation supports the SSE-S3 and SSE-KMS encryption types.\n    </p>\n         <p>Valid Values: <code>SSES3</code> | <code>SSEKMS</code>\n         </p>",
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "RequestPayer": {
+                    "target": "com.amazonaws.s3#RequestPayer",
+                    "traits": {
+                        "smithy.api#httpHeader": "x-amz-request-payer"
+                    }
+                },
+                "ExpectedBucketOwner": {
+                    "target": "com.amazonaws.s3#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The account ID of the expected bucket owner. If the account ID that you provide doesn't match the \n      actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code> \n      (access denied).\n    </p>",
+                        "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
+                    }
+                },
+                "ContentMD5": {
+                    "target": "com.amazonaws.s3#ContentMD5",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The MD5 hash for the request body. For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.\n   </p>",
+                        "smithy.api#httpHeader": "Content-MD5"
+                    }
+                },
+                "ChecksumAlgorithm": {
+                    "target": "com.amazonaws.s3#ChecksumAlgorithm",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      Indicates the algorithm used to create the checksum for the object when you use an Amazon Web Services SDK. This header \n      doesn't provide any additional functionality if you don't use the SDK. When you send this header, \n      there must be a corresponding <code>x-amz-checksum</code> or <code>x-amz-trailer</code> header sent. \n      Otherwise, Amazon S3 fails the request with the HTTP status code <code>400 Bad Request</code>. For more \n      information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">\n        Checking object integrity </a> in the <i>Amazon S3 User Guide</i>.  \n    </p>\n         <p>If you provide an individual checksum, Amazon S3 ignores any provided <code>ChecksumAlgorithm</code> \n      parameter.</p>",
+                        "smithy.api#httpHeader": "x-amz-sdk-checksum-algorithm"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.s3#UpdateObjectEncryptionResponse": {
+            "type": "structure",
+            "members": {
+                "RequestCharged": {
+                    "target": "com.amazonaws.s3#RequestCharged",
+                    "traits": {
+                        "smithy.api#httpHeader": "x-amz-request-charged"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.s3#UploadIdMarker": {


### PR DESCRIPTION
## Summary

Add the `UpdateObjectEncryption` operation to the S3 model, continuing the Smithy model refresh toward upstream `db89911` (see #676). Like the previous batch, the new operation is added to the `S3Service` trait with a default stub that returns `NotImplemented`.

## Changes

### `data/s3.json`

- +1 operation: `UpdateObjectEncryption` (`PUT /{Bucket}/{Key+}?encryption`)
- +9 shapes: `UpdateObjectEncryptionRequest`, `UpdateObjectEncryptionResponse`, `ObjectEncryption` (union), `SSEKMSEncryption`, `NonEmptyKmsKeyArnString`, `AccessDenied`, `BlockedEncryptionTypes`, `EncryptionType`, `EncryptionTypeList`
- The request carries the required `ObjectEncryption` union payload (member `SSE-KMS` with xmlName `SSE-KMS` → `SSEKMSEncryption`, required `KMSKeyArn` + optional `BucketKeyEnabled`), the `versionId` query, and the `x-amz-request-payer`, `x-amz-expected-bucket-owner`, `Content-MD5` and `x-amz-sdk-checksum-algorithm` headers
- All changed shapes are byte-identical to upstream `db89911`

### codegen

- `xml.rs`: root XML serde now handles union payloads via `codegen_xml_serde_root_struct_enum` — `Serialize`/`Deserialize` wrap the payload in the root element named after the payload member (e.g. `<ObjectEncryption>`), matching the official wire form (empirically confirmed with aws-sdk-s3 1.144.0); `SerializeContent`/`DeserializeContent` (member embedding) stay unwrapped
- `dto.rs` + `ops.rs`: `{Op}Response` output shapes are normalized to the `<Op>Output` convention in `unify_operation_types` (in-place rename), removing the previous hardcoded `to_type_name` entry
- `aws_conv.rs`: struct-enum variant names are mapped to the aws-sdk UpperCamelCase convention (`SSEKMS` → `Ssekms`) and `SSEKMSEncryption` → `SsekmsEncryption`
- `rust.rs`: `StructEnumVariant` gains `xml_name`

### Generated code (`just codegen`)

- dto: new input/output types and builders
- ops: HTTP deserialization for the new query/headers and the `?encryption` router rule
- s3_trait: `update_object_encryption` method with a `NotImplemented` stub
- access: `update_object_encryption` access hook
- xml: root and content serde for `ObjectEncryption`
- s3s-aws conv/proxy: field wiring to `aws_sdk_s3` `UpdateObjectEncryption`

### Route fixtures and tests

- +route fixture entries for the `?encryption` router rule
- `crates/s3s/tests/xml.rs`: `update_object_encryption_union_root` regression test covering the official wrapped wire form round-trip, the serialized wrapper assertion, rejection of the unwrapped form, and the unwrapped content form

## Verification

- `just codegen` idempotent (second run produces no diff)
- `just lint` clean; CI-style `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean
- `just test` all green
- changed model shapes verified byte-identical to upstream `db89911`

Refs #676
