### PR TITLE
feat(data): add object annotation operations to S3 model

### DIFF
--- a/codegen/src/v1/dto.rs
+++ b/codegen/src/v1/dto.rs
@@ -188,7 +188,7 @@ pub fn collect_rust_types(model: &smithy::Model, ops: &Operations) -> RustTypes 
                     let is_op_input = rs_shape_name.strip_suffix("Request").is_some_and(|op| ops.contains_key(op));
 
                     let option_type = 'optional: {
-                        if field_type == "StreamingBlob" && default_value.as_ref().unwrap() == "" {
+                        if field_type == "StreamingBlob" {
                             break 'optional true;
                         }
                         if is_op_input && is_required.not() {

--- a/codegen/src/v1/ops.rs
+++ b/codegen/src/v1/ops.rs
@@ -1262,6 +1262,19 @@ fn codegen_router(ops: &Operations, rust_types: &RustTypes) {
                         }
                         let fallback_op_name = group.iter().find(|r| is_final_op(r)).map(|r| r.op.name.as_str());
 
+                        // Count how many routes share each query tag, so that
+                        // shared tags can be disambiguated by required query
+                        // members while single-op tags keep the plain check.
+                        let tag_counts: HashMap<&str, usize> = {
+                            let mut counts: HashMap<&str, usize> = default();
+                            for r in group {
+                                if let Some(tag) = r.query_tag.as_deref() {
+                                    *counts.entry(tag).or_insert(0) += 1;
+                                }
+                            }
+                            counts
+                        };
+
                         g!("if let Some(qs) = qs {{");
                         for route in group {
                             let has_query_tag = route.query_tag.is_some();
@@ -1291,29 +1304,17 @@ fn codegen_router(ops: &Operations, rust_types: &RustTypes) {
                                 (true, false) => {
                                     let tag = route.query_tag.as_deref().unwrap();
 
-                                    // Special handling for operations that share the same query tag
-                                    // but are differentiated by the presence of an 'id' parameter
-                                    let needs_id_check = matches!(
-                                        route.op.name.as_str(),
-                                        "GetBucketAnalyticsConfiguration"
-                                            | "GetBucketIntelligentTieringConfiguration"
-                                            | "GetBucketInventoryConfiguration"
-                                            | "GetBucketMetricsConfiguration"
-                                    );
-                                    let needs_no_id_check = matches!(
-                                        route.op.name.as_str(),
-                                        "ListBucketAnalyticsConfigurations"
-                                            | "ListBucketIntelligentTieringConfigurations"
-                                            | "ListBucketInventoryConfigurations"
-                                            | "ListBucketMetricsConfigurations"
-                                    );
-
-                                    if needs_id_check {
-                                        g!("if qs.has(\"{tag}\") && qs.has(\"id\") {{");
-                                        succ(route, true);
-                                        g!("}}");
-                                    } else if needs_no_id_check {
-                                        g!("if qs.has(\"{tag}\") && !qs.has(\"id\") {{");
+                                    // Operations sharing a query tag are disambiguated by the
+                                    // presence of a required query member (e.g. `id` for the
+                                    // analytics/metrics groups, `annotationName` for the object
+                                    // annotation operations). The route carrying the required
+                                    // member is sorted first and matches only when it is present;
+                                    // the remaining route matches on the bare tag. Single-op tags
+                                    // keep the plain tag check.
+                                    if tag_counts.get(tag).copied().unwrap_or(0) > 1
+                                        && let Some(required) = route.required_query_strings.first()
+                                    {
+                                        g!("if qs.has(\"{tag}\") && qs.has(\"{required}\") {{");
                                         succ(route, true);
                                         g!("}}");
                                     } else {

--- a/crates/s3s-aws/src/conv/generated.rs
+++ b/crates/s3s-aws/src/conv/generated.rs
@@ -288,6 +288,82 @@ impl AwsConversion for s3s::dto::AnnotationConfigurationState {
     }
 }
 
+impl AwsConversion for s3s::dto::AnnotationDirective {
+    type Target = aws_sdk_s3::types::AnnotationDirective;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(match x {
+            aws_sdk_s3::types::AnnotationDirective::Copy => Self::from_static(Self::COPY),
+            aws_sdk_s3::types::AnnotationDirective::Exclude => Self::from_static(Self::EXCLUDE),
+            _ => Self::from(x.as_str().to_owned()),
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        Ok(aws_sdk_s3::types::AnnotationDirective::from(x.as_str()))
+    }
+}
+
+impl AwsConversion for s3s::dto::AnnotationEntry {
+    type Target = aws_sdk_s3::types::AnnotationEntry;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            annotation_name: try_from_aws(x.annotation_name)?,
+            checksum_algorithm: try_from_aws(x.checksum_algorithm)?,
+            e_tag: try_from_aws(x.e_tag)?,
+            last_modified: try_from_aws(x.last_modified)?,
+            replication_status: try_from_aws(x.replication_status)?,
+            size: try_from_aws(x.size)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_annotation_name(Some(try_into_aws(x.annotation_name)?));
+        y = y.set_checksum_algorithm(try_into_aws(x.checksum_algorithm)?);
+        y = y.set_e_tag(try_into_aws(x.e_tag)?);
+        y = y.set_last_modified(Some(try_into_aws(x.last_modified)?));
+        y = y.set_replication_status(try_into_aws(x.replication_status)?);
+        y = y.set_size(Some(try_into_aws(x.size)?));
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::AnnotationLimitExceeded {
+    type Target = aws_sdk_s3::types::error::AnnotationLimitExceeded;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::AnnotationNameTooLong {
+    type Target = aws_sdk_s3::types::error::AnnotationNameTooLong;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
+    }
+}
+
 impl AwsConversion for s3s::dto::AnnotationTableConfiguration {
     type Target = aws_sdk_s3::types::AnnotationTableConfiguration;
     type Error = S3Error;
@@ -1126,6 +1202,7 @@ impl AwsConversion for s3s::dto::CopyObjectInput {
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(Self {
             acl: try_from_aws(x.acl)?,
+            annotation_directive: try_from_aws(x.annotation_directive)?,
             bucket: unwrap_from_aws(x.bucket, "bucket")?,
             bucket_key_enabled: try_from_aws(x.bucket_key_enabled)?,
             cache_control: try_from_aws(x.cache_control)?,
@@ -1149,6 +1226,8 @@ impl AwsConversion for s3s::dto::CopyObjectInput {
             grant_read: try_from_aws(x.grant_read)?,
             grant_read_acp: try_from_aws(x.grant_read_acp)?,
             grant_write_acp: try_from_aws(x.grant_write_acp)?,
+            if_match: try_from_aws(x.if_match)?,
+            if_none_match: try_from_aws(x.if_none_match)?,
             key: unwrap_from_aws(x.key, "key")?,
             metadata: try_from_aws(x.metadata)?,
             metadata_directive: try_from_aws(x.metadata_directive)?,
@@ -1173,6 +1252,7 @@ impl AwsConversion for s3s::dto::CopyObjectInput {
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(Self {
             acl: try_from_aws(x.acl)?,
+            annotation_directive: try_from_aws(x.annotation_directive)?,
             bucket: unwrap_from_aws(x.bucket, "bucket")?,
             bucket_key_enabled: try_from_aws(x.bucket_key_enabled)?,
             cache_control: try_from_aws(x.cache_control)?,
@@ -1196,6 +1276,8 @@ impl AwsConversion for s3s::dto::CopyObjectInput {
             grant_read: try_from_aws(x.grant_read)?,
             grant_read_acp: try_from_aws(x.grant_read_acp)?,
             grant_write_acp: try_from_aws(x.grant_write_acp)?,
+            if_match: try_from_aws(x.if_match)?,
+            if_none_match: try_from_aws(x.if_none_match)?,
             key: unwrap_from_aws(x.key, "key")?,
             metadata: try_from_aws(x.metadata)?,
             metadata_directive: try_from_aws(x.metadata_directive)?,
@@ -1220,6 +1302,7 @@ impl AwsConversion for s3s::dto::CopyObjectInput {
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         let mut y = Self::Target::builder();
         y = y.set_acl(try_into_aws(x.acl)?);
+        y = y.set_annotation_directive(try_into_aws(x.annotation_directive)?);
         y = y.set_bucket(Some(try_into_aws(x.bucket)?));
         y = y.set_bucket_key_enabled(try_into_aws(x.bucket_key_enabled)?);
         y = y.set_cache_control(try_into_aws(x.cache_control)?);
@@ -1243,6 +1326,8 @@ impl AwsConversion for s3s::dto::CopyObjectInput {
         y = y.set_grant_read(try_into_aws(x.grant_read)?);
         y = y.set_grant_read_acp(try_into_aws(x.grant_read_acp)?);
         y = y.set_grant_write_acp(try_into_aws(x.grant_write_acp)?);
+        y = y.set_if_match(try_into_aws(x.if_match)?);
+        y = y.set_if_none_match(try_into_aws(x.if_none_match)?);
         y = y.set_key(Some(try_into_aws(x.key)?));
         y = y.set_metadata(try_into_aws(x.metadata)?);
         y = y.set_metadata_directive(try_into_aws(x.metadata_directive)?);
@@ -2407,6 +2492,54 @@ impl AwsConversion for s3s::dto::DeleteMarkerReplicationStatus {
 
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         Ok(aws_sdk_s3::types::DeleteMarkerReplicationStatus::from(x.as_str()))
+    }
+}
+
+impl AwsConversion for s3s::dto::DeleteObjectAnnotationInput {
+    type Target = aws_sdk_s3::operation::delete_object_annotation::DeleteObjectAnnotationInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            annotation_name: unwrap_from_aws(x.annotation_name, "annotation_name")?,
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+            key: unwrap_from_aws(x.key, "key")?,
+            object_if_match: try_from_aws(x.object_if_match)?,
+            request_payer: try_from_aws(x.request_payer)?,
+            version_id: try_from_aws(x.version_id)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_annotation_name(Some(try_into_aws(x.annotation_name)?));
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y = y.set_key(Some(try_into_aws(x.key)?));
+        y = y.set_object_if_match(try_into_aws(x.object_if_match)?);
+        y = y.set_request_payer(try_into_aws(x.request_payer)?);
+        y = y.set_version_id(try_into_aws(x.version_id)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::DeleteObjectAnnotationOutput {
+    type Target = aws_sdk_s3::operation::delete_object_annotation::DeleteObjectAnnotationOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            object_version_id: try_from_aws(x.object_version_id)?,
+            request_charged: try_from_aws(x.request_charged)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_object_version_id(try_into_aws(x.object_version_id)?);
+        y = y.set_request_charged(try_into_aws(x.request_charged)?);
+        Ok(y.build())
     }
 }
 
@@ -3927,6 +4060,88 @@ impl AwsConversion for s3s::dto::GetObjectAclOutput {
     }
 }
 
+impl AwsConversion for s3s::dto::GetObjectAnnotationInput {
+    type Target = aws_sdk_s3::operation::get_object_annotation::GetObjectAnnotationInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            annotation_name: unwrap_from_aws(x.annotation_name, "annotation_name")?,
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            checksum_mode: try_from_aws(x.checksum_mode)?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+            key: unwrap_from_aws(x.key, "key")?,
+            request_payer: try_from_aws(x.request_payer)?,
+            version_id: try_from_aws(x.version_id)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_annotation_name(Some(try_into_aws(x.annotation_name)?));
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_checksum_mode(try_into_aws(x.checksum_mode)?);
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y = y.set_key(Some(try_into_aws(x.key)?));
+        y = y.set_request_payer(try_into_aws(x.request_payer)?);
+        y = y.set_version_id(try_into_aws(x.version_id)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::GetObjectAnnotationOutput {
+    type Target = aws_sdk_s3::operation::get_object_annotation::GetObjectAnnotationOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            annotation_payload: Some(try_from_aws(x.annotation_payload)?),
+            checksum_crc32: try_from_aws(x.checksum_crc32)?,
+            checksum_crc32c: try_from_aws(x.checksum_crc32_c)?,
+            checksum_crc64nvme: try_from_aws(x.checksum_crc64_nvme)?,
+            checksum_md5: try_from_aws(x.checksum_md5)?,
+            checksum_sha1: try_from_aws(x.checksum_sha1)?,
+            checksum_sha256: try_from_aws(x.checksum_sha256)?,
+            checksum_sha512: try_from_aws(x.checksum_sha512)?,
+            checksum_type: try_from_aws(x.checksum_type)?,
+            checksum_xxhash128: try_from_aws(x.checksum_xxhash128)?,
+            checksum_xxhash3: try_from_aws(x.checksum_xxhash3)?,
+            checksum_xxhash64: try_from_aws(x.checksum_xxhash64)?,
+            content_length: try_from_aws(x.content_length)?,
+            e_tag: try_from_aws(x.e_tag)?,
+            last_modified: try_from_aws(x.last_modified)?,
+            object_version_id: try_from_aws(x.object_version_id)?,
+            replication_status: try_from_aws(x.replication_status)?,
+            request_charged: try_from_aws(x.request_charged)?,
+            server_side_encryption: try_from_aws(x.server_side_encryption)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_annotation_payload(try_into_aws(x.annotation_payload)?);
+        y = y.set_checksum_crc32(try_into_aws(x.checksum_crc32)?);
+        y = y.set_checksum_crc32_c(try_into_aws(x.checksum_crc32c)?);
+        y = y.set_checksum_crc64_nvme(try_into_aws(x.checksum_crc64nvme)?);
+        y = y.set_checksum_md5(try_into_aws(x.checksum_md5)?);
+        y = y.set_checksum_sha1(try_into_aws(x.checksum_sha1)?);
+        y = y.set_checksum_sha256(try_into_aws(x.checksum_sha256)?);
+        y = y.set_checksum_sha512(try_into_aws(x.checksum_sha512)?);
+        y = y.set_checksum_type(try_into_aws(x.checksum_type)?);
+        y = y.set_checksum_xxhash128(try_into_aws(x.checksum_xxhash128)?);
+        y = y.set_checksum_xxhash3(try_into_aws(x.checksum_xxhash3)?);
+        y = y.set_checksum_xxhash64(try_into_aws(x.checksum_xxhash64)?);
+        y = y.set_content_length(try_into_aws(x.content_length)?);
+        y = y.set_e_tag(try_into_aws(x.e_tag)?);
+        y = y.set_last_modified(try_into_aws(x.last_modified)?);
+        y = y.set_object_version_id(try_into_aws(x.object_version_id)?);
+        y = y.set_replication_status(try_into_aws(x.replication_status)?);
+        y = y.set_request_charged(try_into_aws(x.request_charged)?);
+        y = y.set_server_side_encryption(try_into_aws(x.server_side_encryption)?);
+        Ok(y.build())
+    }
+}
+
 impl AwsConversion for s3s::dto::GetObjectAttributesInput {
     type Target = aws_sdk_s3::operation::get_object_attributes::GetObjectAttributesInput;
     type Error = S3Error;
@@ -4859,6 +5074,22 @@ impl AwsConversion for s3s::dto::IntelligentTieringStatus {
     }
 }
 
+impl AwsConversion for s3s::dto::InvalidAnnotationName {
+    type Target = aws_sdk_s3::types::error::InvalidAnnotationName;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
+    }
+}
+
 impl AwsConversion for s3s::dto::InvalidObjectState {
     type Target = aws_sdk_s3::types::error::InvalidObjectState;
     type Error = S3Error;
@@ -4874,6 +5105,22 @@ impl AwsConversion for s3s::dto::InvalidObjectState {
         let mut y = Self::Target::builder();
         y = y.set_access_tier(try_into_aws(x.access_tier)?);
         y = y.set_storage_class(try_into_aws(x.storage_class)?);
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::InvalidPrefix {
+    type Target = aws_sdk_s3::types::error::InvalidPrefix;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
         Ok(y.build())
     }
 }
@@ -5824,6 +6071,72 @@ impl AwsConversion for s3s::dto::ListMultipartUploadsOutput {
     }
 }
 
+impl AwsConversion for s3s::dto::ListObjectAnnotationsInput {
+    type Target = aws_sdk_s3::operation::list_object_annotations::ListObjectAnnotationsInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            annotation_prefix: try_from_aws(x.annotation_prefix)?,
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            continuation_token: try_from_aws(x.continuation_token)?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+            key: unwrap_from_aws(x.key, "key")?,
+            max_annotation_results: try_from_aws(x.max_annotation_results)?,
+            request_payer: try_from_aws(x.request_payer)?,
+            version_id: try_from_aws(x.version_id)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_annotation_prefix(try_into_aws(x.annotation_prefix)?);
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_continuation_token(try_into_aws(x.continuation_token)?);
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y = y.set_key(Some(try_into_aws(x.key)?));
+        y = y.set_max_annotation_results(try_into_aws(x.max_annotation_results)?);
+        y = y.set_request_payer(try_into_aws(x.request_payer)?);
+        y = y.set_version_id(try_into_aws(x.version_id)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::ListObjectAnnotationsOutput {
+    type Target = aws_sdk_s3::operation::list_object_annotations::ListObjectAnnotationsOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            annotation_count: try_from_aws(x.annotation_count)?,
+            annotation_prefix: try_from_aws(x.annotation_prefix)?,
+            annotations: try_from_aws(x.annotations)?,
+            bucket: try_from_aws(x.bucket)?,
+            continuation_token: try_from_aws(x.continuation_token)?,
+            key: try_from_aws(x.key)?,
+            max_annotation_results: try_from_aws(x.max_annotation_results)?,
+            next_continuation_token: try_from_aws(x.next_continuation_token)?,
+            object_version_id: try_from_aws(x.object_version_id)?,
+            request_charged: try_from_aws(x.request_charged)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_annotation_count(try_into_aws(x.annotation_count)?);
+        y = y.set_annotation_prefix(try_into_aws(x.annotation_prefix)?);
+        y = y.set_annotations(try_into_aws(x.annotations)?);
+        y = y.set_bucket(try_into_aws(x.bucket)?);
+        y = y.set_continuation_token(try_into_aws(x.continuation_token)?);
+        y = y.set_key(try_into_aws(x.key)?);
+        y = y.set_max_annotation_results(try_into_aws(x.max_annotation_results)?);
+        y = y.set_next_continuation_token(try_into_aws(x.next_continuation_token)?);
+        y = y.set_object_version_id(try_into_aws(x.object_version_id)?);
+        y = y.set_request_charged(try_into_aws(x.request_charged)?);
+        Ok(y.build())
+    }
+}
+
 impl AwsConversion for s3s::dto::ListObjectVersionsInput {
     type Target = aws_sdk_s3::operation::list_object_versions::ListObjectVersionsInput;
     type Error = S3Error;
@@ -6486,6 +6799,22 @@ impl AwsConversion for s3s::dto::MultipartUpload {
         y = y.set_owner(try_into_aws(x.owner)?);
         y = y.set_storage_class(try_into_aws(x.storage_class)?);
         y = y.set_upload_id(try_into_aws(x.upload_id)?);
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::NoSuchAnnotation {
+    type Target = aws_sdk_s3::types::error::NoSuchAnnotation;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
         Ok(y.build())
     }
 }
@@ -8258,6 +8587,110 @@ impl AwsConversion for s3s::dto::PutObjectAclOutput {
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         let mut y = Self::Target::builder();
         y = y.set_request_charged(try_into_aws(x.request_charged)?);
+        Ok(y.build())
+    }
+}
+
+impl AwsConversion for s3s::dto::PutObjectAnnotationInput {
+    type Target = aws_sdk_s3::operation::put_object_annotation::PutObjectAnnotationInput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            annotation_name: unwrap_from_aws(x.annotation_name, "annotation_name")?,
+            annotation_payload: Some(try_from_aws(x.annotation_payload)?),
+            bucket: unwrap_from_aws(x.bucket, "bucket")?,
+            checksum_algorithm: try_from_aws(x.checksum_algorithm)?,
+            checksum_crc32: try_from_aws(x.checksum_crc32)?,
+            checksum_crc32c: try_from_aws(x.checksum_crc32_c)?,
+            checksum_crc64nvme: try_from_aws(x.checksum_crc64_nvme)?,
+            checksum_md5: try_from_aws(x.checksum_md5)?,
+            checksum_sha1: try_from_aws(x.checksum_sha1)?,
+            checksum_sha256: try_from_aws(x.checksum_sha256)?,
+            checksum_sha512: try_from_aws(x.checksum_sha512)?,
+            checksum_xxhash128: try_from_aws(x.checksum_xxhash128)?,
+            checksum_xxhash3: try_from_aws(x.checksum_xxhash3)?,
+            checksum_xxhash64: try_from_aws(x.checksum_xxhash64)?,
+            content_md5: try_from_aws(x.content_md5)?,
+            expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
+            key: unwrap_from_aws(x.key, "key")?,
+            object_if_match: try_from_aws(x.object_if_match)?,
+            request_payer: try_from_aws(x.request_payer)?,
+            version_id: try_from_aws(x.version_id)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_annotation_name(Some(try_into_aws(x.annotation_name)?));
+        y = y.set_annotation_payload(try_into_aws(x.annotation_payload)?);
+        y = y.set_bucket(Some(try_into_aws(x.bucket)?));
+        y = y.set_checksum_algorithm(try_into_aws(x.checksum_algorithm)?);
+        y = y.set_checksum_crc32(try_into_aws(x.checksum_crc32)?);
+        y = y.set_checksum_crc32_c(try_into_aws(x.checksum_crc32c)?);
+        y = y.set_checksum_crc64_nvme(try_into_aws(x.checksum_crc64nvme)?);
+        y = y.set_checksum_md5(try_into_aws(x.checksum_md5)?);
+        y = y.set_checksum_sha1(try_into_aws(x.checksum_sha1)?);
+        y = y.set_checksum_sha256(try_into_aws(x.checksum_sha256)?);
+        y = y.set_checksum_sha512(try_into_aws(x.checksum_sha512)?);
+        y = y.set_checksum_xxhash128(try_into_aws(x.checksum_xxhash128)?);
+        y = y.set_checksum_xxhash3(try_into_aws(x.checksum_xxhash3)?);
+        y = y.set_checksum_xxhash64(try_into_aws(x.checksum_xxhash64)?);
+        y = y.set_content_md5(try_into_aws(x.content_md5)?);
+        y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
+        y = y.set_key(Some(try_into_aws(x.key)?));
+        y = y.set_object_if_match(try_into_aws(x.object_if_match)?);
+        y = y.set_request_payer(try_into_aws(x.request_payer)?);
+        y = y.set_version_id(try_into_aws(x.version_id)?);
+        y.build().map_err(S3Error::internal_error)
+    }
+}
+
+impl AwsConversion for s3s::dto::PutObjectAnnotationOutput {
+    type Target = aws_sdk_s3::operation::put_object_annotation::PutObjectAnnotationOutput;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        Ok(Self {
+            annotation_name: try_from_aws(x.annotation_name)?,
+            checksum_crc32: try_from_aws(x.checksum_crc32)?,
+            checksum_crc32c: try_from_aws(x.checksum_crc32_c)?,
+            checksum_crc64nvme: try_from_aws(x.checksum_crc64_nvme)?,
+            checksum_md5: try_from_aws(x.checksum_md5)?,
+            checksum_sha1: try_from_aws(x.checksum_sha1)?,
+            checksum_sha256: try_from_aws(x.checksum_sha256)?,
+            checksum_sha512: try_from_aws(x.checksum_sha512)?,
+            checksum_type: try_from_aws(x.checksum_type)?,
+            checksum_xxhash128: try_from_aws(x.checksum_xxhash128)?,
+            checksum_xxhash3: try_from_aws(x.checksum_xxhash3)?,
+            checksum_xxhash64: try_from_aws(x.checksum_xxhash64)?,
+            e_tag: try_from_aws(x.e_tag)?,
+            key: try_from_aws(x.key)?,
+            object_version_id: try_from_aws(x.object_version_id)?,
+            request_charged: try_from_aws(x.request_charged)?,
+            server_side_encryption: try_from_aws(x.server_side_encryption)?,
+        })
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let mut y = Self::Target::builder();
+        y = y.set_annotation_name(try_into_aws(x.annotation_name)?);
+        y = y.set_checksum_crc32(try_into_aws(x.checksum_crc32)?);
+        y = y.set_checksum_crc32_c(try_into_aws(x.checksum_crc32c)?);
+        y = y.set_checksum_crc64_nvme(try_into_aws(x.checksum_crc64nvme)?);
+        y = y.set_checksum_md5(try_into_aws(x.checksum_md5)?);
+        y = y.set_checksum_sha1(try_into_aws(x.checksum_sha1)?);
+        y = y.set_checksum_sha256(try_into_aws(x.checksum_sha256)?);
+        y = y.set_checksum_sha512(try_into_aws(x.checksum_sha512)?);
+        y = y.set_checksum_type(try_into_aws(x.checksum_type)?);
+        y = y.set_checksum_xxhash128(try_into_aws(x.checksum_xxhash128)?);
+        y = y.set_checksum_xxhash3(try_into_aws(x.checksum_xxhash3)?);
+        y = y.set_checksum_xxhash64(try_into_aws(x.checksum_xxhash64)?);
+        y = y.set_e_tag(try_into_aws(x.e_tag)?);
+        y = y.set_key(try_into_aws(x.key)?);
+        y = y.set_object_version_id(try_into_aws(x.object_version_id)?);
+        y = y.set_request_charged(try_into_aws(x.request_charged)?);
+        y = y.set_server_side_encryption(try_into_aws(x.server_side_encryption)?);
         Ok(y.build())
     }
 }
@@ -10130,6 +10563,22 @@ impl AwsConversion for s3s::dto::Type {
 
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         Ok(aws_sdk_s3::types::Type::from(x.as_str()))
+    }
+}
+
+impl AwsConversion for s3s::dto::UnsupportedMediaType {
+    type Target = aws_sdk_s3::types::error::UnsupportedMediaType;
+    type Error = S3Error;
+
+    fn try_from_aws(x: Self::Target) -> S3Result<Self> {
+        let _ = x;
+        Ok(Self {})
+    }
+
+    fn try_into_aws(x: Self) -> S3Result<Self::Target> {
+        let _ = x;
+        let y = Self::Target::builder();
+        Ok(y.build())
     }
 }
 

--- a/crates/s3s-aws/src/proxy/generated.rs
+++ b/crates/s3s-aws/src/proxy/generated.rs
@@ -91,6 +91,7 @@ impl S3 for Proxy {
         debug!(?input);
         let mut b = self.client.copy_object();
         b = b.set_acl(try_into_aws(input.acl)?);
+        b = b.set_annotation_directive(try_into_aws(input.annotation_directive)?);
         b = b.set_bucket(Some(try_into_aws(input.bucket)?));
         b = b.set_bucket_key_enabled(try_into_aws(input.bucket_key_enabled)?);
         b = b.set_cache_control(try_into_aws(input.cache_control)?);
@@ -114,6 +115,8 @@ impl S3 for Proxy {
         b = b.set_grant_read(try_into_aws(input.grant_read)?);
         b = b.set_grant_read_acp(try_into_aws(input.grant_read_acp)?);
         b = b.set_grant_write_acp(try_into_aws(input.grant_write_acp)?);
+        b = b.set_if_match(try_into_aws(input.if_match)?);
+        b = b.set_if_none_match(try_into_aws(input.if_none_match)?);
         b = b.set_key(Some(try_into_aws(input.key)?));
         b = b.set_metadata(try_into_aws(input.metadata)?);
         b = b.set_metadata_directive(try_into_aws(input.metadata_directive)?);
@@ -651,6 +654,33 @@ impl S3 for Proxy {
         b = b.set_if_match_size(try_into_aws(input.if_match_size)?);
         b = b.set_key(Some(try_into_aws(input.key)?));
         b = b.set_mfa(try_into_aws(input.mfa)?);
+        b = b.set_request_payer(try_into_aws(input.request_payer)?);
+        b = b.set_version_id(try_into_aws(input.version_id)?);
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
+    async fn delete_object_annotation(
+        &self,
+        req: S3Request<s3s::dto::DeleteObjectAnnotationInput>,
+    ) -> S3Result<S3Response<s3s::dto::DeleteObjectAnnotationOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.client.delete_object_annotation();
+        b = b.set_annotation_name(Some(try_into_aws(input.annotation_name)?));
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        b = b.set_key(Some(try_into_aws(input.key)?));
+        b = b.set_object_if_match(try_into_aws(input.object_if_match)?);
         b = b.set_request_payer(try_into_aws(input.request_payer)?);
         b = b.set_version_id(try_into_aws(input.version_id)?);
         let result = b.send().await;
@@ -1313,6 +1343,33 @@ impl S3 for Proxy {
     }
 
     #[tracing::instrument(skip(self, req))]
+    async fn get_object_annotation(
+        &self,
+        req: S3Request<s3s::dto::GetObjectAnnotationInput>,
+    ) -> S3Result<S3Response<s3s::dto::GetObjectAnnotationOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.client.get_object_annotation();
+        b = b.set_annotation_name(Some(try_into_aws(input.annotation_name)?));
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_checksum_mode(try_into_aws(input.checksum_mode)?);
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        b = b.set_key(Some(try_into_aws(input.key)?));
+        b = b.set_request_payer(try_into_aws(input.request_payer)?);
+        b = b.set_version_id(try_into_aws(input.version_id)?);
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
     async fn get_object_attributes(
         &self,
         req: S3Request<s3s::dto::GetObjectAttributesInput>,
@@ -1698,6 +1755,34 @@ impl S3 for Proxy {
         b = b.set_prefix(try_into_aws(input.prefix)?);
         b = b.set_request_payer(try_into_aws(input.request_payer)?);
         b = b.set_upload_id_marker(try_into_aws(input.upload_id_marker)?);
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
+    async fn list_object_annotations(
+        &self,
+        req: S3Request<s3s::dto::ListObjectAnnotationsInput>,
+    ) -> S3Result<S3Response<s3s::dto::ListObjectAnnotationsOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.client.list_object_annotations();
+        b = b.set_annotation_prefix(try_into_aws(input.annotation_prefix)?);
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_continuation_token(try_into_aws(input.continuation_token)?);
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        b = b.set_key(Some(try_into_aws(input.key)?));
+        b = b.set_max_annotation_results(try_into_aws(input.max_annotation_results)?);
+        b = b.set_request_payer(try_into_aws(input.request_payer)?);
+        b = b.set_version_id(try_into_aws(input.version_id)?);
         let result = b.send().await;
         match result {
             Ok(output) => {
@@ -2397,6 +2482,46 @@ impl S3 for Proxy {
         b = b.set_grant_write(try_into_aws(input.grant_write)?);
         b = b.set_grant_write_acp(try_into_aws(input.grant_write_acp)?);
         b = b.set_key(Some(try_into_aws(input.key)?));
+        b = b.set_request_payer(try_into_aws(input.request_payer)?);
+        b = b.set_version_id(try_into_aws(input.version_id)?);
+        let result = b.send().await;
+        match result {
+            Ok(output) => {
+                let headers = super::meta::build_headers(&output)?;
+                let output = try_from_aws(output)?;
+                debug!(?output);
+                Ok(S3Response::with_headers(output, headers))
+            }
+            Err(e) => Err(wrap_sdk_error!(e)),
+        }
+    }
+
+    #[tracing::instrument(skip(self, req))]
+    async fn put_object_annotation(
+        &self,
+        req: S3Request<s3s::dto::PutObjectAnnotationInput>,
+    ) -> S3Result<S3Response<s3s::dto::PutObjectAnnotationOutput>> {
+        let input = req.input;
+        debug!(?input);
+        let mut b = self.client.put_object_annotation();
+        b = b.set_annotation_name(Some(try_into_aws(input.annotation_name)?));
+        b = b.set_annotation_payload(try_into_aws(input.annotation_payload)?);
+        b = b.set_bucket(Some(try_into_aws(input.bucket)?));
+        b = b.set_checksum_algorithm(try_into_aws(input.checksum_algorithm)?);
+        b = b.set_checksum_crc32(try_into_aws(input.checksum_crc32)?);
+        b = b.set_checksum_crc32_c(try_into_aws(input.checksum_crc32c)?);
+        b = b.set_checksum_crc64_nvme(try_into_aws(input.checksum_crc64nvme)?);
+        b = b.set_checksum_md5(try_into_aws(input.checksum_md5)?);
+        b = b.set_checksum_sha1(try_into_aws(input.checksum_sha1)?);
+        b = b.set_checksum_sha256(try_into_aws(input.checksum_sha256)?);
+        b = b.set_checksum_sha512(try_into_aws(input.checksum_sha512)?);
+        b = b.set_checksum_xxhash128(try_into_aws(input.checksum_xxhash128)?);
+        b = b.set_checksum_xxhash3(try_into_aws(input.checksum_xxhash3)?);
+        b = b.set_checksum_xxhash64(try_into_aws(input.checksum_xxhash64)?);
+        b = b.set_content_md5(try_into_aws(input.content_md5)?);
+        b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
+        b = b.set_key(Some(try_into_aws(input.key)?));
+        b = b.set_object_if_match(try_into_aws(input.object_if_match)?);
         b = b.set_request_payer(try_into_aws(input.request_payer)?);
         b = b.set_version_id(try_into_aws(input.version_id)?);
         let result = b.send().await;

--- a/crates/s3s/src/access/generated.rs
+++ b/crates/s3s/src/access/generated.rs
@@ -222,6 +222,13 @@ pub trait S3Access: Send + Sync + 'static {
         Ok(())
     }
 
+    /// Checks whether the DeleteObjectAnnotation request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn delete_object_annotation(&self, _req: &mut S3Request<DeleteObjectAnnotationInput>) -> S3Result<()> {
+        Ok(())
+    }
+
     /// Checks whether the DeleteObjectTagging request has accesses to the resources.
     ///
     /// This method returns `Ok(())` by default.
@@ -439,6 +446,13 @@ pub trait S3Access: Send + Sync + 'static {
         Ok(())
     }
 
+    /// Checks whether the GetObjectAnnotation request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn get_object_annotation(&self, _req: &mut S3Request<GetObjectAnnotationInput>) -> S3Result<()> {
+        Ok(())
+    }
+
     /// Checks whether the GetObjectAttributes request has accesses to the resources.
     ///
     /// This method returns `Ok(())` by default.
@@ -560,6 +574,13 @@ pub trait S3Access: Send + Sync + 'static {
     ///
     /// This method returns `Ok(())` by default.
     async fn list_multipart_uploads(&self, _req: &mut S3Request<ListMultipartUploadsInput>) -> S3Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether the ListObjectAnnotations request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn list_object_annotations(&self, _req: &mut S3Request<ListObjectAnnotationsInput>) -> S3Result<()> {
         Ok(())
     }
 
@@ -768,6 +789,13 @@ pub trait S3Access: Send + Sync + 'static {
     ///
     /// This method returns `Ok(())` by default.
     async fn put_object_acl(&self, _req: &mut S3Request<PutObjectAclInput>) -> S3Result<()> {
+        Ok(())
+    }
+
+    /// Checks whether the PutObjectAnnotation request has accesses to the resources.
+    ///
+    /// This method returns `Ok(())` by default.
+    async fn put_object_annotation(&self, _req: &mut S3Request<PutObjectAnnotationInput>) -> S3Result<()> {
         Ok(())
     }
 

--- a/crates/s3s/src/dto/generated.rs
+++ b/crates/s3s/src/dto/generated.rs
@@ -489,6 +489,12 @@ impl From<AnnotationConfigurationState> for Cow<'static, str> {
     }
 }
 
+impl From<AnnotationDirective> for Cow<'static, str> {
+    fn from(s: AnnotationDirective) -> Self {
+        s.0
+    }
+}
+
 impl From<ArchiveStatus> for Cow<'static, str> {
     fn from(s: ArchiveStatus) -> Self {
         s.0
@@ -953,6 +959,115 @@ impl FromStr for AnnotationConfigurationState {
         Ok(Self::from(s.to_owned()))
     }
 }
+
+pub type AnnotationCount = i32;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnnotationDirective(Cow<'static, str>);
+
+impl AnnotationDirective {
+    pub const COPY: &'static str = "COPY";
+
+    pub const EXCLUDE: &'static str = "EXCLUDE";
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn from_static(s: &'static str) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl From<String> for AnnotationDirective {
+    fn from(s: String) -> Self {
+        Self(Cow::from(s))
+    }
+}
+
+impl FromStr for AnnotationDirective {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s.to_owned()))
+    }
+}
+
+/// <p>Describes a single annotation attached to an object, including its name, last modified time,
+/// size, ETag, checksum algorithm, and replication status. Returned in the response from
+/// <code>ListObjectAnnotations</code>.</p>
+#[derive(Clone, PartialEq)]
+pub struct AnnotationEntry {
+    /// <p>The name of the annotation.</p>
+    pub annotation_name: AnnotationName,
+    /// <p>The checksum algorithm used for the annotation.</p>
+    pub checksum_algorithm: Option<ChecksumAlgorithmList>,
+    /// <p>The entity tag of the annotation.</p>
+    pub e_tag: Option<ETag>,
+    /// <p>The date and time the annotation was last modified.</p>
+    pub last_modified: LastModified,
+    /// <p>The replication status of the annotation.</p>
+    pub replication_status: Option<ReplicationStatus>,
+    /// <p>The size of the annotation payload, in bytes.</p>
+    pub size: Size,
+}
+
+impl fmt::Debug for AnnotationEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("AnnotationEntry");
+        d.field("annotation_name", &self.annotation_name);
+        if let Some(ref val) = self.checksum_algorithm {
+            d.field("checksum_algorithm", val);
+        }
+        if let Some(ref val) = self.e_tag {
+            d.field("e_tag", val);
+        }
+        d.field("last_modified", &self.last_modified);
+        if let Some(ref val) = self.replication_status {
+            d.field("replication_status", val);
+        }
+        d.field("size", &self.size);
+        d.finish_non_exhaustive()
+    }
+}
+impl DtoExt for AnnotationEntry {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref val) = self.replication_status
+            && val.as_str() == ""
+        {
+            self.replication_status = None;
+        }
+    }
+}
+
+/// <p>The request would exceed the maximum number of annotations allowed per object.</p>
+#[derive(Clone, Default, PartialEq)]
+pub struct AnnotationLimitExceeded {}
+
+impl fmt::Debug for AnnotationLimitExceeded {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("AnnotationLimitExceeded");
+        d.finish_non_exhaustive()
+    }
+}
+
+pub type AnnotationList = List<AnnotationEntry>;
+
+pub type AnnotationName = String;
+
+/// <p>The annotation name exceeds 512 bytes.</p>
+#[derive(Clone, Default, PartialEq)]
+pub struct AnnotationNameTooLong {}
+
+impl fmt::Debug for AnnotationNameTooLong {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("AnnotationNameTooLong");
+        d.finish_non_exhaustive()
+    }
+}
+
+pub type AnnotationPrefix = String;
 
 /// <p>Specifies the configuration for the annotation table associated with a bucket's Amazon S3 Metadata
 /// configuration. The annotation table is an Iceberg table that records annotation events for objects
@@ -3151,23 +3266,20 @@ impl fmt::Debug for ContinuationEvent {
 #[cfg(not(feature = "minio"))]
 pub struct CopyObjectInput {
     /// <p>The canned access control list (ACL) to apply to the object.</p>
-    /// <p>When you copy an object, the ACL metadata is not preserved and is set to
-    /// <code>private</code> by default. Only the owner has full access control. To override the
-    /// default ACL setting, specify a new ACL when you generate a copy request. For more
-    /// information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Using ACLs</a>. </p>
-    /// <p>If the destination bucket that you're copying objects to uses the bucket owner enforced
-    /// setting for S3 Object Ownership, ACLs are disabled and no longer affect permissions.
-    /// Buckets that use this setting only accept <code>PUT</code> requests that don't specify an
-    /// ACL or <code>PUT</code> requests that specify bucket owner full control ACLs, such as the
-    /// <code>bucket-owner-full-control</code> canned ACL or an equivalent form of this ACL
-    /// expressed in the XML format. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html">Controlling ownership of
-    /// objects and disabling ACLs</a> in the <i>Amazon S3 User Guide</i>.</p>
+    /// <p>When you copy an object, the ACL metadata is not preserved and is set to <code>private</code> by
+    /// default. Only the owner has full access control. To override the default ACL setting, specify a new ACL
+    /// when you generate a copy request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Using ACLs</a>. </p>
+    /// <p>If the destination bucket that you're copying objects to uses the bucket owner enforced setting for
+    /// S3 Object Ownership, ACLs are disabled and no longer affect permissions. Buckets that use this setting
+    /// only accept <code>PUT</code> requests that don't specify an ACL or <code>PUT</code> requests that
+    /// specify bucket owner full control ACLs, such as the <code>bucket-owner-full-control</code> canned ACL or
+    /// an equivalent form of this ACL expressed in the XML format. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html">Controlling ownership
+    /// of objects and disabling ACLs</a> in the <i>Amazon S3 User Guide</i>.</p>
     /// <note>
     /// <ul>
     /// <li>
-    /// <p>If your destination bucket uses the bucket owner enforced setting for Object
-    /// Ownership, all objects written to the bucket by any account will be owned by the
-    /// bucket owner.</p>
+    /// <p>If your destination bucket uses the bucket owner enforced setting for Object Ownership, all
+    /// objects written to the bucket by any account will be owned by the bucket owner.</p>
     /// </li>
     /// <li>
     /// <p>This functionality is not supported for directory buckets.</p>
@@ -3178,6 +3290,31 @@ pub struct CopyObjectInput {
     /// </ul>
     /// </note>
     pub acl: Option<ObjectCannedACL>,
+    /// <p>Specifies whether you want to copy annotations from the source object or exclude them. If this
+    /// header isn't specified, <code>COPY</code> is the default behavior.</p>
+    /// <p>Valid Values: <code>COPY | EXCLUDE</code>
+    /// </p>
+    /// <p>You can specify this directive as either an HTTP header
+    /// (<code>x-amz-object-annotation-directive</code>) or as a query string parameter. Use the query
+    /// string form when generating presigned URLs that need to control annotation copy behavior.</p>
+    /// <p>When set to <code>COPY</code>, you must have <code>s3:GetObjectAnnotation</code> permission on
+    /// the source object and <code>s3:PutObjectAnnotation</code> permission on the destination. Each
+    /// annotation copied is billed as a separate PUT request. If annotations on the source are modified
+    /// during the copy, Amazon S3 returns a retryable error.</p>
+    /// <note>
+    /// <p>For directory buckets, annotations are not supported. Use <code>EXCLUDE</code> to copy
+    /// objects to directory buckets without errors. If you specify <code>COPY</code> for a directory
+    /// bucket, the request returns HTTP 501 (Not Implemented).</p>
+    /// </note>
+    /// <note>
+    /// <p>When you copy objects using multipart upload (for example, when the Amazon Web Services CLI or Amazon Web Services SDKs
+    /// use Transfer Manager for objects larger than approximately 8 MB), annotations are not copied by
+    /// default. To include annotations, specify <code>--copy-props default</code> in the Amazon Web Services CLI or the
+    /// equivalent SDK configuration. With this opt-in, the SDK reads source annotations, completes the
+    /// multipart upload, and then writes each annotation to the destination. Between the upload completion
+    /// and the last annotation write, the destination object exists without all its annotations.</p>
+    /// </note>
+    pub annotation_directive: Option<AnnotationDirective>,
     /// <p>The name of the destination bucket.</p>
     /// <p>
     /// <b>Directory buckets</b> - When you use this operation with a directory bucket, you must use virtual-hosted-style requests in the format <code>
@@ -3187,32 +3324,36 @@ pub struct CopyObjectInput {
     /// restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html">Directory bucket naming
     /// rules</a> in the <i>Amazon S3 User Guide</i>.</p>
     /// <note>
-    /// <p>Copying objects across different Amazon Web Services Regions isn't supported when the source or destination bucket is in Amazon Web Services Local Zones. The source and destination buckets must have the same parent Amazon Web Services Region. Otherwise,
-    /// you get an HTTP <code>400 Bad Request</code> error with the error code <code>InvalidRequest</code>.</p>
+    /// <p>Copying objects across different Amazon Web Services Regions isn't supported when the source or destination
+    /// bucket is in Amazon Web Services Local Zones. The source and destination buckets must have the same parent Amazon Web Services Region.
+    /// Otherwise, you get an HTTP <code>400 Bad Request</code> error with the error code
+    /// <code>InvalidRequest</code>.</p>
     /// </note>
     /// <p>
-    /// <b>Access points</b> - When you use this action with an access point, you must provide the alias of the access point in place of the bucket name or specify the access point ARN. When using the access point ARN, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+    /// <b>Access points</b> - When you use this action with an access point for general purpose buckets, you must provide the alias of the access point in place of the bucket name or specify the access point ARN. When you use this action with an access point for directory buckets, you must provide the access point name in place of the bucket name. When using the access point ARN, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
     /// <note>
-    /// <p>Access points and Object Lambda access points are not supported by directory buckets.</p>
+    /// <p>Object Lambda access points are not supported by directory buckets.</p>
     /// </note>
     /// <p>
-    /// <b>S3 on Outposts</b> - When you use this action with S3 on Outposts, you must use the Outpost bucket access point ARN or the access point alias for the destination bucket.
-    ///
-    /// You can only copy objects within the same Outpost bucket. It's not supported to copy objects across different Amazon Web Services Outposts, between buckets on the same Outposts, or between Outposts buckets and any other bucket types.
-    /// For more information about S3 on Outposts, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">What is S3 on Outposts?</a> in the <i>S3 on Outposts guide</i>.
-    /// When you use this action with S3 on Outposts through the REST API, you must direct requests to the S3 on Outposts hostname, in the format
+    /// <b>S3 on Outposts</b> - When you use this action with S3 on Outposts,
+    /// you must use the Outpost bucket access point ARN or the access point alias for the destination bucket.
+    /// You can only copy objects within the same Outpost bucket. It's not supported to copy objects across
+    /// different Amazon Web Services Outposts, between buckets on the same Outposts, or between Outposts buckets and any
+    /// other bucket types. For more information about S3 on Outposts, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">What is S3 on Outposts?</a> in the
+    /// <i>S3 on Outposts guide</i>. When you use this action with S3 on Outposts through the REST
+    /// API, you must direct requests to the S3 on Outposts hostname, in the format
     /// <code>
-    /// <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com</code>. The hostname isn't required when you use the Amazon Web Services CLI or SDKs.
-    /// </p>
+    /// <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com</code>.
+    /// The hostname isn't required when you use the Amazon Web Services CLI or SDKs. </p>
     pub bucket: BucketName,
-    /// <p>Specifies whether Amazon S3 should use an S3 Bucket Key for object encryption with
-    /// server-side encryption using Key Management Service (KMS) keys (SSE-KMS). If a target object uses
-    /// SSE-KMS, you can enable an S3 Bucket Key for the object.</p>
-    /// <p>Setting this header to <code>true</code> causes Amazon S3 to use an S3 Bucket Key for object
-    /// encryption with SSE-KMS. Specifying this header with a COPY action doesn’t affect
-    /// bucket-level settings for S3 Bucket Key.</p>
-    /// <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the
-    /// <i>Amazon S3 User Guide</i>.</p>
+    /// <p>Specifies whether Amazon S3 should use an S3 Bucket Key for object encryption with server-side encryption
+    /// using Key Management Service (KMS) keys (SSE-KMS). If a target object uses SSE-KMS, you can enable an S3 Bucket Key
+    /// for the object.</p>
+    /// <p>Setting this header to <code>true</code> causes Amazon S3 to use an S3 Bucket Key for object encryption
+    /// with SSE-KMS. Specifying this header with a COPY action doesn’t affect bucket-level settings for S3
+    /// Bucket Key.</p>
+    /// <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3
+    /// Bucket Keys</a> in the <i>Amazon S3 User Guide</i>.</p>
     /// <note>
     /// <p>
     /// <b>Directory buckets</b> -
@@ -3225,24 +3366,22 @@ pub struct CopyObjectInput {
     /// <p>Indicates the algorithm that you want Amazon S3 to use to create the checksum for the object. For more information, see
     /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in
     /// the <i>Amazon S3 User Guide</i>.</p>
-    /// <p>When you copy an object, if the source object has a checksum, that checksum value will
-    /// be copied to the new object by default. If the <code>CopyObject</code> request does not
-    /// include this <code>x-amz-checksum-algorithm</code> header, the checksum algorithm will be
-    /// copied from the source object to the destination object (if it's present on the source
-    /// object). You can optionally specify a different checksum algorithm to use with the
-    /// <code>x-amz-checksum-algorithm</code> header. Unrecognized or unsupported values will
-    /// respond with the HTTP status code <code>400 Bad Request</code>.</p>
+    /// <p>When you copy an object, if the source object has a checksum, that checksum value will be copied to
+    /// the new object by default. If the <code>CopyObject</code> request does not include this
+    /// <code>x-amz-checksum-algorithm</code> header, the checksum algorithm will be copied from the source
+    /// object to the destination object (if it's present on the source object). You can optionally specify a
+    /// different checksum algorithm to use with the <code>x-amz-checksum-algorithm</code> header. Unrecognized
+    /// or unsupported values will respond with the HTTP status code <code>400 Bad Request</code>.</p>
     /// <note>
     /// <p>For directory buckets, when you use Amazon Web Services SDKs, <code>CRC32</code> is the default checksum algorithm that's used for performance.</p>
     /// </note>
     pub checksum_algorithm: Option<ChecksumAlgorithm>,
-    /// <p>Specifies presentational information for the object. Indicates whether an object should
-    /// be displayed in a web browser or downloaded as a file. It allows specifying the desired
-    /// filename for the downloaded file.</p>
+    /// <p>Specifies presentational information for the object. Indicates whether an object should be displayed
+    /// in a web browser or downloaded as a file. It allows specifying the desired filename for the downloaded
+    /// file.</p>
     pub content_disposition: Option<ContentDisposition>,
-    /// <p>Specifies what content encodings have been applied to the object and thus what decoding
-    /// mechanisms must be applied to obtain the media-type referenced by the Content-Type header
-    /// field.</p>
+    /// <p>Specifies what content encodings have been applied to the object and thus what decoding mechanisms
+    /// must be applied to obtain the media-type referenced by the Content-Type header field.</p>
     /// <note>
     /// <p>For directory buckets, only the <code>aws-chunked</code> value is supported in this header field.</p>
     /// </note>
@@ -3251,23 +3390,21 @@ pub struct CopyObjectInput {
     pub content_language: Option<ContentLanguage>,
     /// <p>A standard MIME type that describes the format of the object data.</p>
     pub content_type: Option<ContentType>,
-    /// <p>Specifies the source object for the copy operation. The source object can be up to 5 GB.
-    /// If the source object is an object that was uploaded by using a multipart upload, the object
-    /// copy will be a single part object after the source object is copied to the destination
-    /// bucket.</p>
-    /// <p>You specify the value of the copy source in one of two formats, depending on whether you
-    /// want to access the source object through an <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points.html">access point</a>:</p>
+    /// <p>Specifies the source object for the copy operation. The source object can be up to 5 GB. If the
+    /// source object is an object that was uploaded by using a multipart upload, the object copy will be a
+    /// single part object after the source object is copied to the destination bucket.</p>
+    /// <p>You specify the value of the copy source in one of two formats, depending on whether you want to
+    /// access the source object through an <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points.html">access point</a>:</p>
     /// <ul>
     /// <li>
-    /// <p>For objects not accessed through an access point, specify the name of the source bucket
-    /// and the key of the source object, separated by a slash (/). For example, to copy the
-    /// object <code>reports/january.pdf</code> from the general purpose bucket
-    /// <code>awsexamplebucket</code>, use
-    /// <code>awsexamplebucket/reports/january.pdf</code>. The value must be URL-encoded.
-    /// To copy the object <code>reports/january.pdf</code> from the directory bucket
+    /// <p>For objects not accessed through an access point, specify the name of the source bucket and the key of
+    /// the source object, separated by a slash (/). For example, to copy the object
+    /// <code>reports/january.pdf</code> from the general purpose bucket <code>awsexamplebucket</code>, use
+    /// <code>awsexamplebucket/reports/january.pdf</code>. The value must be URL-encoded. To copy the
+    /// object <code>reports/january.pdf</code> from the directory bucket
     /// <code>awsexamplebucket--use1-az5--x-s3</code>, use
-    /// <code>awsexamplebucket--use1-az5--x-s3/reports/january.pdf</code>. The value must
-    /// be URL-encoded.</p>
+    /// <code>awsexamplebucket--use1-az5--x-s3/reports/january.pdf</code>. The value must be
+    /// URL-encoded.</p>
     /// </li>
     /// <li>
     /// <p>For objects accessed through access points, specify the Amazon Resource Name (ARN) of the object as accessed through the access point, in the format <code>arn:aws:s3:&lt;Region&gt;:&lt;account-id&gt;:accesspoint/&lt;access-point-name&gt;/object/&lt;key&gt;</code>. For example, to copy the object <code>reports/january.pdf</code> through access point <code>my-access-point</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3:us-west-2:123456789012:accesspoint/my-access-point/object/reports/january.pdf</code>. The value must be URL encoded.</p>
@@ -3284,31 +3421,27 @@ pub struct CopyObjectInput {
     /// <p>Alternatively, for objects accessed through Amazon S3 on Outposts, specify the ARN of the object as accessed in the format <code>arn:aws:s3-outposts:&lt;Region&gt;:&lt;account-id&gt;:outpost/&lt;outpost-id&gt;/object/&lt;key&gt;</code>. For example, to copy the object <code>reports/january.pdf</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/object/reports/january.pdf</code>. The value must be URL-encoded.  </p>
     /// </li>
     /// </ul>
-    /// <p>If your source bucket versioning is enabled, the <code>x-amz-copy-source</code> header
-    /// by default identifies the current version of an object to copy. If the current version is a
-    /// delete marker, Amazon S3 behaves as if the object was deleted. To copy a different version, use
-    /// the <code>versionId</code> query parameter. Specifically, append
-    /// <code>?versionId=&lt;version-id&gt;</code> to the value (for example,
-    /// <code>awsexamplebucket/reports/january.pdf?versionId=QUpfdndhfd8438MNFDN93jdnJFkdmqnh893</code>).
-    /// If you don't specify a version ID, Amazon S3 copies the latest version of the source
-    /// object.</p>
-    /// <p>If you enable versioning on the destination bucket, Amazon S3 generates a unique version ID
-    /// for the copied object. This version ID is different from the version ID of the source
-    /// object. Amazon S3 returns the version ID of the copied object in the
-    /// <code>x-amz-version-id</code> response header in the response.</p>
-    /// <p>If you do not enable versioning or suspend it on the destination bucket, the version ID
-    /// that Amazon S3 generates in the <code>x-amz-version-id</code> response header is always
-    /// null.</p>
+    /// <p>If your source bucket versioning is enabled, the <code>x-amz-copy-source</code> header by default
+    /// identifies the current version of an object to copy. If the current version is a delete marker, Amazon S3
+    /// behaves as if the object was deleted. To copy a different version, use the <code>versionId</code> query
+    /// parameter. Specifically, append <code>?versionId=&lt;version-id&gt;</code> to the value (for example,
+    /// <code>awsexamplebucket/reports/january.pdf?versionId=QUpfdndhfd8438MNFDN93jdnJFkdmqnh893</code>). If
+    /// you don't specify a version ID, Amazon S3 copies the latest version of the source object.</p>
+    /// <p>If you enable versioning on the destination bucket, Amazon S3 generates a unique version ID for the
+    /// copied object. This version ID is different from the version ID of the source object. Amazon S3 returns the
+    /// version ID of the copied object in the <code>x-amz-version-id</code> response header in the
+    /// response.</p>
+    /// <p>If you do not enable versioning or suspend it on the destination bucket, the version ID that Amazon S3
+    /// generates in the <code>x-amz-version-id</code> response header is always null.</p>
     /// <note>
     /// <p>
-    /// <b>Directory buckets</b> -
-    /// S3 Versioning isn't enabled and supported for directory buckets.</p>
+    /// <b>Directory buckets</b> - S3 Versioning isn't enabled and supported for directory buckets.</p>
     /// </note>
     pub copy_source: CopySource,
     /// <p>Copies the object if its entity tag (ETag) matches the specified tag.</p>
     /// <p> If both the <code>x-amz-copy-source-if-match</code> and
-    /// <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the request
-    /// and evaluate as follows, Amazon S3 returns <code>200 OK</code> and copies the data:</p>
+    /// <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the request and evaluate as
+    /// follows, Amazon S3 returns <code>200 OK</code> and copies the data:</p>
     /// <ul>
     /// <li>
     /// <p>
@@ -3316,16 +3449,14 @@ pub struct CopyObjectInput {
     /// </li>
     /// <li>
     /// <p>
-    /// <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to
-    /// false</p>
+    /// <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to false</p>
     /// </li>
     /// </ul>
     pub copy_source_if_match: Option<CopySourceIfMatch>,
     /// <p>Copies the object if it has been modified since the specified time.</p>
     /// <p>If both the <code>x-amz-copy-source-if-none-match</code> and
-    /// <code>x-amz-copy-source-if-modified-since</code> headers are present in the request and
-    /// evaluate as follows, Amazon S3 returns the <code>412 Precondition Failed</code> response
-    /// code:</p>
+    /// <code>x-amz-copy-source-if-modified-since</code> headers are present in the request and evaluate as
+    /// follows, Amazon S3 returns the <code>412 Precondition Failed</code> response code:</p>
     /// <ul>
     /// <li>
     /// <p>
@@ -3333,16 +3464,14 @@ pub struct CopyObjectInput {
     /// </li>
     /// <li>
     /// <p>
-    /// <code>x-amz-copy-source-if-modified-since</code> condition evaluates to
-    /// true</p>
+    /// <code>x-amz-copy-source-if-modified-since</code> condition evaluates to true</p>
     /// </li>
     /// </ul>
     pub copy_source_if_modified_since: Option<CopySourceIfModifiedSince>,
     /// <p>Copies the object if its entity tag (ETag) is different than the specified ETag.</p>
     /// <p>If both the <code>x-amz-copy-source-if-none-match</code> and
-    /// <code>x-amz-copy-source-if-modified-since</code> headers are present in the request and
-    /// evaluate as follows, Amazon S3 returns the <code>412 Precondition Failed</code> response
-    /// code:</p>
+    /// <code>x-amz-copy-source-if-modified-since</code> headers are present in the request and evaluate as
+    /// follows, Amazon S3 returns the <code>412 Precondition Failed</code> response code:</p>
     /// <ul>
     /// <li>
     /// <p>
@@ -3350,15 +3479,14 @@ pub struct CopyObjectInput {
     /// </li>
     /// <li>
     /// <p>
-    /// <code>x-amz-copy-source-if-modified-since</code> condition evaluates to
-    /// true</p>
+    /// <code>x-amz-copy-source-if-modified-since</code> condition evaluates to true</p>
     /// </li>
     /// </ul>
     pub copy_source_if_none_match: Option<CopySourceIfNoneMatch>,
     /// <p>Copies the object if it hasn't been modified since the specified time.</p>
     /// <p> If both the <code>x-amz-copy-source-if-match</code> and
-    /// <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the request
-    /// and evaluate as follows, Amazon S3 returns <code>200 OK</code> and copies the data:</p>
+    /// <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the request and evaluate as
+    /// follows, Amazon S3 returns <code>200 OK</code> and copies the data:</p>
     /// <ul>
     /// <li>
     /// <p>
@@ -3366,36 +3494,31 @@ pub struct CopyObjectInput {
     /// </li>
     /// <li>
     /// <p>
-    /// <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to
-    /// false</p>
+    /// <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to false</p>
     /// </li>
     /// </ul>
     pub copy_source_if_unmodified_since: Option<CopySourceIfUnmodifiedSince>,
     /// <p>Specifies the algorithm to use when decrypting the source object (for example,
     /// <code>AES256</code>).</p>
-    /// <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the
-    /// necessary encryption information in your request so that Amazon S3 can decrypt the object for
-    /// copying.</p>
+    /// <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the necessary
+    /// encryption information in your request so that Amazon S3 can decrypt the object for copying.</p>
     /// <note>
     /// <p>This functionality is not supported when the source object is in a directory bucket.</p>
     /// </note>
     pub copy_source_sse_customer_algorithm: Option<CopySourceSSECustomerAlgorithm>,
-    /// <p>Specifies the customer-provided encryption key for Amazon S3 to use to decrypt the source
-    /// object. The encryption key provided in this header must be the same one that was used when
-    /// the source object was created.</p>
-    /// <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the
-    /// necessary encryption information in your request so that Amazon S3 can decrypt the object for
-    /// copying.</p>
+    /// <p>Specifies the customer-provided encryption key for Amazon S3 to use to decrypt the source object. The
+    /// encryption key provided in this header must be the same one that was used when the source object was
+    /// created.</p>
+    /// <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the necessary
+    /// encryption information in your request so that Amazon S3 can decrypt the object for copying.</p>
     /// <note>
     /// <p>This functionality is not supported when the source object is in a directory bucket.</p>
     /// </note>
     pub copy_source_sse_customer_key: Option<CopySourceSSECustomerKey>,
-    /// <p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses
-    /// this header for a message integrity check to ensure that the encryption key was transmitted
-    /// without error.</p>
-    /// <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the
-    /// necessary encryption information in your request so that Amazon S3 can decrypt the object for
-    /// copying.</p>
+    /// <p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses this header
+    /// for a message integrity check to ensure that the encryption key was transmitted without error.</p>
+    /// <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the necessary
+    /// encryption information in your request so that Amazon S3 can decrypt the object for copying.</p>
     /// <note>
     /// <p>This functionality is not supported when the source object is in a directory bucket.</p>
     /// </note>
@@ -3454,26 +3577,38 @@ pub struct CopyObjectInput {
     /// </ul>
     /// </note>
     pub grant_write_acp: Option<GrantWriteACP>,
+    /// <p>Copies the object if the entity tag (ETag) of the destination object matches the specified
+    /// tag. If the ETag values do not match, the operation returns a <code>412 Precondition
+    /// Failed</code> error. If a concurrent operation occurs during the upload S3 returns a
+    /// <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should fetch the
+    /// object's ETag and retry the upload.</p>
+    /// <p>Expects the ETag value as a string.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub if_match: Option<IfMatch>,
+    /// <p>Copies the object only if the object key name at the destination does not already exist in
+    /// the bucket specified. Otherwise, Amazon S3 returns a <code>412 Precondition Failed</code> error. If a
+    /// concurrent operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code>
+    /// response. On a 409 failure you should retry the upload.</p>
+    /// <p>Expects the '*' (asterisk) character.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub if_none_match: Option<IfNoneMatch>,
     /// <p>The key of the destination object.</p>
     pub key: ObjectKey,
     /// <p>A map of metadata to store with the object in S3.</p>
     pub metadata: Option<Metadata>,
-    /// <p>Specifies whether the metadata is copied from the source object or replaced with
-    /// metadata that's provided in the request. When copying an object, you can preserve all
-    /// metadata (the default) or specify new metadata. If this header isn’t specified,
-    /// <code>COPY</code> is the default behavior. </p>
+    /// <p>Specifies whether the metadata is copied from the source object or replaced with metadata that's
+    /// provided in the request. When copying an object, you can preserve all metadata (the default) or specify
+    /// new metadata. If this header isn’t specified, <code>COPY</code> is the default behavior. </p>
     /// <p>
-    /// <b>General purpose bucket</b> - For general purpose buckets, when you
-    /// grant permissions, you can use the <code>s3:x-amz-metadata-directive</code> condition key
-    /// to enforce certain metadata behavior when objects are uploaded. For more information, see
-    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html">Amazon S3
-    /// condition key examples</a> in the <i>Amazon S3 User Guide</i>.</p>
+    /// <b>General purpose bucket</b> - For general purpose buckets, when you grant
+    /// permissions, you can use the <code>s3:x-amz-metadata-directive</code> condition key to enforce certain
+    /// metadata behavior when objects are uploaded. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html">Amazon S3 condition key examples</a> in the
+    /// <i>Amazon S3 User Guide</i>.</p>
     /// <note>
     /// <p>
-    /// <code>x-amz-website-redirect-location</code> is unique to each object and is not
-    /// copied when using the <code>x-amz-metadata-directive</code> header. To copy the value,
-    /// you must specify <code>x-amz-website-redirect-location</code> in the request
-    /// header.</p>
+    /// <code>x-amz-website-redirect-location</code> is unique to each object and is not copied when using
+    /// the <code>x-amz-metadata-directive</code> header. To copy the value, you must specify
+    /// <code>x-amz-website-redirect-location</code> in the request header.</p>
     /// </note>
     pub metadata_directive: Option<MetadataDirective>,
     /// <p>Specifies whether you want to apply a legal hold to the object copy.</p>
@@ -3492,50 +3627,46 @@ pub struct CopyObjectInput {
     /// </note>
     pub object_lock_retain_until_date: Option<ObjectLockRetainUntilDate>,
     pub request_payer: Option<RequestPayer>,
-    /// <p>Specifies the algorithm to use when encrypting the object (for example,
-    /// <code>AES256</code>).</p>
-    /// <p>When you perform a <code>CopyObject</code> operation, if you want to use a different
-    /// type of encryption setting for the target object, you can specify appropriate
-    /// encryption-related headers to encrypt the target object with an Amazon S3 managed key, a
-    /// KMS key, or a customer-provided key. If the encryption setting in your request is
-    /// different from the default encryption configuration of the destination bucket, the
-    /// encryption setting in your request takes precedence. </p>
+    /// <p>Specifies the algorithm to use when encrypting the object (for example, <code>AES256</code>).</p>
+    /// <p>When you perform a <code>CopyObject</code> operation, if you want to use a different type of
+    /// encryption setting for the target object, you can specify appropriate encryption-related headers to
+    /// encrypt the target object with an Amazon S3 managed key, a KMS key, or a customer-provided key. If the
+    /// encryption setting in your request is different from the default encryption configuration of the
+    /// destination bucket, the encryption setting in your request takes precedence. </p>
     /// <note>
     /// <p>This functionality is not supported when the destination bucket is a directory bucket.</p>
     /// </note>
     pub sse_customer_algorithm: Option<SSECustomerAlgorithm>,
-    /// <p>Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This
-    /// value is used to store the object and then it is discarded. Amazon S3 does not store the
-    /// encryption key. The key must be appropriate for use with the algorithm specified in the
+    /// <p>Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This value is
+    /// used to store the object and then it is discarded. Amazon S3 does not store the encryption key. The key must
+    /// be appropriate for use with the algorithm specified in the
     /// <code>x-amz-server-side-encryption-customer-algorithm</code> header.</p>
     /// <note>
     /// <p>This functionality is not supported when the destination bucket is a directory bucket.</p>
     /// </note>
     pub sse_customer_key: Option<SSECustomerKey>,
-    /// <p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses
-    /// this header for a message integrity check to ensure that the encryption key was transmitted
-    /// without error.</p>
+    /// <p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses this header
+    /// for a message integrity check to ensure that the encryption key was transmitted without error.</p>
     /// <note>
     /// <p>This functionality is not supported when the destination bucket is a directory bucket.</p>
     /// </note>
     pub sse_customer_key_md5: Option<SSECustomerKeyMD5>,
-    /// <p>Specifies the Amazon Web Services KMS Encryption Context as an additional encryption context to use
-    /// for the destination object encryption. The value of this header is a base64-encoded UTF-8 string holding JSON with the encryption context key-value pairs.</p>
+    /// <p>Specifies the Amazon Web Services KMS Encryption Context as an additional encryption context to use for the
+    /// destination object encryption. The value of this header is a base64-encoded UTF-8 string holding JSON
+    /// with the encryption context key-value pairs.</p>
     /// <p>
-    /// <b>General purpose buckets</b> - This value must be explicitly
-    /// added to specify encryption context for <code>CopyObject</code> requests if you want an
-    /// additional encryption context for your destination object. The additional encryption
-    /// context of the source object won't be copied to the destination object. For more
-    /// information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html#encryption-context">Encryption
-    /// context</a> in the <i>Amazon S3 User Guide</i>.</p>
+    /// <b>General purpose buckets</b> - This value must be explicitly added to
+    /// specify encryption context for <code>CopyObject</code> requests if you want an additional encryption
+    /// context for your destination object. The additional encryption context of the source object won't be
+    /// copied to the destination object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html#encryption-context">Encryption context</a>
+    /// in the <i>Amazon S3 User Guide</i>.</p>
     /// <p>
     /// <b>Directory buckets</b> - You can optionally provide an explicit encryption context value. The value must match the default encryption context - the bucket Amazon Resource Name (ARN). An additional encryption context value is not supported. </p>
     pub ssekms_encryption_context: Option<SSEKMSEncryptionContext>,
-    /// <p>Specifies the KMS key ID (Key ID, Key ARN, or Key Alias) to use for object encryption.
-    /// All GET and PUT requests for an object protected by KMS will fail if they're not made via
-    /// SSL or using SigV4. For information about configuring any of the officially supported Amazon Web Services
-    /// SDKs and Amazon Web Services CLI, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version">Specifying the
-    /// Signature Version in Request Authentication</a> in the
+    /// <p>Specifies the KMS key ID (Key ID, Key ARN, or Key Alias) to use for object encryption. All GET and
+    /// PUT requests for an object protected by KMS will fail if they're not made via SSL or using SigV4. For
+    /// information about configuring any of the officially supported Amazon Web Services SDKs and Amazon Web Services CLI, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version">Specifying
+    /// the Signature Version in Request Authentication</a> in the
     /// <i>Amazon S3 User Guide</i>.</p>
     /// <p>
     /// <b>Directory buckets</b> -
@@ -3547,37 +3678,35 @@ pub struct CopyObjectInput {
     ///
     /// Incorrect key specification results in an HTTP <code>400 Bad Request</code> error. </p>
     pub ssekms_key_id: Option<SSEKMSKeyId>,
-    /// <p>The server-side encryption algorithm used when storing this object in Amazon S3. Unrecognized
-    /// or unsupported values won’t write a destination object and will receive a <code>400 Bad
-    /// Request</code> response. </p>
-    /// <p>Amazon S3 automatically encrypts all new objects that are copied to an S3 bucket. When
-    /// copying an object, if you don't specify encryption information in your copy request, the
-    /// encryption setting of the target object is set to the default encryption configuration of
-    /// the destination bucket. By default, all buckets have a base level of encryption
-    /// configuration that uses server-side encryption with Amazon S3 managed keys (SSE-S3). If the
-    /// destination bucket has a different default encryption configuration, Amazon S3 uses the
+    /// <p>The server-side encryption algorithm used when storing this object in Amazon S3. Unrecognized or
+    /// unsupported values won’t write a destination object and will receive a <code>400 Bad Request</code>
+    /// response. </p>
+    /// <p>Amazon S3 automatically encrypts all new objects that are copied to an S3 bucket. When copying an object,
+    /// if you don't specify encryption information in your copy request, the encryption setting of the target
+    /// object is set to the default encryption configuration of the destination bucket. By default, all buckets
+    /// have a base level of encryption configuration that uses server-side encryption with Amazon S3 managed keys
+    /// (SSE-S3). If the destination bucket has a different default encryption configuration, Amazon S3 uses the
     /// corresponding encryption key to encrypt the target object copy.</p>
-    /// <p>With server-side encryption, Amazon S3 encrypts your data as it writes your data to disks in
-    /// its data centers and decrypts the data when you access it. For more information about
-    /// server-side encryption, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Using Server-Side Encryption</a>
-    /// in the <i>Amazon S3 User Guide</i>.</p>
+    /// <p>With server-side encryption, Amazon S3 encrypts your data as it writes your data to disks in its data
+    /// centers and decrypts the data when you access it. For more information about server-side encryption, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Using Server-Side
+    /// Encryption</a> in the <i>Amazon S3 User Guide</i>.</p>
     /// <p>
     /// <b>General purpose buckets </b>
     /// </p>
     /// <ul>
     /// <li>
-    /// <p>For general purpose buckets, there are the following supported options for server-side
-    /// encryption: server-side encryption with Key Management Service (KMS) keys (SSE-KMS), dual-layer
-    /// server-side encryption with Amazon Web Services KMS keys (DSSE-KMS), and server-side encryption
-    /// with customer-provided encryption keys (SSE-C). Amazon S3 uses the corresponding
-    /// KMS key, or a customer-provided key to encrypt the target object copy.</p>
+    /// <p>For general purpose buckets, there are the following supported options for server-side encryption:
+    /// server-side encryption with Key Management Service (KMS) keys (SSE-KMS), dual-layer server-side encryption with
+    /// Amazon Web Services KMS keys (DSSE-KMS), and server-side encryption with customer-provided encryption keys
+    /// (SSE-C). Amazon S3 uses the corresponding KMS key, or a customer-provided key to encrypt the target
+    /// object copy.</p>
     /// </li>
     /// <li>
-    /// <p>When you perform a <code>CopyObject</code> operation, if you want to use a
-    /// different type of encryption setting for the target object, you can specify
-    /// appropriate encryption-related headers to encrypt the target object with an Amazon S3
-    /// managed key, a KMS key, or a customer-provided key. If the encryption setting in
-    /// your request is different from the default encryption configuration of the
+    /// <p>When you perform a <code>CopyObject</code> operation, if you want to use a different type of
+    /// encryption setting for the target object, you can specify appropriate encryption-related headers to
+    /// encrypt the target object with an Amazon S3 managed key, a KMS key, or a customer-provided key. If the
+    /// encryption setting in your request is different from the default encryption configuration of the
     /// destination bucket, the encryption setting in your request takes precedence. </p>
     /// </li>
     /// </ul>
@@ -3592,67 +3721,73 @@ pub struct CopyObjectInput {
     /// information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-serv-side-encryption.html">Protecting data with server-side encryption</a> in the <i>Amazon S3 User Guide</i>. For more information about the encryption overriding behaviors in directory buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-specifying-kms-encryption.html">Specifying server-side encryption with KMS for new object uploads</a>.</p>
     /// </li>
     /// <li>
-    /// <p>To encrypt new object copies to a directory bucket with SSE-KMS, we recommend you
-    /// specify SSE-KMS as the directory bucket's default encryption configuration with
-    /// a KMS key (specifically, a <a href="https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk">customer managed key</a>).
-    /// The <a href="https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk">Amazon Web Services managed key</a> (<code>aws/s3</code>) isn't supported. Your SSE-KMS
-    /// configuration can only support 1 <a href="https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk">customer managed key</a> per
-    /// directory bucket for the lifetime of the bucket. After you specify a customer managed key for
-    /// SSE-KMS, you can't override the customer managed key for the bucket's SSE-KMS
-    /// configuration. Then, when you perform a <code>CopyObject</code> operation and want to
-    /// specify server-side encryption settings for new object copies with SSE-KMS in the
-    /// encryption-related request headers, you must ensure the encryption key is the same
-    /// customer managed key that you specified for the directory bucket's default encryption
-    /// configuration.
+    /// <p>To encrypt new object copies to a directory bucket with SSE-KMS, we recommend you specify
+    /// SSE-KMS as the directory bucket's default encryption configuration with a KMS key
+    /// (specifically, a <a href="https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk">customer managed key</a>). The <a href="https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk">Amazon Web Services managed key</a> (<code>aws/s3</code>) isn't supported. Your SSE-KMS configuration can
+    /// only support 1 <a href="https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk">customer managed key</a> per
+    /// directory bucket for the lifetime of the bucket. After you specify a customer managed key for SSE-KMS, you
+    /// can't override the customer managed key for the bucket's SSE-KMS configuration. Then, when you
+    /// perform a <code>CopyObject</code> operation and want to specify server-side encryption settings for
+    /// new object copies with SSE-KMS in the encryption-related request headers, you must ensure the
+    /// encryption key is the same customer managed key that you specified for the directory bucket's default
+    /// encryption configuration.
     /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <b>S3 access points for Amazon FSx </b> - When accessing data stored in
+    /// Amazon FSx file systems using S3 access points, the only valid server side encryption option is
+    /// <code>aws:fsx</code>. All Amazon FSx file systems have encryption configured by default and are
+    /// encrypted at rest. Data is automatically encrypted before being written to the file system, and
+    /// automatically decrypted as it is read. These processes are handled transparently by Amazon FSx.</p>
     /// </li>
     /// </ul>
     pub server_side_encryption: Option<ServerSideEncryption>,
-    /// <p>If the <code>x-amz-storage-class</code> header is not used, the copied object will be
-    /// stored in the <code>STANDARD</code> Storage Class by default. The <code>STANDARD</code>
-    /// storage class provides high durability and high availability. Depending on performance
-    /// needs, you can specify a different Storage Class. </p>
+    /// <p>If the <code>x-amz-storage-class</code> header is not used, the copied object will be stored in the
+    /// <code>STANDARD</code> Storage Class by default. The <code>STANDARD</code> storage class provides high
+    /// durability and high availability. Depending on performance needs, you can specify a different Storage
+    /// Class. </p>
     /// <note>
     /// <ul>
     /// <li>
     /// <p>
     /// <b>Directory buckets </b> -
-    /// For directory buckets, only the S3 Express One Zone storage class is supported to store newly created objects.
+    /// Directory buckets only support <code>EXPRESS_ONEZONE</code> (the S3 Express One Zone storage class) in Availability Zones and <code>ONEZONE_IA</code> (the S3 One Zone-Infrequent Access storage class) in Dedicated Local Zones.  
     /// Unsupported storage class values won't write a destination object and will respond with the HTTP status code <code>400 Bad Request</code>.</p>
     /// </li>
     /// <li>
     /// <p>
-    /// <b>Amazon S3 on Outposts </b> - S3 on Outposts only
-    /// uses the <code>OUTPOSTS</code> Storage Class.</p>
+    /// <b>Amazon S3 on Outposts </b> - S3 on Outposts only uses the
+    /// <code>OUTPOSTS</code> Storage Class.</p>
     /// </li>
     /// </ul>
     /// </note>
-    /// <p>You can use the <code>CopyObject</code> action to change the storage class of an object
-    /// that is already stored in Amazon S3 by using the <code>x-amz-storage-class</code> header. For
-    /// more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage Classes</a> in the
-    /// <i>Amazon S3 User Guide</i>.</p>
-    /// <p>Before using an object as a source object for the copy operation, you must restore a
-    /// copy of it if it meets any of the following conditions:</p>
+    /// <p>You can use the <code>CopyObject</code> action to change the storage class of an object that is
+    /// already stored in Amazon S3 by using the <code>x-amz-storage-class</code> header. For more information, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage Classes</a>
+    /// in the <i>Amazon S3 User Guide</i>.</p>
+    /// <p>Before using an object as a source object for the copy operation, you must restore a copy of it if
+    /// it meets any of the following conditions:</p>
     /// <ul>
     /// <li>
     /// <p>The storage class of the source object is <code>GLACIER</code> or
     /// <code>DEEP_ARCHIVE</code>.</p>
     /// </li>
     /// <li>
-    /// <p>The storage class of the source object is <code>INTELLIGENT_TIERING</code> and
-    /// it's <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering-overview.html#intel-tiering-tier-definition">S3 Intelligent-Tiering access tier</a> is <code>Archive Access</code> or
-    /// <code>Deep Archive Access</code>.</p>
+    /// <p>The storage class of the source object is <code>INTELLIGENT_TIERING</code> and it's <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering-overview.html#intel-tiering-tier-definition">S3
+    /// Intelligent-Tiering access tier</a> is <code>Archive Access</code> or <code>Deep Archive
+    /// Access</code>.</p>
     /// </li>
     /// </ul>
-    /// <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html">RestoreObject</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjectsExamples.html">Copying
-    /// Objects</a> in the <i>Amazon S3 User Guide</i>.</p>
+    /// <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html">RestoreObject</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjectsExamples.html">Copying Objects</a> in the
+    /// <i>Amazon S3 User Guide</i>.</p>
     pub storage_class: Option<StorageClass>,
-    /// <p>The tag-set for the object copy in the destination bucket. This value must be used in
-    /// conjunction with the <code>x-amz-tagging-directive</code> if you choose
-    /// <code>REPLACE</code> for the <code>x-amz-tagging-directive</code>. If you choose
-    /// <code>COPY</code> for the <code>x-amz-tagging-directive</code>, you don't need to set
-    /// the <code>x-amz-tagging</code> header, because the tag-set will be copied from the source
-    /// object directly. The tag-set must be encoded as URL Query parameters.</p>
+    /// <p>The tag-set for the object copy in the destination bucket. This value must be used in conjunction
+    /// with the <code>x-amz-tagging-directive</code> if you choose <code>REPLACE</code> for the
+    /// <code>x-amz-tagging-directive</code>. If you choose <code>COPY</code> for the
+    /// <code>x-amz-tagging-directive</code>, you don't need to set the <code>x-amz-tagging</code> header,
+    /// because the tag-set will be copied from the source object directly. The tag-set must be encoded as URL
+    /// Query parameters.</p>
     /// <p>The default value is the empty value.</p>
     /// <note>
     /// <p>
@@ -3686,8 +3821,8 @@ pub struct CopyObjectInput {
     /// </ul>
     /// </note>
     pub tagging: Option<TaggingHeader>,
-    /// <p>Specifies whether the object tag-set is copied from the source object or replaced with
-    /// the tag-set that's provided in the request.</p>
+    /// <p>Specifies whether the object tag-set is copied from the source object or replaced with the tag-set
+    /// that's provided in the request.</p>
     /// <p>The default value is <code>COPY</code>.</p>
     /// <note>
     /// <p>
@@ -3721,12 +3856,11 @@ pub struct CopyObjectInput {
     /// </ul>
     /// </note>
     pub tagging_directive: Option<TaggingDirective>,
-    /// <p>If the destination bucket is configured as a website, redirects requests for this object
-    /// copy to another object in the same bucket or to an external URL. Amazon S3 stores the value of
-    /// this header in the object metadata. This value is unique to each object and is not copied
-    /// when using the <code>x-amz-metadata-directive</code> header. Instead, you may opt to
-    /// provide this header in combination with the <code>x-amz-metadata-directive</code>
-    /// header.</p>
+    /// <p>If the destination bucket is configured as a website, redirects requests for this object copy to
+    /// another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the
+    /// object metadata. This value is unique to each object and is not copied when using the
+    /// <code>x-amz-metadata-directive</code> header. Instead, you may opt to provide this header in
+    /// combination with the <code>x-amz-metadata-directive</code> header.</p>
     /// <note>
     /// <p>This functionality is not supported for directory buckets.</p>
     /// </note>
@@ -3737,23 +3871,20 @@ pub struct CopyObjectInput {
 #[cfg(feature = "minio")]
 pub struct CopyObjectInput {
     /// <p>The canned access control list (ACL) to apply to the object.</p>
-    /// <p>When you copy an object, the ACL metadata is not preserved and is set to
-    /// <code>private</code> by default. Only the owner has full access control. To override the
-    /// default ACL setting, specify a new ACL when you generate a copy request. For more
-    /// information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Using ACLs</a>. </p>
-    /// <p>If the destination bucket that you're copying objects to uses the bucket owner enforced
-    /// setting for S3 Object Ownership, ACLs are disabled and no longer affect permissions.
-    /// Buckets that use this setting only accept <code>PUT</code> requests that don't specify an
-    /// ACL or <code>PUT</code> requests that specify bucket owner full control ACLs, such as the
-    /// <code>bucket-owner-full-control</code> canned ACL or an equivalent form of this ACL
-    /// expressed in the XML format. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html">Controlling ownership of
-    /// objects and disabling ACLs</a> in the <i>Amazon S3 User Guide</i>.</p>
+    /// <p>When you copy an object, the ACL metadata is not preserved and is set to <code>private</code> by
+    /// default. Only the owner has full access control. To override the default ACL setting, specify a new ACL
+    /// when you generate a copy request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Using ACLs</a>. </p>
+    /// <p>If the destination bucket that you're copying objects to uses the bucket owner enforced setting for
+    /// S3 Object Ownership, ACLs are disabled and no longer affect permissions. Buckets that use this setting
+    /// only accept <code>PUT</code> requests that don't specify an ACL or <code>PUT</code> requests that
+    /// specify bucket owner full control ACLs, such as the <code>bucket-owner-full-control</code> canned ACL or
+    /// an equivalent form of this ACL expressed in the XML format. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html">Controlling ownership
+    /// of objects and disabling ACLs</a> in the <i>Amazon S3 User Guide</i>.</p>
     /// <note>
     /// <ul>
     /// <li>
-    /// <p>If your destination bucket uses the bucket owner enforced setting for Object
-    /// Ownership, all objects written to the bucket by any account will be owned by the
-    /// bucket owner.</p>
+    /// <p>If your destination bucket uses the bucket owner enforced setting for Object Ownership, all
+    /// objects written to the bucket by any account will be owned by the bucket owner.</p>
     /// </li>
     /// <li>
     /// <p>This functionality is not supported for directory buckets.</p>
@@ -3764,6 +3895,31 @@ pub struct CopyObjectInput {
     /// </ul>
     /// </note>
     pub acl: Option<ObjectCannedACL>,
+    /// <p>Specifies whether you want to copy annotations from the source object or exclude them. If this
+    /// header isn't specified, <code>COPY</code> is the default behavior.</p>
+    /// <p>Valid Values: <code>COPY | EXCLUDE</code>
+    /// </p>
+    /// <p>You can specify this directive as either an HTTP header
+    /// (<code>x-amz-object-annotation-directive</code>) or as a query string parameter. Use the query
+    /// string form when generating presigned URLs that need to control annotation copy behavior.</p>
+    /// <p>When set to <code>COPY</code>, you must have <code>s3:GetObjectAnnotation</code> permission on
+    /// the source object and <code>s3:PutObjectAnnotation</code> permission on the destination. Each
+    /// annotation copied is billed as a separate PUT request. If annotations on the source are modified
+    /// during the copy, Amazon S3 returns a retryable error.</p>
+    /// <note>
+    /// <p>For directory buckets, annotations are not supported. Use <code>EXCLUDE</code> to copy
+    /// objects to directory buckets without errors. If you specify <code>COPY</code> for a directory
+    /// bucket, the request returns HTTP 501 (Not Implemented).</p>
+    /// </note>
+    /// <note>
+    /// <p>When you copy objects using multipart upload (for example, when the Amazon Web Services CLI or Amazon Web Services SDKs
+    /// use Transfer Manager for objects larger than approximately 8 MB), annotations are not copied by
+    /// default. To include annotations, specify <code>--copy-props default</code> in the Amazon Web Services CLI or the
+    /// equivalent SDK configuration. With this opt-in, the SDK reads source annotations, completes the
+    /// multipart upload, and then writes each annotation to the destination. Between the upload completion
+    /// and the last annotation write, the destination object exists without all its annotations.</p>
+    /// </note>
+    pub annotation_directive: Option<AnnotationDirective>,
     /// <p>The name of the destination bucket.</p>
     /// <p>
     /// <b>Directory buckets</b> - When you use this operation with a directory bucket, you must use virtual-hosted-style requests in the format <code>
@@ -3773,32 +3929,36 @@ pub struct CopyObjectInput {
     /// restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html">Directory bucket naming
     /// rules</a> in the <i>Amazon S3 User Guide</i>.</p>
     /// <note>
-    /// <p>Copying objects across different Amazon Web Services Regions isn't supported when the source or destination bucket is in Amazon Web Services Local Zones. The source and destination buckets must have the same parent Amazon Web Services Region. Otherwise,
-    /// you get an HTTP <code>400 Bad Request</code> error with the error code <code>InvalidRequest</code>.</p>
+    /// <p>Copying objects across different Amazon Web Services Regions isn't supported when the source or destination
+    /// bucket is in Amazon Web Services Local Zones. The source and destination buckets must have the same parent Amazon Web Services Region.
+    /// Otherwise, you get an HTTP <code>400 Bad Request</code> error with the error code
+    /// <code>InvalidRequest</code>.</p>
     /// </note>
     /// <p>
-    /// <b>Access points</b> - When you use this action with an access point, you must provide the alias of the access point in place of the bucket name or specify the access point ARN. When using the access point ARN, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+    /// <b>Access points</b> - When you use this action with an access point for general purpose buckets, you must provide the alias of the access point in place of the bucket name or specify the access point ARN. When you use this action with an access point for directory buckets, you must provide the access point name in place of the bucket name. When using the access point ARN, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
     /// <note>
-    /// <p>Access points and Object Lambda access points are not supported by directory buckets.</p>
+    /// <p>Object Lambda access points are not supported by directory buckets.</p>
     /// </note>
     /// <p>
-    /// <b>S3 on Outposts</b> - When you use this action with S3 on Outposts, you must use the Outpost bucket access point ARN or the access point alias for the destination bucket.
-    ///
-    /// You can only copy objects within the same Outpost bucket. It's not supported to copy objects across different Amazon Web Services Outposts, between buckets on the same Outposts, or between Outposts buckets and any other bucket types.
-    /// For more information about S3 on Outposts, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">What is S3 on Outposts?</a> in the <i>S3 on Outposts guide</i>.
-    /// When you use this action with S3 on Outposts through the REST API, you must direct requests to the S3 on Outposts hostname, in the format
+    /// <b>S3 on Outposts</b> - When you use this action with S3 on Outposts,
+    /// you must use the Outpost bucket access point ARN or the access point alias for the destination bucket.
+    /// You can only copy objects within the same Outpost bucket. It's not supported to copy objects across
+    /// different Amazon Web Services Outposts, between buckets on the same Outposts, or between Outposts buckets and any
+    /// other bucket types. For more information about S3 on Outposts, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">What is S3 on Outposts?</a> in the
+    /// <i>S3 on Outposts guide</i>. When you use this action with S3 on Outposts through the REST
+    /// API, you must direct requests to the S3 on Outposts hostname, in the format
     /// <code>
-    /// <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com</code>. The hostname isn't required when you use the Amazon Web Services CLI or SDKs.
-    /// </p>
+    /// <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com</code>.
+    /// The hostname isn't required when you use the Amazon Web Services CLI or SDKs. </p>
     pub bucket: BucketName,
-    /// <p>Specifies whether Amazon S3 should use an S3 Bucket Key for object encryption with
-    /// server-side encryption using Key Management Service (KMS) keys (SSE-KMS). If a target object uses
-    /// SSE-KMS, you can enable an S3 Bucket Key for the object.</p>
-    /// <p>Setting this header to <code>true</code> causes Amazon S3 to use an S3 Bucket Key for object
-    /// encryption with SSE-KMS. Specifying this header with a COPY action doesn’t affect
-    /// bucket-level settings for S3 Bucket Key.</p>
-    /// <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the
-    /// <i>Amazon S3 User Guide</i>.</p>
+    /// <p>Specifies whether Amazon S3 should use an S3 Bucket Key for object encryption with server-side encryption
+    /// using Key Management Service (KMS) keys (SSE-KMS). If a target object uses SSE-KMS, you can enable an S3 Bucket Key
+    /// for the object.</p>
+    /// <p>Setting this header to <code>true</code> causes Amazon S3 to use an S3 Bucket Key for object encryption
+    /// with SSE-KMS. Specifying this header with a COPY action doesn’t affect bucket-level settings for S3
+    /// Bucket Key.</p>
+    /// <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3
+    /// Bucket Keys</a> in the <i>Amazon S3 User Guide</i>.</p>
     /// <note>
     /// <p>
     /// <b>Directory buckets</b> -
@@ -3811,24 +3971,22 @@ pub struct CopyObjectInput {
     /// <p>Indicates the algorithm that you want Amazon S3 to use to create the checksum for the object. For more information, see
     /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in
     /// the <i>Amazon S3 User Guide</i>.</p>
-    /// <p>When you copy an object, if the source object has a checksum, that checksum value will
-    /// be copied to the new object by default. If the <code>CopyObject</code> request does not
-    /// include this <code>x-amz-checksum-algorithm</code> header, the checksum algorithm will be
-    /// copied from the source object to the destination object (if it's present on the source
-    /// object). You can optionally specify a different checksum algorithm to use with the
-    /// <code>x-amz-checksum-algorithm</code> header. Unrecognized or unsupported values will
-    /// respond with the HTTP status code <code>400 Bad Request</code>.</p>
+    /// <p>When you copy an object, if the source object has a checksum, that checksum value will be copied to
+    /// the new object by default. If the <code>CopyObject</code> request does not include this
+    /// <code>x-amz-checksum-algorithm</code> header, the checksum algorithm will be copied from the source
+    /// object to the destination object (if it's present on the source object). You can optionally specify a
+    /// different checksum algorithm to use with the <code>x-amz-checksum-algorithm</code> header. Unrecognized
+    /// or unsupported values will respond with the HTTP status code <code>400 Bad Request</code>.</p>
     /// <note>
     /// <p>For directory buckets, when you use Amazon Web Services SDKs, <code>CRC32</code> is the default checksum algorithm that's used for performance.</p>
     /// </note>
     pub checksum_algorithm: Option<ChecksumAlgorithm>,
-    /// <p>Specifies presentational information for the object. Indicates whether an object should
-    /// be displayed in a web browser or downloaded as a file. It allows specifying the desired
-    /// filename for the downloaded file.</p>
+    /// <p>Specifies presentational information for the object. Indicates whether an object should be displayed
+    /// in a web browser or downloaded as a file. It allows specifying the desired filename for the downloaded
+    /// file.</p>
     pub content_disposition: Option<ContentDisposition>,
-    /// <p>Specifies what content encodings have been applied to the object and thus what decoding
-    /// mechanisms must be applied to obtain the media-type referenced by the Content-Type header
-    /// field.</p>
+    /// <p>Specifies what content encodings have been applied to the object and thus what decoding mechanisms
+    /// must be applied to obtain the media-type referenced by the Content-Type header field.</p>
     /// <note>
     /// <p>For directory buckets, only the <code>aws-chunked</code> value is supported in this header field.</p>
     /// </note>
@@ -3837,23 +3995,21 @@ pub struct CopyObjectInput {
     pub content_language: Option<ContentLanguage>,
     /// <p>A standard MIME type that describes the format of the object data.</p>
     pub content_type: Option<ContentType>,
-    /// <p>Specifies the source object for the copy operation. The source object can be up to 5 GB.
-    /// If the source object is an object that was uploaded by using a multipart upload, the object
-    /// copy will be a single part object after the source object is copied to the destination
-    /// bucket.</p>
-    /// <p>You specify the value of the copy source in one of two formats, depending on whether you
-    /// want to access the source object through an <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points.html">access point</a>:</p>
+    /// <p>Specifies the source object for the copy operation. The source object can be up to 5 GB. If the
+    /// source object is an object that was uploaded by using a multipart upload, the object copy will be a
+    /// single part object after the source object is copied to the destination bucket.</p>
+    /// <p>You specify the value of the copy source in one of two formats, depending on whether you want to
+    /// access the source object through an <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points.html">access point</a>:</p>
     /// <ul>
     /// <li>
-    /// <p>For objects not accessed through an access point, specify the name of the source bucket
-    /// and the key of the source object, separated by a slash (/). For example, to copy the
-    /// object <code>reports/january.pdf</code> from the general purpose bucket
-    /// <code>awsexamplebucket</code>, use
-    /// <code>awsexamplebucket/reports/january.pdf</code>. The value must be URL-encoded.
-    /// To copy the object <code>reports/january.pdf</code> from the directory bucket
+    /// <p>For objects not accessed through an access point, specify the name of the source bucket and the key of
+    /// the source object, separated by a slash (/). For example, to copy the object
+    /// <code>reports/january.pdf</code> from the general purpose bucket <code>awsexamplebucket</code>, use
+    /// <code>awsexamplebucket/reports/january.pdf</code>. The value must be URL-encoded. To copy the
+    /// object <code>reports/january.pdf</code> from the directory bucket
     /// <code>awsexamplebucket--use1-az5--x-s3</code>, use
-    /// <code>awsexamplebucket--use1-az5--x-s3/reports/january.pdf</code>. The value must
-    /// be URL-encoded.</p>
+    /// <code>awsexamplebucket--use1-az5--x-s3/reports/january.pdf</code>. The value must be
+    /// URL-encoded.</p>
     /// </li>
     /// <li>
     /// <p>For objects accessed through access points, specify the Amazon Resource Name (ARN) of the object as accessed through the access point, in the format <code>arn:aws:s3:&lt;Region&gt;:&lt;account-id&gt;:accesspoint/&lt;access-point-name&gt;/object/&lt;key&gt;</code>. For example, to copy the object <code>reports/january.pdf</code> through access point <code>my-access-point</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3:us-west-2:123456789012:accesspoint/my-access-point/object/reports/january.pdf</code>. The value must be URL encoded.</p>
@@ -3870,31 +4026,27 @@ pub struct CopyObjectInput {
     /// <p>Alternatively, for objects accessed through Amazon S3 on Outposts, specify the ARN of the object as accessed in the format <code>arn:aws:s3-outposts:&lt;Region&gt;:&lt;account-id&gt;:outpost/&lt;outpost-id&gt;/object/&lt;key&gt;</code>. For example, to copy the object <code>reports/january.pdf</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/object/reports/january.pdf</code>. The value must be URL-encoded.  </p>
     /// </li>
     /// </ul>
-    /// <p>If your source bucket versioning is enabled, the <code>x-amz-copy-source</code> header
-    /// by default identifies the current version of an object to copy. If the current version is a
-    /// delete marker, Amazon S3 behaves as if the object was deleted. To copy a different version, use
-    /// the <code>versionId</code> query parameter. Specifically, append
-    /// <code>?versionId=&lt;version-id&gt;</code> to the value (for example,
-    /// <code>awsexamplebucket/reports/january.pdf?versionId=QUpfdndhfd8438MNFDN93jdnJFkdmqnh893</code>).
-    /// If you don't specify a version ID, Amazon S3 copies the latest version of the source
-    /// object.</p>
-    /// <p>If you enable versioning on the destination bucket, Amazon S3 generates a unique version ID
-    /// for the copied object. This version ID is different from the version ID of the source
-    /// object. Amazon S3 returns the version ID of the copied object in the
-    /// <code>x-amz-version-id</code> response header in the response.</p>
-    /// <p>If you do not enable versioning or suspend it on the destination bucket, the version ID
-    /// that Amazon S3 generates in the <code>x-amz-version-id</code> response header is always
-    /// null.</p>
+    /// <p>If your source bucket versioning is enabled, the <code>x-amz-copy-source</code> header by default
+    /// identifies the current version of an object to copy. If the current version is a delete marker, Amazon S3
+    /// behaves as if the object was deleted. To copy a different version, use the <code>versionId</code> query
+    /// parameter. Specifically, append <code>?versionId=&lt;version-id&gt;</code> to the value (for example,
+    /// <code>awsexamplebucket/reports/january.pdf?versionId=QUpfdndhfd8438MNFDN93jdnJFkdmqnh893</code>). If
+    /// you don't specify a version ID, Amazon S3 copies the latest version of the source object.</p>
+    /// <p>If you enable versioning on the destination bucket, Amazon S3 generates a unique version ID for the
+    /// copied object. This version ID is different from the version ID of the source object. Amazon S3 returns the
+    /// version ID of the copied object in the <code>x-amz-version-id</code> response header in the
+    /// response.</p>
+    /// <p>If you do not enable versioning or suspend it on the destination bucket, the version ID that Amazon S3
+    /// generates in the <code>x-amz-version-id</code> response header is always null.</p>
     /// <note>
     /// <p>
-    /// <b>Directory buckets</b> -
-    /// S3 Versioning isn't enabled and supported for directory buckets.</p>
+    /// <b>Directory buckets</b> - S3 Versioning isn't enabled and supported for directory buckets.</p>
     /// </note>
     pub copy_source: CopySource,
     /// <p>Copies the object if its entity tag (ETag) matches the specified tag.</p>
     /// <p> If both the <code>x-amz-copy-source-if-match</code> and
-    /// <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the request
-    /// and evaluate as follows, Amazon S3 returns <code>200 OK</code> and copies the data:</p>
+    /// <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the request and evaluate as
+    /// follows, Amazon S3 returns <code>200 OK</code> and copies the data:</p>
     /// <ul>
     /// <li>
     /// <p>
@@ -3902,16 +4054,14 @@ pub struct CopyObjectInput {
     /// </li>
     /// <li>
     /// <p>
-    /// <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to
-    /// false</p>
+    /// <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to false</p>
     /// </li>
     /// </ul>
     pub copy_source_if_match: Option<CopySourceIfMatch>,
     /// <p>Copies the object if it has been modified since the specified time.</p>
     /// <p>If both the <code>x-amz-copy-source-if-none-match</code> and
-    /// <code>x-amz-copy-source-if-modified-since</code> headers are present in the request and
-    /// evaluate as follows, Amazon S3 returns the <code>412 Precondition Failed</code> response
-    /// code:</p>
+    /// <code>x-amz-copy-source-if-modified-since</code> headers are present in the request and evaluate as
+    /// follows, Amazon S3 returns the <code>412 Precondition Failed</code> response code:</p>
     /// <ul>
     /// <li>
     /// <p>
@@ -3919,16 +4069,14 @@ pub struct CopyObjectInput {
     /// </li>
     /// <li>
     /// <p>
-    /// <code>x-amz-copy-source-if-modified-since</code> condition evaluates to
-    /// true</p>
+    /// <code>x-amz-copy-source-if-modified-since</code> condition evaluates to true</p>
     /// </li>
     /// </ul>
     pub copy_source_if_modified_since: Option<CopySourceIfModifiedSince>,
     /// <p>Copies the object if its entity tag (ETag) is different than the specified ETag.</p>
     /// <p>If both the <code>x-amz-copy-source-if-none-match</code> and
-    /// <code>x-amz-copy-source-if-modified-since</code> headers are present in the request and
-    /// evaluate as follows, Amazon S3 returns the <code>412 Precondition Failed</code> response
-    /// code:</p>
+    /// <code>x-amz-copy-source-if-modified-since</code> headers are present in the request and evaluate as
+    /// follows, Amazon S3 returns the <code>412 Precondition Failed</code> response code:</p>
     /// <ul>
     /// <li>
     /// <p>
@@ -3936,15 +4084,14 @@ pub struct CopyObjectInput {
     /// </li>
     /// <li>
     /// <p>
-    /// <code>x-amz-copy-source-if-modified-since</code> condition evaluates to
-    /// true</p>
+    /// <code>x-amz-copy-source-if-modified-since</code> condition evaluates to true</p>
     /// </li>
     /// </ul>
     pub copy_source_if_none_match: Option<CopySourceIfNoneMatch>,
     /// <p>Copies the object if it hasn't been modified since the specified time.</p>
     /// <p> If both the <code>x-amz-copy-source-if-match</code> and
-    /// <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the request
-    /// and evaluate as follows, Amazon S3 returns <code>200 OK</code> and copies the data:</p>
+    /// <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the request and evaluate as
+    /// follows, Amazon S3 returns <code>200 OK</code> and copies the data:</p>
     /// <ul>
     /// <li>
     /// <p>
@@ -3952,36 +4099,31 @@ pub struct CopyObjectInput {
     /// </li>
     /// <li>
     /// <p>
-    /// <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to
-    /// false</p>
+    /// <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to false</p>
     /// </li>
     /// </ul>
     pub copy_source_if_unmodified_since: Option<CopySourceIfUnmodifiedSince>,
     /// <p>Specifies the algorithm to use when decrypting the source object (for example,
     /// <code>AES256</code>).</p>
-    /// <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the
-    /// necessary encryption information in your request so that Amazon S3 can decrypt the object for
-    /// copying.</p>
+    /// <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the necessary
+    /// encryption information in your request so that Amazon S3 can decrypt the object for copying.</p>
     /// <note>
     /// <p>This functionality is not supported when the source object is in a directory bucket.</p>
     /// </note>
     pub copy_source_sse_customer_algorithm: Option<CopySourceSSECustomerAlgorithm>,
-    /// <p>Specifies the customer-provided encryption key for Amazon S3 to use to decrypt the source
-    /// object. The encryption key provided in this header must be the same one that was used when
-    /// the source object was created.</p>
-    /// <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the
-    /// necessary encryption information in your request so that Amazon S3 can decrypt the object for
-    /// copying.</p>
+    /// <p>Specifies the customer-provided encryption key for Amazon S3 to use to decrypt the source object. The
+    /// encryption key provided in this header must be the same one that was used when the source object was
+    /// created.</p>
+    /// <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the necessary
+    /// encryption information in your request so that Amazon S3 can decrypt the object for copying.</p>
     /// <note>
     /// <p>This functionality is not supported when the source object is in a directory bucket.</p>
     /// </note>
     pub copy_source_sse_customer_key: Option<CopySourceSSECustomerKey>,
-    /// <p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses
-    /// this header for a message integrity check to ensure that the encryption key was transmitted
-    /// without error.</p>
-    /// <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the
-    /// necessary encryption information in your request so that Amazon S3 can decrypt the object for
-    /// copying.</p>
+    /// <p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses this header
+    /// for a message integrity check to ensure that the encryption key was transmitted without error.</p>
+    /// <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the necessary
+    /// encryption information in your request so that Amazon S3 can decrypt the object for copying.</p>
     /// <note>
     /// <p>This functionality is not supported when the source object is in a directory bucket.</p>
     /// </note>
@@ -4040,26 +4182,38 @@ pub struct CopyObjectInput {
     /// </ul>
     /// </note>
     pub grant_write_acp: Option<GrantWriteACP>,
+    /// <p>Copies the object if the entity tag (ETag) of the destination object matches the specified
+    /// tag. If the ETag values do not match, the operation returns a <code>412 Precondition
+    /// Failed</code> error. If a concurrent operation occurs during the upload S3 returns a
+    /// <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should fetch the
+    /// object's ETag and retry the upload.</p>
+    /// <p>Expects the ETag value as a string.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub if_match: Option<IfMatch>,
+    /// <p>Copies the object only if the object key name at the destination does not already exist in
+    /// the bucket specified. Otherwise, Amazon S3 returns a <code>412 Precondition Failed</code> error. If a
+    /// concurrent operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code>
+    /// response. On a 409 failure you should retry the upload.</p>
+    /// <p>Expects the '*' (asterisk) character.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub if_none_match: Option<IfNoneMatch>,
     /// <p>The key of the destination object.</p>
     pub key: ObjectKey,
     /// <p>A map of metadata to store with the object in S3.</p>
     pub metadata: Option<Metadata>,
-    /// <p>Specifies whether the metadata is copied from the source object or replaced with
-    /// metadata that's provided in the request. When copying an object, you can preserve all
-    /// metadata (the default) or specify new metadata. If this header isn’t specified,
-    /// <code>COPY</code> is the default behavior. </p>
+    /// <p>Specifies whether the metadata is copied from the source object or replaced with metadata that's
+    /// provided in the request. When copying an object, you can preserve all metadata (the default) or specify
+    /// new metadata. If this header isn’t specified, <code>COPY</code> is the default behavior. </p>
     /// <p>
-    /// <b>General purpose bucket</b> - For general purpose buckets, when you
-    /// grant permissions, you can use the <code>s3:x-amz-metadata-directive</code> condition key
-    /// to enforce certain metadata behavior when objects are uploaded. For more information, see
-    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html">Amazon S3
-    /// condition key examples</a> in the <i>Amazon S3 User Guide</i>.</p>
+    /// <b>General purpose bucket</b> - For general purpose buckets, when you grant
+    /// permissions, you can use the <code>s3:x-amz-metadata-directive</code> condition key to enforce certain
+    /// metadata behavior when objects are uploaded. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html">Amazon S3 condition key examples</a> in the
+    /// <i>Amazon S3 User Guide</i>.</p>
     /// <note>
     /// <p>
-    /// <code>x-amz-website-redirect-location</code> is unique to each object and is not
-    /// copied when using the <code>x-amz-metadata-directive</code> header. To copy the value,
-    /// you must specify <code>x-amz-website-redirect-location</code> in the request
-    /// header.</p>
+    /// <code>x-amz-website-redirect-location</code> is unique to each object and is not copied when using
+    /// the <code>x-amz-metadata-directive</code> header. To copy the value, you must specify
+    /// <code>x-amz-website-redirect-location</code> in the request header.</p>
     /// </note>
     pub metadata_directive: Option<MetadataDirective>,
     /// <p>Specifies whether you want to apply a legal hold to the object copy.</p>
@@ -4078,50 +4232,46 @@ pub struct CopyObjectInput {
     /// </note>
     pub object_lock_retain_until_date: Option<ObjectLockRetainUntilDate>,
     pub request_payer: Option<RequestPayer>,
-    /// <p>Specifies the algorithm to use when encrypting the object (for example,
-    /// <code>AES256</code>).</p>
-    /// <p>When you perform a <code>CopyObject</code> operation, if you want to use a different
-    /// type of encryption setting for the target object, you can specify appropriate
-    /// encryption-related headers to encrypt the target object with an Amazon S3 managed key, a
-    /// KMS key, or a customer-provided key. If the encryption setting in your request is
-    /// different from the default encryption configuration of the destination bucket, the
-    /// encryption setting in your request takes precedence. </p>
+    /// <p>Specifies the algorithm to use when encrypting the object (for example, <code>AES256</code>).</p>
+    /// <p>When you perform a <code>CopyObject</code> operation, if you want to use a different type of
+    /// encryption setting for the target object, you can specify appropriate encryption-related headers to
+    /// encrypt the target object with an Amazon S3 managed key, a KMS key, or a customer-provided key. If the
+    /// encryption setting in your request is different from the default encryption configuration of the
+    /// destination bucket, the encryption setting in your request takes precedence. </p>
     /// <note>
     /// <p>This functionality is not supported when the destination bucket is a directory bucket.</p>
     /// </note>
     pub sse_customer_algorithm: Option<SSECustomerAlgorithm>,
-    /// <p>Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This
-    /// value is used to store the object and then it is discarded. Amazon S3 does not store the
-    /// encryption key. The key must be appropriate for use with the algorithm specified in the
+    /// <p>Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This value is
+    /// used to store the object and then it is discarded. Amazon S3 does not store the encryption key. The key must
+    /// be appropriate for use with the algorithm specified in the
     /// <code>x-amz-server-side-encryption-customer-algorithm</code> header.</p>
     /// <note>
     /// <p>This functionality is not supported when the destination bucket is a directory bucket.</p>
     /// </note>
     pub sse_customer_key: Option<SSECustomerKey>,
-    /// <p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses
-    /// this header for a message integrity check to ensure that the encryption key was transmitted
-    /// without error.</p>
+    /// <p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses this header
+    /// for a message integrity check to ensure that the encryption key was transmitted without error.</p>
     /// <note>
     /// <p>This functionality is not supported when the destination bucket is a directory bucket.</p>
     /// </note>
     pub sse_customer_key_md5: Option<SSECustomerKeyMD5>,
-    /// <p>Specifies the Amazon Web Services KMS Encryption Context as an additional encryption context to use
-    /// for the destination object encryption. The value of this header is a base64-encoded UTF-8 string holding JSON with the encryption context key-value pairs.</p>
+    /// <p>Specifies the Amazon Web Services KMS Encryption Context as an additional encryption context to use for the
+    /// destination object encryption. The value of this header is a base64-encoded UTF-8 string holding JSON
+    /// with the encryption context key-value pairs.</p>
     /// <p>
-    /// <b>General purpose buckets</b> - This value must be explicitly
-    /// added to specify encryption context for <code>CopyObject</code> requests if you want an
-    /// additional encryption context for your destination object. The additional encryption
-    /// context of the source object won't be copied to the destination object. For more
-    /// information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html#encryption-context">Encryption
-    /// context</a> in the <i>Amazon S3 User Guide</i>.</p>
+    /// <b>General purpose buckets</b> - This value must be explicitly added to
+    /// specify encryption context for <code>CopyObject</code> requests if you want an additional encryption
+    /// context for your destination object. The additional encryption context of the source object won't be
+    /// copied to the destination object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html#encryption-context">Encryption context</a>
+    /// in the <i>Amazon S3 User Guide</i>.</p>
     /// <p>
     /// <b>Directory buckets</b> - You can optionally provide an explicit encryption context value. The value must match the default encryption context - the bucket Amazon Resource Name (ARN). An additional encryption context value is not supported. </p>
     pub ssekms_encryption_context: Option<SSEKMSEncryptionContext>,
-    /// <p>Specifies the KMS key ID (Key ID, Key ARN, or Key Alias) to use for object encryption.
-    /// All GET and PUT requests for an object protected by KMS will fail if they're not made via
-    /// SSL or using SigV4. For information about configuring any of the officially supported Amazon Web Services
-    /// SDKs and Amazon Web Services CLI, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version">Specifying the
-    /// Signature Version in Request Authentication</a> in the
+    /// <p>Specifies the KMS key ID (Key ID, Key ARN, or Key Alias) to use for object encryption. All GET and
+    /// PUT requests for an object protected by KMS will fail if they're not made via SSL or using SigV4. For
+    /// information about configuring any of the officially supported Amazon Web Services SDKs and Amazon Web Services CLI, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version">Specifying
+    /// the Signature Version in Request Authentication</a> in the
     /// <i>Amazon S3 User Guide</i>.</p>
     /// <p>
     /// <b>Directory buckets</b> -
@@ -4133,37 +4283,35 @@ pub struct CopyObjectInput {
     ///
     /// Incorrect key specification results in an HTTP <code>400 Bad Request</code> error. </p>
     pub ssekms_key_id: Option<SSEKMSKeyId>,
-    /// <p>The server-side encryption algorithm used when storing this object in Amazon S3. Unrecognized
-    /// or unsupported values won’t write a destination object and will receive a <code>400 Bad
-    /// Request</code> response. </p>
-    /// <p>Amazon S3 automatically encrypts all new objects that are copied to an S3 bucket. When
-    /// copying an object, if you don't specify encryption information in your copy request, the
-    /// encryption setting of the target object is set to the default encryption configuration of
-    /// the destination bucket. By default, all buckets have a base level of encryption
-    /// configuration that uses server-side encryption with Amazon S3 managed keys (SSE-S3). If the
-    /// destination bucket has a different default encryption configuration, Amazon S3 uses the
+    /// <p>The server-side encryption algorithm used when storing this object in Amazon S3. Unrecognized or
+    /// unsupported values won’t write a destination object and will receive a <code>400 Bad Request</code>
+    /// response. </p>
+    /// <p>Amazon S3 automatically encrypts all new objects that are copied to an S3 bucket. When copying an object,
+    /// if you don't specify encryption information in your copy request, the encryption setting of the target
+    /// object is set to the default encryption configuration of the destination bucket. By default, all buckets
+    /// have a base level of encryption configuration that uses server-side encryption with Amazon S3 managed keys
+    /// (SSE-S3). If the destination bucket has a different default encryption configuration, Amazon S3 uses the
     /// corresponding encryption key to encrypt the target object copy.</p>
-    /// <p>With server-side encryption, Amazon S3 encrypts your data as it writes your data to disks in
-    /// its data centers and decrypts the data when you access it. For more information about
-    /// server-side encryption, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Using Server-Side Encryption</a>
-    /// in the <i>Amazon S3 User Guide</i>.</p>
+    /// <p>With server-side encryption, Amazon S3 encrypts your data as it writes your data to disks in its data
+    /// centers and decrypts the data when you access it. For more information about server-side encryption, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Using Server-Side
+    /// Encryption</a> in the <i>Amazon S3 User Guide</i>.</p>
     /// <p>
     /// <b>General purpose buckets </b>
     /// </p>
     /// <ul>
     /// <li>
-    /// <p>For general purpose buckets, there are the following supported options for server-side
-    /// encryption: server-side encryption with Key Management Service (KMS) keys (SSE-KMS), dual-layer
-    /// server-side encryption with Amazon Web Services KMS keys (DSSE-KMS), and server-side encryption
-    /// with customer-provided encryption keys (SSE-C). Amazon S3 uses the corresponding
-    /// KMS key, or a customer-provided key to encrypt the target object copy.</p>
+    /// <p>For general purpose buckets, there are the following supported options for server-side encryption:
+    /// server-side encryption with Key Management Service (KMS) keys (SSE-KMS), dual-layer server-side encryption with
+    /// Amazon Web Services KMS keys (DSSE-KMS), and server-side encryption with customer-provided encryption keys
+    /// (SSE-C). Amazon S3 uses the corresponding KMS key, or a customer-provided key to encrypt the target
+    /// object copy.</p>
     /// </li>
     /// <li>
-    /// <p>When you perform a <code>CopyObject</code> operation, if you want to use a
-    /// different type of encryption setting for the target object, you can specify
-    /// appropriate encryption-related headers to encrypt the target object with an Amazon S3
-    /// managed key, a KMS key, or a customer-provided key. If the encryption setting in
-    /// your request is different from the default encryption configuration of the
+    /// <p>When you perform a <code>CopyObject</code> operation, if you want to use a different type of
+    /// encryption setting for the target object, you can specify appropriate encryption-related headers to
+    /// encrypt the target object with an Amazon S3 managed key, a KMS key, or a customer-provided key. If the
+    /// encryption setting in your request is different from the default encryption configuration of the
     /// destination bucket, the encryption setting in your request takes precedence. </p>
     /// </li>
     /// </ul>
@@ -4178,67 +4326,73 @@ pub struct CopyObjectInput {
     /// information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-serv-side-encryption.html">Protecting data with server-side encryption</a> in the <i>Amazon S3 User Guide</i>. For more information about the encryption overriding behaviors in directory buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-specifying-kms-encryption.html">Specifying server-side encryption with KMS for new object uploads</a>.</p>
     /// </li>
     /// <li>
-    /// <p>To encrypt new object copies to a directory bucket with SSE-KMS, we recommend you
-    /// specify SSE-KMS as the directory bucket's default encryption configuration with
-    /// a KMS key (specifically, a <a href="https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk">customer managed key</a>).
-    /// The <a href="https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk">Amazon Web Services managed key</a> (<code>aws/s3</code>) isn't supported. Your SSE-KMS
-    /// configuration can only support 1 <a href="https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk">customer managed key</a> per
-    /// directory bucket for the lifetime of the bucket. After you specify a customer managed key for
-    /// SSE-KMS, you can't override the customer managed key for the bucket's SSE-KMS
-    /// configuration. Then, when you perform a <code>CopyObject</code> operation and want to
-    /// specify server-side encryption settings for new object copies with SSE-KMS in the
-    /// encryption-related request headers, you must ensure the encryption key is the same
-    /// customer managed key that you specified for the directory bucket's default encryption
-    /// configuration.
+    /// <p>To encrypt new object copies to a directory bucket with SSE-KMS, we recommend you specify
+    /// SSE-KMS as the directory bucket's default encryption configuration with a KMS key
+    /// (specifically, a <a href="https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk">customer managed key</a>). The <a href="https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk">Amazon Web Services managed key</a> (<code>aws/s3</code>) isn't supported. Your SSE-KMS configuration can
+    /// only support 1 <a href="https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk">customer managed key</a> per
+    /// directory bucket for the lifetime of the bucket. After you specify a customer managed key for SSE-KMS, you
+    /// can't override the customer managed key for the bucket's SSE-KMS configuration. Then, when you
+    /// perform a <code>CopyObject</code> operation and want to specify server-side encryption settings for
+    /// new object copies with SSE-KMS in the encryption-related request headers, you must ensure the
+    /// encryption key is the same customer managed key that you specified for the directory bucket's default
+    /// encryption configuration.
     /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <b>S3 access points for Amazon FSx </b> - When accessing data stored in
+    /// Amazon FSx file systems using S3 access points, the only valid server side encryption option is
+    /// <code>aws:fsx</code>. All Amazon FSx file systems have encryption configured by default and are
+    /// encrypted at rest. Data is automatically encrypted before being written to the file system, and
+    /// automatically decrypted as it is read. These processes are handled transparently by Amazon FSx.</p>
     /// </li>
     /// </ul>
     pub server_side_encryption: Option<ServerSideEncryption>,
-    /// <p>If the <code>x-amz-storage-class</code> header is not used, the copied object will be
-    /// stored in the <code>STANDARD</code> Storage Class by default. The <code>STANDARD</code>
-    /// storage class provides high durability and high availability. Depending on performance
-    /// needs, you can specify a different Storage Class. </p>
+    /// <p>If the <code>x-amz-storage-class</code> header is not used, the copied object will be stored in the
+    /// <code>STANDARD</code> Storage Class by default. The <code>STANDARD</code> storage class provides high
+    /// durability and high availability. Depending on performance needs, you can specify a different Storage
+    /// Class. </p>
     /// <note>
     /// <ul>
     /// <li>
     /// <p>
     /// <b>Directory buckets </b> -
-    /// For directory buckets, only the S3 Express One Zone storage class is supported to store newly created objects.
+    /// Directory buckets only support <code>EXPRESS_ONEZONE</code> (the S3 Express One Zone storage class) in Availability Zones and <code>ONEZONE_IA</code> (the S3 One Zone-Infrequent Access storage class) in Dedicated Local Zones.  
     /// Unsupported storage class values won't write a destination object and will respond with the HTTP status code <code>400 Bad Request</code>.</p>
     /// </li>
     /// <li>
     /// <p>
-    /// <b>Amazon S3 on Outposts </b> - S3 on Outposts only
-    /// uses the <code>OUTPOSTS</code> Storage Class.</p>
+    /// <b>Amazon S3 on Outposts </b> - S3 on Outposts only uses the
+    /// <code>OUTPOSTS</code> Storage Class.</p>
     /// </li>
     /// </ul>
     /// </note>
-    /// <p>You can use the <code>CopyObject</code> action to change the storage class of an object
-    /// that is already stored in Amazon S3 by using the <code>x-amz-storage-class</code> header. For
-    /// more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage Classes</a> in the
-    /// <i>Amazon S3 User Guide</i>.</p>
-    /// <p>Before using an object as a source object for the copy operation, you must restore a
-    /// copy of it if it meets any of the following conditions:</p>
+    /// <p>You can use the <code>CopyObject</code> action to change the storage class of an object that is
+    /// already stored in Amazon S3 by using the <code>x-amz-storage-class</code> header. For more information, see
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage Classes</a>
+    /// in the <i>Amazon S3 User Guide</i>.</p>
+    /// <p>Before using an object as a source object for the copy operation, you must restore a copy of it if
+    /// it meets any of the following conditions:</p>
     /// <ul>
     /// <li>
     /// <p>The storage class of the source object is <code>GLACIER</code> or
     /// <code>DEEP_ARCHIVE</code>.</p>
     /// </li>
     /// <li>
-    /// <p>The storage class of the source object is <code>INTELLIGENT_TIERING</code> and
-    /// it's <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering-overview.html#intel-tiering-tier-definition">S3 Intelligent-Tiering access tier</a> is <code>Archive Access</code> or
-    /// <code>Deep Archive Access</code>.</p>
+    /// <p>The storage class of the source object is <code>INTELLIGENT_TIERING</code> and it's <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering-overview.html#intel-tiering-tier-definition">S3
+    /// Intelligent-Tiering access tier</a> is <code>Archive Access</code> or <code>Deep Archive
+    /// Access</code>.</p>
     /// </li>
     /// </ul>
-    /// <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html">RestoreObject</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjectsExamples.html">Copying
-    /// Objects</a> in the <i>Amazon S3 User Guide</i>.</p>
+    /// <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html">RestoreObject</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjectsExamples.html">Copying Objects</a> in the
+    /// <i>Amazon S3 User Guide</i>.</p>
     pub storage_class: Option<StorageClass>,
-    /// <p>The tag-set for the object copy in the destination bucket. This value must be used in
-    /// conjunction with the <code>x-amz-tagging-directive</code> if you choose
-    /// <code>REPLACE</code> for the <code>x-amz-tagging-directive</code>. If you choose
-    /// <code>COPY</code> for the <code>x-amz-tagging-directive</code>, you don't need to set
-    /// the <code>x-amz-tagging</code> header, because the tag-set will be copied from the source
-    /// object directly. The tag-set must be encoded as URL Query parameters.</p>
+    /// <p>The tag-set for the object copy in the destination bucket. This value must be used in conjunction
+    /// with the <code>x-amz-tagging-directive</code> if you choose <code>REPLACE</code> for the
+    /// <code>x-amz-tagging-directive</code>. If you choose <code>COPY</code> for the
+    /// <code>x-amz-tagging-directive</code>, you don't need to set the <code>x-amz-tagging</code> header,
+    /// because the tag-set will be copied from the source object directly. The tag-set must be encoded as URL
+    /// Query parameters.</p>
     /// <p>The default value is the empty value.</p>
     /// <note>
     /// <p>
@@ -4272,8 +4426,8 @@ pub struct CopyObjectInput {
     /// </ul>
     /// </note>
     pub tagging: Option<TaggingHeader>,
-    /// <p>Specifies whether the object tag-set is copied from the source object or replaced with
-    /// the tag-set that's provided in the request.</p>
+    /// <p>Specifies whether the object tag-set is copied from the source object or replaced with the tag-set
+    /// that's provided in the request.</p>
     /// <p>The default value is <code>COPY</code>.</p>
     /// <note>
     /// <p>
@@ -4308,12 +4462,11 @@ pub struct CopyObjectInput {
     /// </note>
     pub tagging_directive: Option<TaggingDirective>,
     pub version_id: Option<ObjectVersionId>,
-    /// <p>If the destination bucket is configured as a website, redirects requests for this object
-    /// copy to another object in the same bucket or to an external URL. Amazon S3 stores the value of
-    /// this header in the object metadata. This value is unique to each object and is not copied
-    /// when using the <code>x-amz-metadata-directive</code> header. Instead, you may opt to
-    /// provide this header in combination with the <code>x-amz-metadata-directive</code>
-    /// header.</p>
+    /// <p>If the destination bucket is configured as a website, redirects requests for this object copy to
+    /// another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the
+    /// object metadata. This value is unique to each object and is not copied when using the
+    /// <code>x-amz-metadata-directive</code> header. Instead, you may opt to provide this header in
+    /// combination with the <code>x-amz-metadata-directive</code> header.</p>
     /// <note>
     /// <p>This functionality is not supported for directory buckets.</p>
     /// </note>
@@ -4325,6 +4478,9 @@ impl fmt::Debug for CopyObjectInput {
         let mut d = f.debug_struct("CopyObjectInput");
         if let Some(ref val) = self.acl {
             d.field("acl", val);
+        }
+        if let Some(ref val) = self.annotation_directive {
+            d.field("annotation_directive", val);
         }
         d.field("bucket", &self.bucket);
         if let Some(ref val) = self.bucket_key_enabled {
@@ -4390,6 +4546,12 @@ impl fmt::Debug for CopyObjectInput {
         }
         if let Some(ref val) = self.grant_write_acp {
             d.field("grant_write_acp", val);
+        }
+        if let Some(ref val) = self.if_match {
+            d.field("if_match", val);
+        }
+        if let Some(ref val) = self.if_none_match {
+            d.field("if_none_match", val);
         }
         d.field("key", &self.key);
         if let Some(ref val) = self.metadata {
@@ -4449,6 +4611,9 @@ impl fmt::Debug for CopyObjectInput {
         if let Some(ref val) = self.acl {
             d.field("acl", val);
         }
+        if let Some(ref val) = self.annotation_directive {
+            d.field("annotation_directive", val);
+        }
         d.field("bucket", &self.bucket);
         if let Some(ref val) = self.bucket_key_enabled {
             d.field("bucket_key_enabled", val);
@@ -4513,6 +4678,12 @@ impl fmt::Debug for CopyObjectInput {
         }
         if let Some(ref val) = self.grant_write_acp {
             d.field("grant_write_acp", val);
+        }
+        if let Some(ref val) = self.if_match {
+            d.field("if_match", val);
+        }
+        if let Some(ref val) = self.if_none_match {
+            d.field("if_none_match", val);
         }
         d.field("key", &self.key);
         if let Some(ref val) = self.metadata {
@@ -4583,6 +4754,11 @@ impl DtoExt for CopyObjectInput {
             && val.as_str() == ""
         {
             self.acl = None;
+        }
+        if let Some(ref val) = self.annotation_directive
+            && val.as_str() == ""
+        {
+            self.annotation_directive = None;
         }
         if self.cache_control.as_deref() == Some("") {
             self.cache_control = None;
@@ -4692,6 +4868,11 @@ impl DtoExt for CopyObjectInput {
             && val.as_str() == ""
         {
             self.acl = None;
+        }
+        if let Some(ref val) = self.annotation_directive
+            && val.as_str() == ""
+        {
+            self.annotation_directive = None;
         }
         if self.cache_control.as_deref() == Some("") {
             self.cache_control = None;
@@ -8323,6 +8504,104 @@ impl FromStr for DeleteMarkerReplicationStatus {
 pub type DeleteMarkerVersionId = String;
 
 pub type DeleteMarkers = List<DeleteMarkerEntry>;
+
+#[derive(Clone, Default, PartialEq)]
+pub struct DeleteObjectAnnotationInput {
+    /// <p>The name of the annotation to delete. Annotation names are UTF-8 encoded and cannot start with
+    /// <code>aws</code> or <code>s3</code> (case-insensitive).</p>
+    /// <p>Length Constraints: Minimum length of 1. Maximum length of 512 bytes.</p>
+    pub annotation_name: AnnotationName,
+    /// <p>The name of the bucket that contains the object.</p>
+    pub bucket: BucketName,
+    /// <p>The account ID of the expected bucket owner.</p>
+    pub expected_bucket_owner: Option<AccountId>,
+    /// <p>The object key.</p>
+    pub key: ObjectKey,
+    /// <p>If specified, the operation only succeeds if the object's ETag matches the provided value.</p>
+    pub object_if_match: Option<ObjectIfMatch>,
+    pub request_payer: Option<RequestPayer>,
+    /// <p>The version ID of the object.</p>
+    pub version_id: Option<ObjectVersionId>,
+}
+
+impl fmt::Debug for DeleteObjectAnnotationInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("DeleteObjectAnnotationInput");
+        d.field("annotation_name", &self.annotation_name);
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.field("key", &self.key);
+        if let Some(ref val) = self.object_if_match {
+            d.field("object_if_match", val);
+        }
+        if let Some(ref val) = self.request_payer {
+            d.field("request_payer", val);
+        }
+        if let Some(ref val) = self.version_id {
+            d.field("version_id", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl DeleteObjectAnnotationInput {
+    #[must_use]
+    pub fn builder() -> builders::DeleteObjectAnnotationInputBuilder {
+        default()
+    }
+}
+impl DtoExt for DeleteObjectAnnotationInput {
+    fn ignore_empty_strings(&mut self) {
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+        if self.object_if_match.as_deref() == Some("") {
+            self.object_if_match = None;
+        }
+        if let Some(ref val) = self.request_payer
+            && val.as_str() == ""
+        {
+            self.request_payer = None;
+        }
+        if self.version_id.as_deref() == Some("") {
+            self.version_id = None;
+        }
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct DeleteObjectAnnotationOutput {
+    /// <p>The version ID of the object that the annotation was deleted from.</p>
+    pub object_version_id: Option<ObjectVersionId>,
+    pub request_charged: Option<RequestCharged>,
+}
+
+impl fmt::Debug for DeleteObjectAnnotationOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("DeleteObjectAnnotationOutput");
+        if let Some(ref val) = self.object_version_id {
+            d.field("object_version_id", val);
+        }
+        if let Some(ref val) = self.request_charged {
+            d.field("request_charged", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+impl DtoExt for DeleteObjectAnnotationOutput {
+    fn ignore_empty_strings(&mut self) {
+        if self.object_version_id.as_deref() == Some("") {
+            self.object_version_id = None;
+        }
+        if let Some(ref val) = self.request_charged
+            && val.as_str() == ""
+        {
+            self.request_charged = None;
+        }
+    }
+}
 
 #[derive(Clone, Default, PartialEq)]
 pub struct DeleteObjectInput {
@@ -13315,6 +13594,235 @@ impl DtoExt for GetObjectAclOutput {
 }
 
 #[derive(Clone, Default, PartialEq)]
+pub struct GetObjectAnnotationInput {
+    /// <p>The name of the annotation to retrieve.</p>
+    /// <p>Length Constraints: Minimum length of 1. Maximum length of 512 bytes.</p>
+    pub annotation_name: AnnotationName,
+    /// <p>The name of the bucket that contains the object.</p>
+    pub bucket: BucketName,
+    /// <p>Set to <code>ENABLED</code> to validate the checksum of the annotation payload on retrieval.</p>
+    pub checksum_mode: Option<ChecksumMode>,
+    /// <p>The account ID of the expected bucket owner. If the bucket is owned by a different account, the request fails with an HTTP 403 (Access Denied) error.</p>
+    pub expected_bucket_owner: Option<AccountId>,
+    /// <p>The object key.</p>
+    pub key: ObjectKey,
+    pub request_payer: Option<RequestPayer>,
+    /// <p>The version ID of the object.</p>
+    pub version_id: Option<ObjectVersionId>,
+}
+
+impl fmt::Debug for GetObjectAnnotationInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("GetObjectAnnotationInput");
+        d.field("annotation_name", &self.annotation_name);
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.checksum_mode {
+            d.field("checksum_mode", val);
+        }
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.field("key", &self.key);
+        if let Some(ref val) = self.request_payer {
+            d.field("request_payer", val);
+        }
+        if let Some(ref val) = self.version_id {
+            d.field("version_id", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl GetObjectAnnotationInput {
+    #[must_use]
+    pub fn builder() -> builders::GetObjectAnnotationInputBuilder {
+        default()
+    }
+}
+impl DtoExt for GetObjectAnnotationInput {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref val) = self.checksum_mode
+            && val.as_str() == ""
+        {
+            self.checksum_mode = None;
+        }
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+        if let Some(ref val) = self.request_payer
+            && val.as_str() == ""
+        {
+            self.request_payer = None;
+        }
+        if self.version_id.as_deref() == Some("") {
+            self.version_id = None;
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct GetObjectAnnotationOutput {
+    /// <p>The annotation payload.</p>
+    pub annotation_payload: Option<StreamingBlob>,
+    /// <p>The CRC32 checksum of the annotation payload.</p>
+    pub checksum_crc32: Option<ChecksumCRC32>,
+    /// <p>The CRC32C checksum of the annotation payload.</p>
+    pub checksum_crc32c: Option<ChecksumCRC32C>,
+    /// <p>The CRC64NVME checksum of the annotation payload.</p>
+    pub checksum_crc64nvme: Option<ChecksumCRC64NVME>,
+    /// <p>The MD5 checksum of the annotation payload.</p>
+    pub checksum_md5: Option<ChecksumMD5>,
+    /// <p>The SHA1 checksum of the annotation payload.</p>
+    pub checksum_sha1: Option<ChecksumSHA1>,
+    /// <p>The SHA256 checksum of the annotation payload.</p>
+    pub checksum_sha256: Option<ChecksumSHA256>,
+    /// <p>The SHA512 checksum of the annotation payload.</p>
+    pub checksum_sha512: Option<ChecksumSHA512>,
+    /// <p>The type of checksum used.</p>
+    pub checksum_type: Option<ChecksumType>,
+    /// <p>The XXHASH128 checksum of the annotation payload.</p>
+    pub checksum_xxhash128: Option<ChecksumXXHASH128>,
+    /// <p>The XXHASH3 checksum of the annotation payload.</p>
+    pub checksum_xxhash3: Option<ChecksumXXHASH3>,
+    /// <p>The XXHASH64 checksum of the annotation payload.</p>
+    pub checksum_xxhash64: Option<ChecksumXXHASH64>,
+    /// <p>The size of the annotation payload, in bytes.</p>
+    pub content_length: Option<ContentLength>,
+    /// <p>The entity tag of the annotation.</p>
+    pub e_tag: Option<ETag>,
+    /// <p>The date and time the annotation was last modified.</p>
+    pub last_modified: Option<LastModified>,
+    /// <p>The version ID of the object that the annotation is attached to.</p>
+    pub object_version_id: Option<ObjectVersionId>,
+    /// <p>The replication status of the annotation. Possible values include <code>PENDING</code>, <code>COMPLETED</code>, <code>FAILED</code>, and <code>REPLICA</code>.</p>
+    pub replication_status: Option<ReplicationStatus>,
+    pub request_charged: Option<RequestCharged>,
+    /// <p>The server-side encryption algorithm used.</p>
+    pub server_side_encryption: Option<ServerSideEncryption>,
+}
+
+impl fmt::Debug for GetObjectAnnotationOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("GetObjectAnnotationOutput");
+        if let Some(ref val) = self.annotation_payload {
+            d.field("annotation_payload", val);
+        }
+        if let Some(ref val) = self.checksum_crc32 {
+            d.field("checksum_crc32", val);
+        }
+        if let Some(ref val) = self.checksum_crc32c {
+            d.field("checksum_crc32c", val);
+        }
+        if let Some(ref val) = self.checksum_crc64nvme {
+            d.field("checksum_crc64nvme", val);
+        }
+        if let Some(ref val) = self.checksum_md5 {
+            d.field("checksum_md5", val);
+        }
+        if let Some(ref val) = self.checksum_sha1 {
+            d.field("checksum_sha1", val);
+        }
+        if let Some(ref val) = self.checksum_sha256 {
+            d.field("checksum_sha256", val);
+        }
+        if let Some(ref val) = self.checksum_sha512 {
+            d.field("checksum_sha512", val);
+        }
+        if let Some(ref val) = self.checksum_type {
+            d.field("checksum_type", val);
+        }
+        if let Some(ref val) = self.checksum_xxhash128 {
+            d.field("checksum_xxhash128", val);
+        }
+        if let Some(ref val) = self.checksum_xxhash3 {
+            d.field("checksum_xxhash3", val);
+        }
+        if let Some(ref val) = self.checksum_xxhash64 {
+            d.field("checksum_xxhash64", val);
+        }
+        if let Some(ref val) = self.content_length {
+            d.field("content_length", val);
+        }
+        if let Some(ref val) = self.e_tag {
+            d.field("e_tag", val);
+        }
+        if let Some(ref val) = self.last_modified {
+            d.field("last_modified", val);
+        }
+        if let Some(ref val) = self.object_version_id {
+            d.field("object_version_id", val);
+        }
+        if let Some(ref val) = self.replication_status {
+            d.field("replication_status", val);
+        }
+        if let Some(ref val) = self.request_charged {
+            d.field("request_charged", val);
+        }
+        if let Some(ref val) = self.server_side_encryption {
+            d.field("server_side_encryption", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+impl DtoExt for GetObjectAnnotationOutput {
+    fn ignore_empty_strings(&mut self) {
+        if self.checksum_crc32.as_deref() == Some("") {
+            self.checksum_crc32 = None;
+        }
+        if self.checksum_crc32c.as_deref() == Some("") {
+            self.checksum_crc32c = None;
+        }
+        if self.checksum_crc64nvme.as_deref() == Some("") {
+            self.checksum_crc64nvme = None;
+        }
+        if self.checksum_md5.as_deref() == Some("") {
+            self.checksum_md5 = None;
+        }
+        if self.checksum_sha1.as_deref() == Some("") {
+            self.checksum_sha1 = None;
+        }
+        if self.checksum_sha256.as_deref() == Some("") {
+            self.checksum_sha256 = None;
+        }
+        if self.checksum_sha512.as_deref() == Some("") {
+            self.checksum_sha512 = None;
+        }
+        if let Some(ref val) = self.checksum_type
+            && val.as_str() == ""
+        {
+            self.checksum_type = None;
+        }
+        if self.checksum_xxhash128.as_deref() == Some("") {
+            self.checksum_xxhash128 = None;
+        }
+        if self.checksum_xxhash3.as_deref() == Some("") {
+            self.checksum_xxhash3 = None;
+        }
+        if self.checksum_xxhash64.as_deref() == Some("") {
+            self.checksum_xxhash64 = None;
+        }
+        if self.object_version_id.as_deref() == Some("") {
+            self.object_version_id = None;
+        }
+        if let Some(ref val) = self.replication_status
+            && val.as_str() == ""
+        {
+            self.replication_status = None;
+        }
+        if let Some(ref val) = self.request_charged
+            && val.as_str() == ""
+        {
+            self.request_charged = None;
+        }
+        if let Some(ref val) = self.server_side_encryption
+            && val.as_str() == ""
+        {
+            self.server_side_encryption = None;
+        }
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
 pub struct GetObjectAttributesInput {
     /// <p>The name of the bucket that contains the object.</p>
     /// <p>
@@ -16174,6 +16682,17 @@ impl FromStr for IntelligentTieringStatus {
     }
 }
 
+/// <p>The annotation name you provided is invalid.</p>
+#[derive(Clone, Default, PartialEq)]
+pub struct InvalidAnnotationName {}
+
+impl fmt::Debug for InvalidAnnotationName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("InvalidAnnotationName");
+        d.finish_non_exhaustive()
+    }
+}
+
 /// <p>Object is archived and inaccessible until restored.</p>
 /// <p>If the object you are retrieving is stored in the S3 Glacier Flexible Retrieval storage
 /// class, the S3 Glacier Deep Archive storage class, the S3 Intelligent-Tiering Archive Access
@@ -16212,6 +16731,17 @@ impl DtoExt for InvalidObjectState {
         {
             self.storage_class = None;
         }
+    }
+}
+
+/// <p>The annotation prefix you provided is invalid.</p>
+#[derive(Clone, Default, PartialEq)]
+pub struct InvalidPrefix {}
+
+impl fmt::Debug for InvalidPrefix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("InvalidPrefix");
+        d.finish_non_exhaustive()
     }
 }
 
@@ -18510,6 +19040,167 @@ impl DtoExt for ListMultipartUploadsOutput {
 }
 
 #[derive(Clone, Default, PartialEq)]
+pub struct ListObjectAnnotationsInput {
+    /// <p>Filter results to annotations whose name begins with the specified prefix.</p>
+    pub annotation_prefix: Option<AnnotationPrefix>,
+    /// <p>The name of the bucket that contains the object.</p>
+    pub bucket: BucketName,
+    /// <p>Continuation token returned by a previous request to retrieve the next page.</p>
+    pub continuation_token: Option<Token>,
+    /// <p>The account ID of the expected bucket owner.</p>
+    pub expected_bucket_owner: Option<AccountId>,
+    /// <p>The object key.</p>
+    pub key: ObjectKey,
+    /// <p>The maximum number of annotations to return in the response. Maximum is 1,000.</p>
+    pub max_annotation_results: Option<MaxAnnotationResults>,
+    pub request_payer: Option<RequestPayer>,
+    /// <p>The version ID of the object.</p>
+    pub version_id: Option<ObjectVersionId>,
+}
+
+impl fmt::Debug for ListObjectAnnotationsInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("ListObjectAnnotationsInput");
+        if let Some(ref val) = self.annotation_prefix {
+            d.field("annotation_prefix", val);
+        }
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.continuation_token {
+            d.field("continuation_token", val);
+        }
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.field("key", &self.key);
+        if let Some(ref val) = self.max_annotation_results {
+            d.field("max_annotation_results", val);
+        }
+        if let Some(ref val) = self.request_payer {
+            d.field("request_payer", val);
+        }
+        if let Some(ref val) = self.version_id {
+            d.field("version_id", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl ListObjectAnnotationsInput {
+    #[must_use]
+    pub fn builder() -> builders::ListObjectAnnotationsInputBuilder {
+        default()
+    }
+}
+impl DtoExt for ListObjectAnnotationsInput {
+    fn ignore_empty_strings(&mut self) {
+        if self.annotation_prefix.as_deref() == Some("") {
+            self.annotation_prefix = None;
+        }
+        if self.continuation_token.as_deref() == Some("") {
+            self.continuation_token = None;
+        }
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+        if let Some(ref val) = self.request_payer
+            && val.as_str() == ""
+        {
+            self.request_payer = None;
+        }
+        if self.version_id.as_deref() == Some("") {
+            self.version_id = None;
+        }
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct ListObjectAnnotationsOutput {
+    /// <p>The number of annotations returned.</p>
+    pub annotation_count: Option<AnnotationCount>,
+    /// <p>The prefix used to filter the response.</p>
+    pub annotation_prefix: Option<AnnotationPrefix>,
+    /// <p>The list of annotations attached to the object.</p>
+    pub annotations: Option<AnnotationList>,
+    /// <p>The bucket name.</p>
+    pub bucket: Option<BucketName>,
+    /// <p>The continuation token used in this request.</p>
+    pub continuation_token: Option<Token>,
+    /// <p>The object key.</p>
+    pub key: Option<ObjectKey>,
+    /// <p>The maximum number of annotations returned in the response.</p>
+    pub max_annotation_results: Option<MaxAnnotationResults>,
+    /// <p>The continuation token to use to retrieve the next page of results.</p>
+    pub next_continuation_token: Option<NextToken>,
+    /// <p>The version ID of the object.</p>
+    pub object_version_id: Option<ObjectVersionId>,
+    pub request_charged: Option<RequestCharged>,
+}
+
+impl fmt::Debug for ListObjectAnnotationsOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("ListObjectAnnotationsOutput");
+        if let Some(ref val) = self.annotation_count {
+            d.field("annotation_count", val);
+        }
+        if let Some(ref val) = self.annotation_prefix {
+            d.field("annotation_prefix", val);
+        }
+        if let Some(ref val) = self.annotations {
+            d.field("annotations", val);
+        }
+        if let Some(ref val) = self.bucket {
+            d.field("bucket", val);
+        }
+        if let Some(ref val) = self.continuation_token {
+            d.field("continuation_token", val);
+        }
+        if let Some(ref val) = self.key {
+            d.field("key", val);
+        }
+        if let Some(ref val) = self.max_annotation_results {
+            d.field("max_annotation_results", val);
+        }
+        if let Some(ref val) = self.next_continuation_token {
+            d.field("next_continuation_token", val);
+        }
+        if let Some(ref val) = self.object_version_id {
+            d.field("object_version_id", val);
+        }
+        if let Some(ref val) = self.request_charged {
+            d.field("request_charged", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+impl DtoExt for ListObjectAnnotationsOutput {
+    fn ignore_empty_strings(&mut self) {
+        if self.annotation_prefix.as_deref() == Some("") {
+            self.annotation_prefix = None;
+        }
+        if self.bucket.as_deref() == Some("") {
+            self.bucket = None;
+        }
+        if self.continuation_token.as_deref() == Some("") {
+            self.continuation_token = None;
+        }
+        if self.key.as_deref() == Some("") {
+            self.key = None;
+        }
+        if self.next_continuation_token.as_deref() == Some("") {
+            self.next_continuation_token = None;
+        }
+        if self.object_version_id.as_deref() == Some("") {
+            self.object_version_id = None;
+        }
+        if let Some(ref val) = self.request_charged
+            && val.as_str() == ""
+        {
+            self.request_charged = None;
+        }
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
 pub struct ListObjectVersionsInput {
     /// <p>The bucket name that contains the objects. </p>
     pub bucket: BucketName,
@@ -19906,6 +20597,8 @@ pub type Marker = String;
 
 pub type MaxAgeSeconds = i32;
 
+pub type MaxAnnotationResults = i32;
+
 pub type MaxBuckets = i32;
 
 pub type MaxDirectoryBuckets = i32;
@@ -20475,6 +21168,17 @@ pub type NextUploadIdMarker = String;
 
 pub type NextVersionIdMarker = String;
 
+/// <p>The specified annotation does not exist on this object.</p>
+#[derive(Clone, Default, PartialEq)]
+pub struct NoSuchAnnotation {}
+
+impl fmt::Debug for NoSuchAnnotation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("NoSuchAnnotation");
+        d.finish_non_exhaustive()
+    }
+}
+
 /// <p>The specified bucket does not exist.</p>
 #[derive(Clone, Default, PartialEq)]
 pub struct NoSuchBucket {}
@@ -20991,6 +21695,8 @@ impl DtoExt for ObjectIdentifier {
 }
 
 pub type ObjectIdentifierList = List<ObjectIdentifier>;
+
+pub type ObjectIfMatch = String;
 
 pub type ObjectKey = String;
 
@@ -25693,6 +26399,330 @@ impl DtoExt for PutObjectAclOutput {
             && val.as_str() == ""
         {
             self.request_charged = None;
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct PutObjectAnnotationInput {
+    /// <p>The name of the annotation.</p>
+    /// <p>Length Constraints: Minimum length of 1. Maximum length of 512 bytes.</p>
+    pub annotation_name: AnnotationName,
+    /// <p>The annotation payload. Must be between 1 byte and 1 MiB in size, and must be valid UTF-8
+    /// encoded text. If the payload contains invalid UTF-8 bytes, the request fails with HTTP 415
+    /// (Unsupported Media Type). To store binary data, encode the payload using Base64 before
+    /// uploading.</p>
+    pub annotation_payload: Option<StreamingBlob>,
+    /// <p>The name of the bucket that contains the object.</p>
+    pub bucket: BucketName,
+    /// <p>The checksum algorithm to use. Supported values: <code>CRC32</code>, <code>CRC32C</code>, <code>CRC64NVME</code>, <code>SHA1</code>, <code>SHA256</code>, <code>SHA512</code>, <code>MD5</code>, <code>XXHASH64</code>, <code>XXHASH3</code>, <code>XXHASH128</code>.</p>
+    pub checksum_algorithm: Option<ChecksumAlgorithm>,
+    /// <p>Base64-encoded CRC32 checksum of the annotation payload.</p>
+    pub checksum_crc32: Option<ChecksumCRC32>,
+    /// <p>Base64-encoded CRC32C checksum of the annotation payload.</p>
+    pub checksum_crc32c: Option<ChecksumCRC32C>,
+    /// <p>Base64-encoded CRC64NVME checksum of the annotation payload.</p>
+    pub checksum_crc64nvme: Option<ChecksumCRC64NVME>,
+    /// <p>Base64-encoded MD5 checksum of the annotation payload.</p>
+    pub checksum_md5: Option<ChecksumMD5>,
+    /// <p>Base64-encoded SHA1 checksum of the annotation payload.</p>
+    pub checksum_sha1: Option<ChecksumSHA1>,
+    /// <p>Base64-encoded SHA256 checksum of the annotation payload.</p>
+    pub checksum_sha256: Option<ChecksumSHA256>,
+    /// <p>Base64-encoded SHA512 checksum of the annotation payload.</p>
+    pub checksum_sha512: Option<ChecksumSHA512>,
+    /// <p>Base64-encoded XXHASH128 checksum of the annotation payload.</p>
+    pub checksum_xxhash128: Option<ChecksumXXHASH128>,
+    /// <p>Base64-encoded XXHASH3 checksum of the annotation payload.</p>
+    pub checksum_xxhash3: Option<ChecksumXXHASH3>,
+    /// <p>Base64-encoded XXHASH64 checksum of the annotation payload.</p>
+    pub checksum_xxhash64: Option<ChecksumXXHASH64>,
+    /// <p>Base64-encoded MD5 digest of the message.</p>
+    pub content_md5: Option<ContentMD5>,
+    /// <p>The account ID of the expected bucket owner. If the bucket is owned by a different account, the request fails with an HTTP 403 (Access Denied) error.</p>
+    pub expected_bucket_owner: Option<AccountId>,
+    /// <p>The object key.</p>
+    pub key: ObjectKey,
+    /// <p>If specified, the operation only succeeds if the object's ETag matches the provided value.</p>
+    pub object_if_match: Option<ObjectIfMatch>,
+    pub request_payer: Option<RequestPayer>,
+    /// <p>The version ID of the object to attach the annotation to.</p>
+    pub version_id: Option<ObjectVersionId>,
+}
+
+impl fmt::Debug for PutObjectAnnotationInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("PutObjectAnnotationInput");
+        d.field("annotation_name", &self.annotation_name);
+        if let Some(ref val) = self.annotation_payload {
+            d.field("annotation_payload", val);
+        }
+        d.field("bucket", &self.bucket);
+        if let Some(ref val) = self.checksum_algorithm {
+            d.field("checksum_algorithm", val);
+        }
+        if let Some(ref val) = self.checksum_crc32 {
+            d.field("checksum_crc32", val);
+        }
+        if let Some(ref val) = self.checksum_crc32c {
+            d.field("checksum_crc32c", val);
+        }
+        if let Some(ref val) = self.checksum_crc64nvme {
+            d.field("checksum_crc64nvme", val);
+        }
+        if let Some(ref val) = self.checksum_md5 {
+            d.field("checksum_md5", val);
+        }
+        if let Some(ref val) = self.checksum_sha1 {
+            d.field("checksum_sha1", val);
+        }
+        if let Some(ref val) = self.checksum_sha256 {
+            d.field("checksum_sha256", val);
+        }
+        if let Some(ref val) = self.checksum_sha512 {
+            d.field("checksum_sha512", val);
+        }
+        if let Some(ref val) = self.checksum_xxhash128 {
+            d.field("checksum_xxhash128", val);
+        }
+        if let Some(ref val) = self.checksum_xxhash3 {
+            d.field("checksum_xxhash3", val);
+        }
+        if let Some(ref val) = self.checksum_xxhash64 {
+            d.field("checksum_xxhash64", val);
+        }
+        if let Some(ref val) = self.content_md5 {
+            d.field("content_md5", val);
+        }
+        if let Some(ref val) = self.expected_bucket_owner {
+            d.field("expected_bucket_owner", val);
+        }
+        d.field("key", &self.key);
+        if let Some(ref val) = self.object_if_match {
+            d.field("object_if_match", val);
+        }
+        if let Some(ref val) = self.request_payer {
+            d.field("request_payer", val);
+        }
+        if let Some(ref val) = self.version_id {
+            d.field("version_id", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+
+impl PutObjectAnnotationInput {
+    #[must_use]
+    pub fn builder() -> builders::PutObjectAnnotationInputBuilder {
+        default()
+    }
+}
+impl DtoExt for PutObjectAnnotationInput {
+    fn ignore_empty_strings(&mut self) {
+        if let Some(ref val) = self.checksum_algorithm
+            && val.as_str() == ""
+        {
+            self.checksum_algorithm = None;
+        }
+        if self.checksum_crc32.as_deref() == Some("") {
+            self.checksum_crc32 = None;
+        }
+        if self.checksum_crc32c.as_deref() == Some("") {
+            self.checksum_crc32c = None;
+        }
+        if self.checksum_crc64nvme.as_deref() == Some("") {
+            self.checksum_crc64nvme = None;
+        }
+        if self.checksum_md5.as_deref() == Some("") {
+            self.checksum_md5 = None;
+        }
+        if self.checksum_sha1.as_deref() == Some("") {
+            self.checksum_sha1 = None;
+        }
+        if self.checksum_sha256.as_deref() == Some("") {
+            self.checksum_sha256 = None;
+        }
+        if self.checksum_sha512.as_deref() == Some("") {
+            self.checksum_sha512 = None;
+        }
+        if self.checksum_xxhash128.as_deref() == Some("") {
+            self.checksum_xxhash128 = None;
+        }
+        if self.checksum_xxhash3.as_deref() == Some("") {
+            self.checksum_xxhash3 = None;
+        }
+        if self.checksum_xxhash64.as_deref() == Some("") {
+            self.checksum_xxhash64 = None;
+        }
+        if self.content_md5.as_deref() == Some("") {
+            self.content_md5 = None;
+        }
+        if self.expected_bucket_owner.as_deref() == Some("") {
+            self.expected_bucket_owner = None;
+        }
+        if self.object_if_match.as_deref() == Some("") {
+            self.object_if_match = None;
+        }
+        if let Some(ref val) = self.request_payer
+            && val.as_str() == ""
+        {
+            self.request_payer = None;
+        }
+        if self.version_id.as_deref() == Some("") {
+            self.version_id = None;
+        }
+    }
+}
+
+#[derive(Clone, Default, PartialEq)]
+pub struct PutObjectAnnotationOutput {
+    /// <p>The name of the annotation.</p>
+    pub annotation_name: Option<AnnotationName>,
+    /// <p>The CRC32 checksum of the stored annotation.</p>
+    pub checksum_crc32: Option<ChecksumCRC32>,
+    /// <p>The CRC32C checksum of the stored annotation.</p>
+    pub checksum_crc32c: Option<ChecksumCRC32C>,
+    /// <p>The CRC64NVME checksum of the stored annotation.</p>
+    pub checksum_crc64nvme: Option<ChecksumCRC64NVME>,
+    /// <p>The MD5 checksum of the stored annotation.</p>
+    pub checksum_md5: Option<ChecksumMD5>,
+    /// <p>The SHA1 checksum of the stored annotation.</p>
+    pub checksum_sha1: Option<ChecksumSHA1>,
+    /// <p>The SHA256 checksum of the stored annotation.</p>
+    pub checksum_sha256: Option<ChecksumSHA256>,
+    /// <p>The SHA512 checksum of the stored annotation.</p>
+    pub checksum_sha512: Option<ChecksumSHA512>,
+    /// <p>The type of checksum used.</p>
+    pub checksum_type: Option<ChecksumType>,
+    /// <p>The XXHASH128 checksum of the stored annotation.</p>
+    pub checksum_xxhash128: Option<ChecksumXXHASH128>,
+    /// <p>The XXHASH3 checksum of the stored annotation.</p>
+    pub checksum_xxhash3: Option<ChecksumXXHASH3>,
+    /// <p>The XXHASH64 checksum of the stored annotation.</p>
+    pub checksum_xxhash64: Option<ChecksumXXHASH64>,
+    /// <p>The entity tag of the annotation.</p>
+    pub e_tag: Option<ETag>,
+    /// <p>The object key.</p>
+    pub key: Option<ObjectKey>,
+    /// <p>The version ID of the object that the annotation was attached to.</p>
+    pub object_version_id: Option<ObjectVersionId>,
+    pub request_charged: Option<RequestCharged>,
+    /// <p>The server-side encryption algorithm used to encrypt the annotation.</p>
+    pub server_side_encryption: Option<ServerSideEncryption>,
+}
+
+impl fmt::Debug for PutObjectAnnotationOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("PutObjectAnnotationOutput");
+        if let Some(ref val) = self.annotation_name {
+            d.field("annotation_name", val);
+        }
+        if let Some(ref val) = self.checksum_crc32 {
+            d.field("checksum_crc32", val);
+        }
+        if let Some(ref val) = self.checksum_crc32c {
+            d.field("checksum_crc32c", val);
+        }
+        if let Some(ref val) = self.checksum_crc64nvme {
+            d.field("checksum_crc64nvme", val);
+        }
+        if let Some(ref val) = self.checksum_md5 {
+            d.field("checksum_md5", val);
+        }
+        if let Some(ref val) = self.checksum_sha1 {
+            d.field("checksum_sha1", val);
+        }
+        if let Some(ref val) = self.checksum_sha256 {
+            d.field("checksum_sha256", val);
+        }
+        if let Some(ref val) = self.checksum_sha512 {
+            d.field("checksum_sha512", val);
+        }
+        if let Some(ref val) = self.checksum_type {
+            d.field("checksum_type", val);
+        }
+        if let Some(ref val) = self.checksum_xxhash128 {
+            d.field("checksum_xxhash128", val);
+        }
+        if let Some(ref val) = self.checksum_xxhash3 {
+            d.field("checksum_xxhash3", val);
+        }
+        if let Some(ref val) = self.checksum_xxhash64 {
+            d.field("checksum_xxhash64", val);
+        }
+        if let Some(ref val) = self.e_tag {
+            d.field("e_tag", val);
+        }
+        if let Some(ref val) = self.key {
+            d.field("key", val);
+        }
+        if let Some(ref val) = self.object_version_id {
+            d.field("object_version_id", val);
+        }
+        if let Some(ref val) = self.request_charged {
+            d.field("request_charged", val);
+        }
+        if let Some(ref val) = self.server_side_encryption {
+            d.field("server_side_encryption", val);
+        }
+        d.finish_non_exhaustive()
+    }
+}
+impl DtoExt for PutObjectAnnotationOutput {
+    fn ignore_empty_strings(&mut self) {
+        if self.annotation_name.as_deref() == Some("") {
+            self.annotation_name = None;
+        }
+        if self.checksum_crc32.as_deref() == Some("") {
+            self.checksum_crc32 = None;
+        }
+        if self.checksum_crc32c.as_deref() == Some("") {
+            self.checksum_crc32c = None;
+        }
+        if self.checksum_crc64nvme.as_deref() == Some("") {
+            self.checksum_crc64nvme = None;
+        }
+        if self.checksum_md5.as_deref() == Some("") {
+            self.checksum_md5 = None;
+        }
+        if self.checksum_sha1.as_deref() == Some("") {
+            self.checksum_sha1 = None;
+        }
+        if self.checksum_sha256.as_deref() == Some("") {
+            self.checksum_sha256 = None;
+        }
+        if self.checksum_sha512.as_deref() == Some("") {
+            self.checksum_sha512 = None;
+        }
+        if let Some(ref val) = self.checksum_type
+            && val.as_str() == ""
+        {
+            self.checksum_type = None;
+        }
+        if self.checksum_xxhash128.as_deref() == Some("") {
+            self.checksum_xxhash128 = None;
+        }
+        if self.checksum_xxhash3.as_deref() == Some("") {
+            self.checksum_xxhash3 = None;
+        }
+        if self.checksum_xxhash64.as_deref() == Some("") {
+            self.checksum_xxhash64 = None;
+        }
+        if self.key.as_deref() == Some("") {
+            self.key = None;
+        }
+        if self.object_version_id.as_deref() == Some("") {
+            self.object_version_id = None;
+        }
+        if let Some(ref val) = self.request_charged
+            && val.as_str() == ""
+        {
+            self.request_charged = None;
+        }
+        if let Some(ref val) = self.server_side_encryption
+            && val.as_str() == ""
+        {
+            self.server_side_encryption = None;
         }
     }
 }
@@ -31075,6 +32105,17 @@ impl FromStr for Type {
 
 pub type URI = String;
 
+/// <p>The annotation payload is not valid UTF-8 encoded text.</p>
+#[derive(Clone, Default, PartialEq)]
+pub struct UnsupportedMediaType {}
+
+impl fmt::Debug for UnsupportedMediaType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("UnsupportedMediaType");
+        d.finish_non_exhaustive()
+    }
+}
+
 #[derive(Clone, PartialEq)]
 pub struct UpdateBucketMetadataAnnotationTableConfigurationInput {
     /// <p>The annotation table configuration updates to apply.</p>
@@ -32930,6 +33971,7 @@ mod tests {
         require_default::<DeleteBucketTaggingOutput>();
         require_default::<DeleteBucketWebsiteOutput>();
         require_default::<DeleteObjectOutput>();
+        require_default::<DeleteObjectAnnotationOutput>();
         require_default::<DeleteObjectTaggingOutput>();
         require_default::<DeleteObjectsOutput>();
         require_default::<DeletePublicAccessBlockOutput>();
@@ -32958,6 +34000,7 @@ mod tests {
         require_default::<GetBucketWebsiteOutput>();
         require_default::<GetObjectOutput>();
         require_default::<GetObjectAclOutput>();
+        require_default::<GetObjectAnnotationOutput>();
         require_default::<GetObjectAttributesOutput>();
         require_default::<GetObjectLegalHoldOutput>();
         require_default::<GetObjectLockConfigurationOutput>();
@@ -32974,6 +34017,7 @@ mod tests {
         require_default::<ListBucketsOutput>();
         require_default::<ListDirectoryBucketsOutput>();
         require_default::<ListMultipartUploadsOutput>();
+        require_default::<ListObjectAnnotationsOutput>();
         require_default::<ListObjectVersionsOutput>();
         require_default::<ListObjectsOutput>();
         require_default::<ListObjectsV2Output>();
@@ -33000,6 +34044,7 @@ mod tests {
         require_default::<PutBucketWebsiteOutput>();
         require_default::<PutObjectOutput>();
         require_default::<PutObjectAclOutput>();
+        require_default::<PutObjectAnnotationOutput>();
         require_default::<PutObjectLegalHoldOutput>();
         require_default::<PutObjectLockConfigurationOutput>();
         require_default::<PutObjectRetentionOutput>();
@@ -33065,6 +34110,8 @@ mod tests {
         require_clone::<DeleteBucketWebsiteOutput>();
         require_clone::<DeleteObjectInput>();
         require_clone::<DeleteObjectOutput>();
+        require_clone::<DeleteObjectAnnotationInput>();
+        require_clone::<DeleteObjectAnnotationOutput>();
         require_clone::<DeleteObjectTaggingInput>();
         require_clone::<DeleteObjectTaggingOutput>();
         require_clone::<DeleteObjectsInput>();
@@ -33120,6 +34167,7 @@ mod tests {
         require_clone::<GetObjectInput>();
         require_clone::<GetObjectAclInput>();
         require_clone::<GetObjectAclOutput>();
+        require_clone::<GetObjectAnnotationInput>();
         require_clone::<GetObjectAttributesInput>();
         require_clone::<GetObjectAttributesOutput>();
         require_clone::<GetObjectLegalHoldInput>();
@@ -33151,6 +34199,8 @@ mod tests {
         require_clone::<ListDirectoryBucketsOutput>();
         require_clone::<ListMultipartUploadsInput>();
         require_clone::<ListMultipartUploadsOutput>();
+        require_clone::<ListObjectAnnotationsInput>();
+        require_clone::<ListObjectAnnotationsOutput>();
         require_clone::<ListObjectVersionsInput>();
         require_clone::<ListObjectVersionsOutput>();
         require_clone::<ListObjectsInput>();
@@ -33201,6 +34251,7 @@ mod tests {
         require_clone::<PutObjectOutput>();
         require_clone::<PutObjectAclInput>();
         require_clone::<PutObjectAclOutput>();
+        require_clone::<PutObjectAnnotationOutput>();
         require_clone::<PutObjectLegalHoldInput>();
         require_clone::<PutObjectLegalHoldOutput>();
         require_clone::<PutObjectLockConfigurationInput>();
@@ -33265,6 +34316,7 @@ mod tests {
         require_default::<DeleteBucketTaggingOutput>();
         require_default::<DeleteBucketWebsiteOutput>();
         require_default::<DeleteObjectOutput>();
+        require_default::<DeleteObjectAnnotationOutput>();
         require_default::<DeleteObjectTaggingOutput>();
         require_default::<DeleteObjectsOutput>();
         require_default::<DeletePublicAccessBlockOutput>();
@@ -33293,6 +34345,7 @@ mod tests {
         require_default::<GetBucketWebsiteOutput>();
         require_default::<GetObjectOutput>();
         require_default::<GetObjectAclOutput>();
+        require_default::<GetObjectAnnotationOutput>();
         require_default::<GetObjectAttributesOutput>();
         require_default::<GetObjectLegalHoldOutput>();
         require_default::<GetObjectLockConfigurationOutput>();
@@ -33309,6 +34362,7 @@ mod tests {
         require_default::<ListBucketsOutput>();
         require_default::<ListDirectoryBucketsOutput>();
         require_default::<ListMultipartUploadsOutput>();
+        require_default::<ListObjectAnnotationsOutput>();
         require_default::<ListObjectVersionsOutput>();
         require_default::<ListObjectsOutput>();
         require_default::<ListObjectsV2Output>();
@@ -33336,6 +34390,7 @@ mod tests {
         require_default::<PutBucketWebsiteOutput>();
         require_default::<PutObjectOutput>();
         require_default::<PutObjectAclOutput>();
+        require_default::<PutObjectAnnotationOutput>();
         require_default::<PutObjectLegalHoldOutput>();
         require_default::<PutObjectLockConfigurationOutput>();
         require_default::<PutObjectRetentionOutput>();
@@ -33401,6 +34456,8 @@ mod tests {
         require_clone::<DeleteBucketWebsiteOutput>();
         require_clone::<DeleteObjectInput>();
         require_clone::<DeleteObjectOutput>();
+        require_clone::<DeleteObjectAnnotationInput>();
+        require_clone::<DeleteObjectAnnotationOutput>();
         require_clone::<DeleteObjectTaggingInput>();
         require_clone::<DeleteObjectTaggingOutput>();
         require_clone::<DeleteObjectsInput>();
@@ -33456,6 +34513,7 @@ mod tests {
         require_clone::<GetObjectInput>();
         require_clone::<GetObjectAclInput>();
         require_clone::<GetObjectAclOutput>();
+        require_clone::<GetObjectAnnotationInput>();
         require_clone::<GetObjectAttributesInput>();
         require_clone::<GetObjectAttributesOutput>();
         require_clone::<GetObjectLegalHoldInput>();
@@ -33487,6 +34545,8 @@ mod tests {
         require_clone::<ListDirectoryBucketsOutput>();
         require_clone::<ListMultipartUploadsInput>();
         require_clone::<ListMultipartUploadsOutput>();
+        require_clone::<ListObjectAnnotationsInput>();
+        require_clone::<ListObjectAnnotationsOutput>();
         require_clone::<ListObjectVersionsInput>();
         require_clone::<ListObjectVersionsOutput>();
         require_clone::<ListObjectsInput>();
@@ -33538,6 +34598,7 @@ mod tests {
         require_clone::<PutObjectOutput>();
         require_clone::<PutObjectAclInput>();
         require_clone::<PutObjectAclOutput>();
+        require_clone::<PutObjectAnnotationOutput>();
         require_clone::<PutObjectLegalHoldInput>();
         require_clone::<PutObjectLegalHoldOutput>();
         require_clone::<PutObjectLockConfigurationInput>();
@@ -34037,6 +35098,8 @@ pub mod builders {
     pub struct CopyObjectInputBuilder {
         acl: Option<ObjectCannedACL>,
 
+        annotation_directive: Option<AnnotationDirective>,
+
         bucket: Option<BucketName>,
 
         bucket_key_enabled: Option<BucketKeyEnabled>,
@@ -34083,6 +35146,10 @@ pub mod builders {
 
         grant_write_acp: Option<GrantWriteACP>,
 
+        if_match: Option<IfMatch>,
+
+        if_none_match: Option<IfNoneMatch>,
+
         key: Option<ObjectKey>,
 
         metadata: Option<Metadata>,
@@ -34121,6 +35188,11 @@ pub mod builders {
     impl CopyObjectInputBuilder {
         pub fn set_acl(&mut self, field: Option<ObjectCannedACL>) -> &mut Self {
             self.acl = field;
+            self
+        }
+
+        pub fn set_annotation_directive(&mut self, field: Option<AnnotationDirective>) -> &mut Self {
+            self.annotation_directive = field;
             self
         }
 
@@ -34239,6 +35311,16 @@ pub mod builders {
             self
         }
 
+        pub fn set_if_match(&mut self, field: Option<IfMatch>) -> &mut Self {
+            self.if_match = field;
+            self
+        }
+
+        pub fn set_if_none_match(&mut self, field: Option<IfNoneMatch>) -> &mut Self {
+            self.if_none_match = field;
+            self
+        }
+
         pub fn set_key(&mut self, field: ObjectKey) -> &mut Self {
             self.key = Some(field);
             self
@@ -34327,6 +35409,12 @@ pub mod builders {
         #[must_use]
         pub fn acl(mut self, field: Option<ObjectCannedACL>) -> Self {
             self.acl = field;
+            self
+        }
+
+        #[must_use]
+        pub fn annotation_directive(mut self, field: Option<AnnotationDirective>) -> Self {
+            self.annotation_directive = field;
             self
         }
 
@@ -34469,6 +35557,18 @@ pub mod builders {
         }
 
         #[must_use]
+        pub fn if_match(mut self, field: Option<IfMatch>) -> Self {
+            self.if_match = field;
+            self
+        }
+
+        #[must_use]
+        pub fn if_none_match(mut self, field: Option<IfNoneMatch>) -> Self {
+            self.if_none_match = field;
+            self
+        }
+
+        #[must_use]
         pub fn key(mut self, field: ObjectKey) -> Self {
             self.key = Some(field);
             self
@@ -34572,6 +35672,7 @@ pub mod builders {
 
         pub fn build(self) -> Result<CopyObjectInput, BuildError> {
             let acl = self.acl;
+            let annotation_directive = self.annotation_directive;
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
             let bucket_key_enabled = self.bucket_key_enabled;
             let cache_control = self.cache_control;
@@ -34595,6 +35696,8 @@ pub mod builders {
             let grant_read = self.grant_read;
             let grant_read_acp = self.grant_read_acp;
             let grant_write_acp = self.grant_write_acp;
+            let if_match = self.if_match;
+            let if_none_match = self.if_none_match;
             let key = self.key.ok_or_else(|| BuildError::missing_field("key"))?;
             let metadata = self.metadata;
             let metadata_directive = self.metadata_directive;
@@ -34614,6 +35717,7 @@ pub mod builders {
             let website_redirect_location = self.website_redirect_location;
             Ok(CopyObjectInput {
                 acl,
+                annotation_directive,
                 bucket,
                 bucket_key_enabled,
                 cache_control,
@@ -34637,6 +35741,8 @@ pub mod builders {
                 grant_read,
                 grant_read_acp,
                 grant_write_acp,
+                if_match,
+                if_none_match,
                 key,
                 metadata,
                 metadata_directive,
@@ -36423,6 +37529,124 @@ pub mod builders {
         }
     }
 
+    /// A builder for [`DeleteObjectAnnotationInput`]
+    #[derive(Default)]
+    pub struct DeleteObjectAnnotationInputBuilder {
+        annotation_name: Option<AnnotationName>,
+
+        bucket: Option<BucketName>,
+
+        expected_bucket_owner: Option<AccountId>,
+
+        key: Option<ObjectKey>,
+
+        object_if_match: Option<ObjectIfMatch>,
+
+        request_payer: Option<RequestPayer>,
+
+        version_id: Option<ObjectVersionId>,
+    }
+
+    impl DeleteObjectAnnotationInputBuilder {
+        pub fn set_annotation_name(&mut self, field: AnnotationName) -> &mut Self {
+            self.annotation_name = Some(field);
+            self
+        }
+
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn set_key(&mut self, field: ObjectKey) -> &mut Self {
+            self.key = Some(field);
+            self
+        }
+
+        pub fn set_object_if_match(&mut self, field: Option<ObjectIfMatch>) -> &mut Self {
+            self.object_if_match = field;
+            self
+        }
+
+        pub fn set_request_payer(&mut self, field: Option<RequestPayer>) -> &mut Self {
+            self.request_payer = field;
+            self
+        }
+
+        pub fn set_version_id(&mut self, field: Option<ObjectVersionId>) -> &mut Self {
+            self.version_id = field;
+            self
+        }
+
+        #[must_use]
+        pub fn annotation_name(mut self, field: AnnotationName) -> Self {
+            self.annotation_name = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn key(mut self, field: ObjectKey) -> Self {
+            self.key = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn object_if_match(mut self, field: Option<ObjectIfMatch>) -> Self {
+            self.object_if_match = field;
+            self
+        }
+
+        #[must_use]
+        pub fn request_payer(mut self, field: Option<RequestPayer>) -> Self {
+            self.request_payer = field;
+            self
+        }
+
+        #[must_use]
+        pub fn version_id(mut self, field: Option<ObjectVersionId>) -> Self {
+            self.version_id = field;
+            self
+        }
+
+        pub fn build(self) -> Result<DeleteObjectAnnotationInput, BuildError> {
+            let annotation_name = self
+                .annotation_name
+                .ok_or_else(|| BuildError::missing_field("annotation_name"))?;
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            let key = self.key.ok_or_else(|| BuildError::missing_field("key"))?;
+            let object_if_match = self.object_if_match;
+            let request_payer = self.request_payer;
+            let version_id = self.version_id;
+            Ok(DeleteObjectAnnotationInput {
+                annotation_name,
+                bucket,
+                expected_bucket_owner,
+                key,
+                object_if_match,
+                request_payer,
+                version_id,
+            })
+        }
+    }
+
     /// A builder for [`DeleteObjectTaggingInput`]
     #[derive(Default)]
     pub struct DeleteObjectTaggingInputBuilder {
@@ -38081,6 +39305,124 @@ pub mod builders {
         }
     }
 
+    /// A builder for [`GetObjectAnnotationInput`]
+    #[derive(Default)]
+    pub struct GetObjectAnnotationInputBuilder {
+        annotation_name: Option<AnnotationName>,
+
+        bucket: Option<BucketName>,
+
+        checksum_mode: Option<ChecksumMode>,
+
+        expected_bucket_owner: Option<AccountId>,
+
+        key: Option<ObjectKey>,
+
+        request_payer: Option<RequestPayer>,
+
+        version_id: Option<ObjectVersionId>,
+    }
+
+    impl GetObjectAnnotationInputBuilder {
+        pub fn set_annotation_name(&mut self, field: AnnotationName) -> &mut Self {
+            self.annotation_name = Some(field);
+            self
+        }
+
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_mode(&mut self, field: Option<ChecksumMode>) -> &mut Self {
+            self.checksum_mode = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn set_key(&mut self, field: ObjectKey) -> &mut Self {
+            self.key = Some(field);
+            self
+        }
+
+        pub fn set_request_payer(&mut self, field: Option<RequestPayer>) -> &mut Self {
+            self.request_payer = field;
+            self
+        }
+
+        pub fn set_version_id(&mut self, field: Option<ObjectVersionId>) -> &mut Self {
+            self.version_id = field;
+            self
+        }
+
+        #[must_use]
+        pub fn annotation_name(mut self, field: AnnotationName) -> Self {
+            self.annotation_name = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_mode(mut self, field: Option<ChecksumMode>) -> Self {
+            self.checksum_mode = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn key(mut self, field: ObjectKey) -> Self {
+            self.key = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn request_payer(mut self, field: Option<RequestPayer>) -> Self {
+            self.request_payer = field;
+            self
+        }
+
+        #[must_use]
+        pub fn version_id(mut self, field: Option<ObjectVersionId>) -> Self {
+            self.version_id = field;
+            self
+        }
+
+        pub fn build(self) -> Result<GetObjectAnnotationInput, BuildError> {
+            let annotation_name = self
+                .annotation_name
+                .ok_or_else(|| BuildError::missing_field("annotation_name"))?;
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_mode = self.checksum_mode;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            let key = self.key.ok_or_else(|| BuildError::missing_field("key"))?;
+            let request_payer = self.request_payer;
+            let version_id = self.version_id;
+            Ok(GetObjectAnnotationInput {
+                annotation_name,
+                bucket,
+                checksum_mode,
+                expected_bucket_owner,
+                key,
+                request_payer,
+                version_id,
+            })
+        }
+    }
+
     /// A builder for [`GetObjectAttributesInput`]
     #[derive(Default)]
     pub struct GetObjectAttributesInputBuilder {
@@ -39513,6 +40855,137 @@ pub mod builders {
                 prefix,
                 request_payer,
                 upload_id_marker,
+            })
+        }
+    }
+
+    /// A builder for [`ListObjectAnnotationsInput`]
+    #[derive(Default)]
+    pub struct ListObjectAnnotationsInputBuilder {
+        annotation_prefix: Option<AnnotationPrefix>,
+
+        bucket: Option<BucketName>,
+
+        continuation_token: Option<Token>,
+
+        expected_bucket_owner: Option<AccountId>,
+
+        key: Option<ObjectKey>,
+
+        max_annotation_results: Option<MaxAnnotationResults>,
+
+        request_payer: Option<RequestPayer>,
+
+        version_id: Option<ObjectVersionId>,
+    }
+
+    impl ListObjectAnnotationsInputBuilder {
+        pub fn set_annotation_prefix(&mut self, field: Option<AnnotationPrefix>) -> &mut Self {
+            self.annotation_prefix = field;
+            self
+        }
+
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_continuation_token(&mut self, field: Option<Token>) -> &mut Self {
+            self.continuation_token = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn set_key(&mut self, field: ObjectKey) -> &mut Self {
+            self.key = Some(field);
+            self
+        }
+
+        pub fn set_max_annotation_results(&mut self, field: Option<MaxAnnotationResults>) -> &mut Self {
+            self.max_annotation_results = field;
+            self
+        }
+
+        pub fn set_request_payer(&mut self, field: Option<RequestPayer>) -> &mut Self {
+            self.request_payer = field;
+            self
+        }
+
+        pub fn set_version_id(&mut self, field: Option<ObjectVersionId>) -> &mut Self {
+            self.version_id = field;
+            self
+        }
+
+        #[must_use]
+        pub fn annotation_prefix(mut self, field: Option<AnnotationPrefix>) -> Self {
+            self.annotation_prefix = field;
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn continuation_token(mut self, field: Option<Token>) -> Self {
+            self.continuation_token = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn key(mut self, field: ObjectKey) -> Self {
+            self.key = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn max_annotation_results(mut self, field: Option<MaxAnnotationResults>) -> Self {
+            self.max_annotation_results = field;
+            self
+        }
+
+        #[must_use]
+        pub fn request_payer(mut self, field: Option<RequestPayer>) -> Self {
+            self.request_payer = field;
+            self
+        }
+
+        #[must_use]
+        pub fn version_id(mut self, field: Option<ObjectVersionId>) -> Self {
+            self.version_id = field;
+            self
+        }
+
+        pub fn build(self) -> Result<ListObjectAnnotationsInput, BuildError> {
+            let annotation_prefix = self.annotation_prefix;
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let continuation_token = self.continuation_token;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            let key = self.key.ok_or_else(|| BuildError::missing_field("key"))?;
+            let max_annotation_results = self.max_annotation_results;
+            let request_payer = self.request_payer;
+            let version_id = self.version_id;
+            Ok(ListObjectAnnotationsInput {
+                annotation_prefix,
+                bucket,
+                continuation_token,
+                expected_bucket_owner,
+                key,
+                max_annotation_results,
+                request_payer,
+                version_id,
             })
         }
     }
@@ -43539,6 +45012,319 @@ pub mod builders {
         }
     }
 
+    /// A builder for [`PutObjectAnnotationInput`]
+    #[derive(Default)]
+    pub struct PutObjectAnnotationInputBuilder {
+        annotation_name: Option<AnnotationName>,
+
+        annotation_payload: Option<StreamingBlob>,
+
+        bucket: Option<BucketName>,
+
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+
+        checksum_crc32: Option<ChecksumCRC32>,
+
+        checksum_crc32c: Option<ChecksumCRC32C>,
+
+        checksum_crc64nvme: Option<ChecksumCRC64NVME>,
+
+        checksum_md5: Option<ChecksumMD5>,
+
+        checksum_sha1: Option<ChecksumSHA1>,
+
+        checksum_sha256: Option<ChecksumSHA256>,
+
+        checksum_sha512: Option<ChecksumSHA512>,
+
+        checksum_xxhash128: Option<ChecksumXXHASH128>,
+
+        checksum_xxhash3: Option<ChecksumXXHASH3>,
+
+        checksum_xxhash64: Option<ChecksumXXHASH64>,
+
+        content_md5: Option<ContentMD5>,
+
+        expected_bucket_owner: Option<AccountId>,
+
+        key: Option<ObjectKey>,
+
+        object_if_match: Option<ObjectIfMatch>,
+
+        request_payer: Option<RequestPayer>,
+
+        version_id: Option<ObjectVersionId>,
+    }
+
+    impl PutObjectAnnotationInputBuilder {
+        pub fn set_annotation_name(&mut self, field: AnnotationName) -> &mut Self {
+            self.annotation_name = Some(field);
+            self
+        }
+
+        pub fn set_annotation_payload(&mut self, field: Option<StreamingBlob>) -> &mut Self {
+            self.annotation_payload = field;
+            self
+        }
+
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_algorithm(&mut self, field: Option<ChecksumAlgorithm>) -> &mut Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        pub fn set_checksum_crc32(&mut self, field: Option<ChecksumCRC32>) -> &mut Self {
+            self.checksum_crc32 = field;
+            self
+        }
+
+        pub fn set_checksum_crc32c(&mut self, field: Option<ChecksumCRC32C>) -> &mut Self {
+            self.checksum_crc32c = field;
+            self
+        }
+
+        pub fn set_checksum_crc64nvme(&mut self, field: Option<ChecksumCRC64NVME>) -> &mut Self {
+            self.checksum_crc64nvme = field;
+            self
+        }
+
+        pub fn set_checksum_md5(&mut self, field: Option<ChecksumMD5>) -> &mut Self {
+            self.checksum_md5 = field;
+            self
+        }
+
+        pub fn set_checksum_sha1(&mut self, field: Option<ChecksumSHA1>) -> &mut Self {
+            self.checksum_sha1 = field;
+            self
+        }
+
+        pub fn set_checksum_sha256(&mut self, field: Option<ChecksumSHA256>) -> &mut Self {
+            self.checksum_sha256 = field;
+            self
+        }
+
+        pub fn set_checksum_sha512(&mut self, field: Option<ChecksumSHA512>) -> &mut Self {
+            self.checksum_sha512 = field;
+            self
+        }
+
+        pub fn set_checksum_xxhash128(&mut self, field: Option<ChecksumXXHASH128>) -> &mut Self {
+            self.checksum_xxhash128 = field;
+            self
+        }
+
+        pub fn set_checksum_xxhash3(&mut self, field: Option<ChecksumXXHASH3>) -> &mut Self {
+            self.checksum_xxhash3 = field;
+            self
+        }
+
+        pub fn set_checksum_xxhash64(&mut self, field: Option<ChecksumXXHASH64>) -> &mut Self {
+            self.checksum_xxhash64 = field;
+            self
+        }
+
+        pub fn set_content_md5(&mut self, field: Option<ContentMD5>) -> &mut Self {
+            self.content_md5 = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn set_key(&mut self, field: ObjectKey) -> &mut Self {
+            self.key = Some(field);
+            self
+        }
+
+        pub fn set_object_if_match(&mut self, field: Option<ObjectIfMatch>) -> &mut Self {
+            self.object_if_match = field;
+            self
+        }
+
+        pub fn set_request_payer(&mut self, field: Option<RequestPayer>) -> &mut Self {
+            self.request_payer = field;
+            self
+        }
+
+        pub fn set_version_id(&mut self, field: Option<ObjectVersionId>) -> &mut Self {
+            self.version_id = field;
+            self
+        }
+
+        #[must_use]
+        pub fn annotation_name(mut self, field: AnnotationName) -> Self {
+            self.annotation_name = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn annotation_payload(mut self, field: Option<StreamingBlob>) -> Self {
+            self.annotation_payload = field;
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_algorithm(mut self, field: Option<ChecksumAlgorithm>) -> Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_crc32(mut self, field: Option<ChecksumCRC32>) -> Self {
+            self.checksum_crc32 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_crc32c(mut self, field: Option<ChecksumCRC32C>) -> Self {
+            self.checksum_crc32c = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_crc64nvme(mut self, field: Option<ChecksumCRC64NVME>) -> Self {
+            self.checksum_crc64nvme = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_md5(mut self, field: Option<ChecksumMD5>) -> Self {
+            self.checksum_md5 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_sha1(mut self, field: Option<ChecksumSHA1>) -> Self {
+            self.checksum_sha1 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_sha256(mut self, field: Option<ChecksumSHA256>) -> Self {
+            self.checksum_sha256 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_sha512(mut self, field: Option<ChecksumSHA512>) -> Self {
+            self.checksum_sha512 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_xxhash128(mut self, field: Option<ChecksumXXHASH128>) -> Self {
+            self.checksum_xxhash128 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_xxhash3(mut self, field: Option<ChecksumXXHASH3>) -> Self {
+            self.checksum_xxhash3 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_xxhash64(mut self, field: Option<ChecksumXXHASH64>) -> Self {
+            self.checksum_xxhash64 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn content_md5(mut self, field: Option<ContentMD5>) -> Self {
+            self.content_md5 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn key(mut self, field: ObjectKey) -> Self {
+            self.key = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn object_if_match(mut self, field: Option<ObjectIfMatch>) -> Self {
+            self.object_if_match = field;
+            self
+        }
+
+        #[must_use]
+        pub fn request_payer(mut self, field: Option<RequestPayer>) -> Self {
+            self.request_payer = field;
+            self
+        }
+
+        #[must_use]
+        pub fn version_id(mut self, field: Option<ObjectVersionId>) -> Self {
+            self.version_id = field;
+            self
+        }
+
+        pub fn build(self) -> Result<PutObjectAnnotationInput, BuildError> {
+            let annotation_name = self
+                .annotation_name
+                .ok_or_else(|| BuildError::missing_field("annotation_name"))?;
+            let annotation_payload = self.annotation_payload;
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_algorithm = self.checksum_algorithm;
+            let checksum_crc32 = self.checksum_crc32;
+            let checksum_crc32c = self.checksum_crc32c;
+            let checksum_crc64nvme = self.checksum_crc64nvme;
+            let checksum_md5 = self.checksum_md5;
+            let checksum_sha1 = self.checksum_sha1;
+            let checksum_sha256 = self.checksum_sha256;
+            let checksum_sha512 = self.checksum_sha512;
+            let checksum_xxhash128 = self.checksum_xxhash128;
+            let checksum_xxhash3 = self.checksum_xxhash3;
+            let checksum_xxhash64 = self.checksum_xxhash64;
+            let content_md5 = self.content_md5;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            let key = self.key.ok_or_else(|| BuildError::missing_field("key"))?;
+            let object_if_match = self.object_if_match;
+            let request_payer = self.request_payer;
+            let version_id = self.version_id;
+            Ok(PutObjectAnnotationInput {
+                annotation_name,
+                annotation_payload,
+                bucket,
+                checksum_algorithm,
+                checksum_crc32,
+                checksum_crc32c,
+                checksum_crc64nvme,
+                checksum_md5,
+                checksum_sha1,
+                checksum_sha256,
+                checksum_sha512,
+                checksum_xxhash128,
+                checksum_xxhash3,
+                checksum_xxhash64,
+                content_md5,
+                expected_bucket_owner,
+                key,
+                object_if_match,
+                request_payer,
+                version_id,
+            })
+        }
+    }
+
     /// A builder for [`PutObjectLegalHoldInput`]
     #[derive(Default)]
     pub struct PutObjectLegalHoldInputBuilder {
@@ -46794,6 +48580,8 @@ pub mod builders {
     pub struct CopyObjectInputBuilder {
         acl: Option<ObjectCannedACL>,
 
+        annotation_directive: Option<AnnotationDirective>,
+
         bucket: Option<BucketName>,
 
         bucket_key_enabled: Option<BucketKeyEnabled>,
@@ -46840,6 +48628,10 @@ pub mod builders {
 
         grant_write_acp: Option<GrantWriteACP>,
 
+        if_match: Option<IfMatch>,
+
+        if_none_match: Option<IfNoneMatch>,
+
         key: Option<ObjectKey>,
 
         metadata: Option<Metadata>,
@@ -46880,6 +48672,11 @@ pub mod builders {
     impl CopyObjectInputBuilder {
         pub fn set_acl(&mut self, field: Option<ObjectCannedACL>) -> &mut Self {
             self.acl = field;
+            self
+        }
+
+        pub fn set_annotation_directive(&mut self, field: Option<AnnotationDirective>) -> &mut Self {
+            self.annotation_directive = field;
             self
         }
 
@@ -46998,6 +48795,16 @@ pub mod builders {
             self
         }
 
+        pub fn set_if_match(&mut self, field: Option<IfMatch>) -> &mut Self {
+            self.if_match = field;
+            self
+        }
+
+        pub fn set_if_none_match(&mut self, field: Option<IfNoneMatch>) -> &mut Self {
+            self.if_none_match = field;
+            self
+        }
+
         pub fn set_key(&mut self, field: ObjectKey) -> &mut Self {
             self.key = Some(field);
             self
@@ -47091,6 +48898,12 @@ pub mod builders {
         #[must_use]
         pub fn acl(mut self, field: Option<ObjectCannedACL>) -> Self {
             self.acl = field;
+            self
+        }
+
+        #[must_use]
+        pub fn annotation_directive(mut self, field: Option<AnnotationDirective>) -> Self {
+            self.annotation_directive = field;
             self
         }
 
@@ -47233,6 +49046,18 @@ pub mod builders {
         }
 
         #[must_use]
+        pub fn if_match(mut self, field: Option<IfMatch>) -> Self {
+            self.if_match = field;
+            self
+        }
+
+        #[must_use]
+        pub fn if_none_match(mut self, field: Option<IfNoneMatch>) -> Self {
+            self.if_none_match = field;
+            self
+        }
+
+        #[must_use]
         pub fn key(mut self, field: ObjectKey) -> Self {
             self.key = Some(field);
             self
@@ -47342,6 +49167,7 @@ pub mod builders {
 
         pub fn build(self) -> Result<CopyObjectInput, BuildError> {
             let acl = self.acl;
+            let annotation_directive = self.annotation_directive;
             let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
             let bucket_key_enabled = self.bucket_key_enabled;
             let cache_control = self.cache_control;
@@ -47365,6 +49191,8 @@ pub mod builders {
             let grant_read = self.grant_read;
             let grant_read_acp = self.grant_read_acp;
             let grant_write_acp = self.grant_write_acp;
+            let if_match = self.if_match;
+            let if_none_match = self.if_none_match;
             let key = self.key.ok_or_else(|| BuildError::missing_field("key"))?;
             let metadata = self.metadata;
             let metadata_directive = self.metadata_directive;
@@ -47385,6 +49213,7 @@ pub mod builders {
             let website_redirect_location = self.website_redirect_location;
             Ok(CopyObjectInput {
                 acl,
+                annotation_directive,
                 bucket,
                 bucket_key_enabled,
                 cache_control,
@@ -47408,6 +49237,8 @@ pub mod builders {
                 grant_read,
                 grant_read_acp,
                 grant_write_acp,
+                if_match,
+                if_none_match,
                 key,
                 metadata,
                 metadata_directive,
@@ -49225,6 +51056,124 @@ pub mod builders {
         }
     }
 
+    /// A builder for [`DeleteObjectAnnotationInput`]
+    #[derive(Default)]
+    pub struct DeleteObjectAnnotationInputBuilder {
+        annotation_name: Option<AnnotationName>,
+
+        bucket: Option<BucketName>,
+
+        expected_bucket_owner: Option<AccountId>,
+
+        key: Option<ObjectKey>,
+
+        object_if_match: Option<ObjectIfMatch>,
+
+        request_payer: Option<RequestPayer>,
+
+        version_id: Option<ObjectVersionId>,
+    }
+
+    impl DeleteObjectAnnotationInputBuilder {
+        pub fn set_annotation_name(&mut self, field: AnnotationName) -> &mut Self {
+            self.annotation_name = Some(field);
+            self
+        }
+
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn set_key(&mut self, field: ObjectKey) -> &mut Self {
+            self.key = Some(field);
+            self
+        }
+
+        pub fn set_object_if_match(&mut self, field: Option<ObjectIfMatch>) -> &mut Self {
+            self.object_if_match = field;
+            self
+        }
+
+        pub fn set_request_payer(&mut self, field: Option<RequestPayer>) -> &mut Self {
+            self.request_payer = field;
+            self
+        }
+
+        pub fn set_version_id(&mut self, field: Option<ObjectVersionId>) -> &mut Self {
+            self.version_id = field;
+            self
+        }
+
+        #[must_use]
+        pub fn annotation_name(mut self, field: AnnotationName) -> Self {
+            self.annotation_name = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn key(mut self, field: ObjectKey) -> Self {
+            self.key = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn object_if_match(mut self, field: Option<ObjectIfMatch>) -> Self {
+            self.object_if_match = field;
+            self
+        }
+
+        #[must_use]
+        pub fn request_payer(mut self, field: Option<RequestPayer>) -> Self {
+            self.request_payer = field;
+            self
+        }
+
+        #[must_use]
+        pub fn version_id(mut self, field: Option<ObjectVersionId>) -> Self {
+            self.version_id = field;
+            self
+        }
+
+        pub fn build(self) -> Result<DeleteObjectAnnotationInput, BuildError> {
+            let annotation_name = self
+                .annotation_name
+                .ok_or_else(|| BuildError::missing_field("annotation_name"))?;
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            let key = self.key.ok_or_else(|| BuildError::missing_field("key"))?;
+            let object_if_match = self.object_if_match;
+            let request_payer = self.request_payer;
+            let version_id = self.version_id;
+            Ok(DeleteObjectAnnotationInput {
+                annotation_name,
+                bucket,
+                expected_bucket_owner,
+                key,
+                object_if_match,
+                request_payer,
+                version_id,
+            })
+        }
+    }
+
     /// A builder for [`DeleteObjectTaggingInput`]
     #[derive(Default)]
     pub struct DeleteObjectTaggingInputBuilder {
@@ -50883,6 +52832,124 @@ pub mod builders {
         }
     }
 
+    /// A builder for [`GetObjectAnnotationInput`]
+    #[derive(Default)]
+    pub struct GetObjectAnnotationInputBuilder {
+        annotation_name: Option<AnnotationName>,
+
+        bucket: Option<BucketName>,
+
+        checksum_mode: Option<ChecksumMode>,
+
+        expected_bucket_owner: Option<AccountId>,
+
+        key: Option<ObjectKey>,
+
+        request_payer: Option<RequestPayer>,
+
+        version_id: Option<ObjectVersionId>,
+    }
+
+    impl GetObjectAnnotationInputBuilder {
+        pub fn set_annotation_name(&mut self, field: AnnotationName) -> &mut Self {
+            self.annotation_name = Some(field);
+            self
+        }
+
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_mode(&mut self, field: Option<ChecksumMode>) -> &mut Self {
+            self.checksum_mode = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn set_key(&mut self, field: ObjectKey) -> &mut Self {
+            self.key = Some(field);
+            self
+        }
+
+        pub fn set_request_payer(&mut self, field: Option<RequestPayer>) -> &mut Self {
+            self.request_payer = field;
+            self
+        }
+
+        pub fn set_version_id(&mut self, field: Option<ObjectVersionId>) -> &mut Self {
+            self.version_id = field;
+            self
+        }
+
+        #[must_use]
+        pub fn annotation_name(mut self, field: AnnotationName) -> Self {
+            self.annotation_name = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_mode(mut self, field: Option<ChecksumMode>) -> Self {
+            self.checksum_mode = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn key(mut self, field: ObjectKey) -> Self {
+            self.key = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn request_payer(mut self, field: Option<RequestPayer>) -> Self {
+            self.request_payer = field;
+            self
+        }
+
+        #[must_use]
+        pub fn version_id(mut self, field: Option<ObjectVersionId>) -> Self {
+            self.version_id = field;
+            self
+        }
+
+        pub fn build(self) -> Result<GetObjectAnnotationInput, BuildError> {
+            let annotation_name = self
+                .annotation_name
+                .ok_or_else(|| BuildError::missing_field("annotation_name"))?;
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_mode = self.checksum_mode;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            let key = self.key.ok_or_else(|| BuildError::missing_field("key"))?;
+            let request_payer = self.request_payer;
+            let version_id = self.version_id;
+            Ok(GetObjectAnnotationInput {
+                annotation_name,
+                bucket,
+                checksum_mode,
+                expected_bucket_owner,
+                key,
+                request_payer,
+                version_id,
+            })
+        }
+    }
+
     /// A builder for [`GetObjectAttributesInput`]
     #[derive(Default)]
     pub struct GetObjectAttributesInputBuilder {
@@ -52315,6 +54382,137 @@ pub mod builders {
                 prefix,
                 request_payer,
                 upload_id_marker,
+            })
+        }
+    }
+
+    /// A builder for [`ListObjectAnnotationsInput`]
+    #[derive(Default)]
+    pub struct ListObjectAnnotationsInputBuilder {
+        annotation_prefix: Option<AnnotationPrefix>,
+
+        bucket: Option<BucketName>,
+
+        continuation_token: Option<Token>,
+
+        expected_bucket_owner: Option<AccountId>,
+
+        key: Option<ObjectKey>,
+
+        max_annotation_results: Option<MaxAnnotationResults>,
+
+        request_payer: Option<RequestPayer>,
+
+        version_id: Option<ObjectVersionId>,
+    }
+
+    impl ListObjectAnnotationsInputBuilder {
+        pub fn set_annotation_prefix(&mut self, field: Option<AnnotationPrefix>) -> &mut Self {
+            self.annotation_prefix = field;
+            self
+        }
+
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_continuation_token(&mut self, field: Option<Token>) -> &mut Self {
+            self.continuation_token = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn set_key(&mut self, field: ObjectKey) -> &mut Self {
+            self.key = Some(field);
+            self
+        }
+
+        pub fn set_max_annotation_results(&mut self, field: Option<MaxAnnotationResults>) -> &mut Self {
+            self.max_annotation_results = field;
+            self
+        }
+
+        pub fn set_request_payer(&mut self, field: Option<RequestPayer>) -> &mut Self {
+            self.request_payer = field;
+            self
+        }
+
+        pub fn set_version_id(&mut self, field: Option<ObjectVersionId>) -> &mut Self {
+            self.version_id = field;
+            self
+        }
+
+        #[must_use]
+        pub fn annotation_prefix(mut self, field: Option<AnnotationPrefix>) -> Self {
+            self.annotation_prefix = field;
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn continuation_token(mut self, field: Option<Token>) -> Self {
+            self.continuation_token = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn key(mut self, field: ObjectKey) -> Self {
+            self.key = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn max_annotation_results(mut self, field: Option<MaxAnnotationResults>) -> Self {
+            self.max_annotation_results = field;
+            self
+        }
+
+        #[must_use]
+        pub fn request_payer(mut self, field: Option<RequestPayer>) -> Self {
+            self.request_payer = field;
+            self
+        }
+
+        #[must_use]
+        pub fn version_id(mut self, field: Option<ObjectVersionId>) -> Self {
+            self.version_id = field;
+            self
+        }
+
+        pub fn build(self) -> Result<ListObjectAnnotationsInput, BuildError> {
+            let annotation_prefix = self.annotation_prefix;
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let continuation_token = self.continuation_token;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            let key = self.key.ok_or_else(|| BuildError::missing_field("key"))?;
+            let max_annotation_results = self.max_annotation_results;
+            let request_payer = self.request_payer;
+            let version_id = self.version_id;
+            Ok(ListObjectAnnotationsInput {
+                annotation_prefix,
+                bucket,
+                continuation_token,
+                expected_bucket_owner,
+                key,
+                max_annotation_results,
+                request_payer,
+                version_id,
             })
         }
     }
@@ -56436,6 +58634,319 @@ pub mod builders {
                 grant_write,
                 grant_write_acp,
                 key,
+                request_payer,
+                version_id,
+            })
+        }
+    }
+
+    /// A builder for [`PutObjectAnnotationInput`]
+    #[derive(Default)]
+    pub struct PutObjectAnnotationInputBuilder {
+        annotation_name: Option<AnnotationName>,
+
+        annotation_payload: Option<StreamingBlob>,
+
+        bucket: Option<BucketName>,
+
+        checksum_algorithm: Option<ChecksumAlgorithm>,
+
+        checksum_crc32: Option<ChecksumCRC32>,
+
+        checksum_crc32c: Option<ChecksumCRC32C>,
+
+        checksum_crc64nvme: Option<ChecksumCRC64NVME>,
+
+        checksum_md5: Option<ChecksumMD5>,
+
+        checksum_sha1: Option<ChecksumSHA1>,
+
+        checksum_sha256: Option<ChecksumSHA256>,
+
+        checksum_sha512: Option<ChecksumSHA512>,
+
+        checksum_xxhash128: Option<ChecksumXXHASH128>,
+
+        checksum_xxhash3: Option<ChecksumXXHASH3>,
+
+        checksum_xxhash64: Option<ChecksumXXHASH64>,
+
+        content_md5: Option<ContentMD5>,
+
+        expected_bucket_owner: Option<AccountId>,
+
+        key: Option<ObjectKey>,
+
+        object_if_match: Option<ObjectIfMatch>,
+
+        request_payer: Option<RequestPayer>,
+
+        version_id: Option<ObjectVersionId>,
+    }
+
+    impl PutObjectAnnotationInputBuilder {
+        pub fn set_annotation_name(&mut self, field: AnnotationName) -> &mut Self {
+            self.annotation_name = Some(field);
+            self
+        }
+
+        pub fn set_annotation_payload(&mut self, field: Option<StreamingBlob>) -> &mut Self {
+            self.annotation_payload = field;
+            self
+        }
+
+        pub fn set_bucket(&mut self, field: BucketName) -> &mut Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        pub fn set_checksum_algorithm(&mut self, field: Option<ChecksumAlgorithm>) -> &mut Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        pub fn set_checksum_crc32(&mut self, field: Option<ChecksumCRC32>) -> &mut Self {
+            self.checksum_crc32 = field;
+            self
+        }
+
+        pub fn set_checksum_crc32c(&mut self, field: Option<ChecksumCRC32C>) -> &mut Self {
+            self.checksum_crc32c = field;
+            self
+        }
+
+        pub fn set_checksum_crc64nvme(&mut self, field: Option<ChecksumCRC64NVME>) -> &mut Self {
+            self.checksum_crc64nvme = field;
+            self
+        }
+
+        pub fn set_checksum_md5(&mut self, field: Option<ChecksumMD5>) -> &mut Self {
+            self.checksum_md5 = field;
+            self
+        }
+
+        pub fn set_checksum_sha1(&mut self, field: Option<ChecksumSHA1>) -> &mut Self {
+            self.checksum_sha1 = field;
+            self
+        }
+
+        pub fn set_checksum_sha256(&mut self, field: Option<ChecksumSHA256>) -> &mut Self {
+            self.checksum_sha256 = field;
+            self
+        }
+
+        pub fn set_checksum_sha512(&mut self, field: Option<ChecksumSHA512>) -> &mut Self {
+            self.checksum_sha512 = field;
+            self
+        }
+
+        pub fn set_checksum_xxhash128(&mut self, field: Option<ChecksumXXHASH128>) -> &mut Self {
+            self.checksum_xxhash128 = field;
+            self
+        }
+
+        pub fn set_checksum_xxhash3(&mut self, field: Option<ChecksumXXHASH3>) -> &mut Self {
+            self.checksum_xxhash3 = field;
+            self
+        }
+
+        pub fn set_checksum_xxhash64(&mut self, field: Option<ChecksumXXHASH64>) -> &mut Self {
+            self.checksum_xxhash64 = field;
+            self
+        }
+
+        pub fn set_content_md5(&mut self, field: Option<ContentMD5>) -> &mut Self {
+            self.content_md5 = field;
+            self
+        }
+
+        pub fn set_expected_bucket_owner(&mut self, field: Option<AccountId>) -> &mut Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        pub fn set_key(&mut self, field: ObjectKey) -> &mut Self {
+            self.key = Some(field);
+            self
+        }
+
+        pub fn set_object_if_match(&mut self, field: Option<ObjectIfMatch>) -> &mut Self {
+            self.object_if_match = field;
+            self
+        }
+
+        pub fn set_request_payer(&mut self, field: Option<RequestPayer>) -> &mut Self {
+            self.request_payer = field;
+            self
+        }
+
+        pub fn set_version_id(&mut self, field: Option<ObjectVersionId>) -> &mut Self {
+            self.version_id = field;
+            self
+        }
+
+        #[must_use]
+        pub fn annotation_name(mut self, field: AnnotationName) -> Self {
+            self.annotation_name = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn annotation_payload(mut self, field: Option<StreamingBlob>) -> Self {
+            self.annotation_payload = field;
+            self
+        }
+
+        #[must_use]
+        pub fn bucket(mut self, field: BucketName) -> Self {
+            self.bucket = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_algorithm(mut self, field: Option<ChecksumAlgorithm>) -> Self {
+            self.checksum_algorithm = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_crc32(mut self, field: Option<ChecksumCRC32>) -> Self {
+            self.checksum_crc32 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_crc32c(mut self, field: Option<ChecksumCRC32C>) -> Self {
+            self.checksum_crc32c = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_crc64nvme(mut self, field: Option<ChecksumCRC64NVME>) -> Self {
+            self.checksum_crc64nvme = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_md5(mut self, field: Option<ChecksumMD5>) -> Self {
+            self.checksum_md5 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_sha1(mut self, field: Option<ChecksumSHA1>) -> Self {
+            self.checksum_sha1 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_sha256(mut self, field: Option<ChecksumSHA256>) -> Self {
+            self.checksum_sha256 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_sha512(mut self, field: Option<ChecksumSHA512>) -> Self {
+            self.checksum_sha512 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_xxhash128(mut self, field: Option<ChecksumXXHASH128>) -> Self {
+            self.checksum_xxhash128 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_xxhash3(mut self, field: Option<ChecksumXXHASH3>) -> Self {
+            self.checksum_xxhash3 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn checksum_xxhash64(mut self, field: Option<ChecksumXXHASH64>) -> Self {
+            self.checksum_xxhash64 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn content_md5(mut self, field: Option<ContentMD5>) -> Self {
+            self.content_md5 = field;
+            self
+        }
+
+        #[must_use]
+        pub fn expected_bucket_owner(mut self, field: Option<AccountId>) -> Self {
+            self.expected_bucket_owner = field;
+            self
+        }
+
+        #[must_use]
+        pub fn key(mut self, field: ObjectKey) -> Self {
+            self.key = Some(field);
+            self
+        }
+
+        #[must_use]
+        pub fn object_if_match(mut self, field: Option<ObjectIfMatch>) -> Self {
+            self.object_if_match = field;
+            self
+        }
+
+        #[must_use]
+        pub fn request_payer(mut self, field: Option<RequestPayer>) -> Self {
+            self.request_payer = field;
+            self
+        }
+
+        #[must_use]
+        pub fn version_id(mut self, field: Option<ObjectVersionId>) -> Self {
+            self.version_id = field;
+            self
+        }
+
+        pub fn build(self) -> Result<PutObjectAnnotationInput, BuildError> {
+            let annotation_name = self
+                .annotation_name
+                .ok_or_else(|| BuildError::missing_field("annotation_name"))?;
+            let annotation_payload = self.annotation_payload;
+            let bucket = self.bucket.ok_or_else(|| BuildError::missing_field("bucket"))?;
+            let checksum_algorithm = self.checksum_algorithm;
+            let checksum_crc32 = self.checksum_crc32;
+            let checksum_crc32c = self.checksum_crc32c;
+            let checksum_crc64nvme = self.checksum_crc64nvme;
+            let checksum_md5 = self.checksum_md5;
+            let checksum_sha1 = self.checksum_sha1;
+            let checksum_sha256 = self.checksum_sha256;
+            let checksum_sha512 = self.checksum_sha512;
+            let checksum_xxhash128 = self.checksum_xxhash128;
+            let checksum_xxhash3 = self.checksum_xxhash3;
+            let checksum_xxhash64 = self.checksum_xxhash64;
+            let content_md5 = self.content_md5;
+            let expected_bucket_owner = self.expected_bucket_owner;
+            let key = self.key.ok_or_else(|| BuildError::missing_field("key"))?;
+            let object_if_match = self.object_if_match;
+            let request_payer = self.request_payer;
+            let version_id = self.version_id;
+            Ok(PutObjectAnnotationInput {
+                annotation_name,
+                annotation_payload,
+                bucket,
+                checksum_algorithm,
+                checksum_crc32,
+                checksum_crc32c,
+                checksum_crc64nvme,
+                checksum_md5,
+                checksum_sha1,
+                checksum_sha256,
+                checksum_sha512,
+                checksum_xxhash128,
+                checksum_xxhash3,
+                checksum_xxhash64,
+                content_md5,
+                expected_bucket_owner,
+                key,
+                object_if_match,
                 request_payer,
                 version_id,
             })

--- a/crates/s3s/src/header/generated.rs
+++ b/crates/s3s/src/header/generated.rs
@@ -264,7 +264,11 @@ pub const X_AMZ_MP_OBJECT_SIZE: HeaderName = HeaderName::from_static("x-amz-mp-o
 
 pub const X_AMZ_MP_PARTS_COUNT: HeaderName = HeaderName::from_static("x-amz-mp-parts-count");
 
+pub const X_AMZ_OBJECT_ANNOTATION_DIRECTIVE: HeaderName = HeaderName::from_static("x-amz-object-annotation-directive");
+
 pub const X_AMZ_OBJECT_ATTRIBUTES: HeaderName = HeaderName::from_static("x-amz-object-attributes");
+
+pub const X_AMZ_OBJECT_IF_MATCH: HeaderName = HeaderName::from_static("x-amz-object-if-match");
 
 pub const X_AMZ_OBJECT_LOCK_LEGAL_HOLD: HeaderName = HeaderName::from_static("x-amz-object-lock-legal-hold");
 
@@ -275,6 +279,8 @@ pub const X_AMZ_OBJECT_LOCK_RETAIN_UNTIL_DATE: HeaderName = HeaderName::from_sta
 pub const X_AMZ_OBJECT_OWNERSHIP: HeaderName = HeaderName::from_static("x-amz-object-ownership");
 
 pub const X_AMZ_OBJECT_SIZE: HeaderName = HeaderName::from_static("x-amz-object-size");
+
+pub const X_AMZ_OBJECT_VERSION_ID: HeaderName = HeaderName::from_static("x-amz-object-version-id");
 
 pub const X_AMZ_OPTIONAL_OBJECT_ATTRIBUTES: HeaderName = HeaderName::from_static("x-amz-optional-object-attributes");
 

--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -27,6 +27,7 @@
 // DeleteBucketTagging
 // DeleteBucketWebsite
 // DeleteObject
+// DeleteObjectAnnotation
 // DeleteObjectTagging
 // DeleteObjects
 // DeletePublicAccessBlock
@@ -55,6 +56,7 @@
 // GetBucketWebsite
 // GetObject
 // GetObjectAcl
+// GetObjectAnnotation
 // GetObjectAttributes
 // GetObjectLegalHold
 // GetObjectLockConfiguration
@@ -71,6 +73,7 @@
 // ListBuckets
 // ListDirectoryBuckets
 // ListMultipartUploads
+// ListObjectAnnotations
 // ListObjectVersions
 // ListObjects
 // ListObjectsV2
@@ -97,6 +100,7 @@
 // PutBucketWebsite
 // PutObject
 // PutObjectAcl
+// PutObjectAnnotation
 // PutObjectLegalHold
 // PutObjectLockConfiguration
 // PutObjectRetention
@@ -133,6 +137,24 @@ use crate::ops::CallContext;
 use crate::path::S3Path;
 
 use std::borrow::Cow;
+
+impl http::TryIntoHeaderValue for AnnotationDirective {
+    type Error = http::InvalidHeaderValue;
+    fn try_into_header_value(self) -> Result<http::HeaderValue, Self::Error> {
+        match Cow::from(self) {
+            Cow::Borrowed(s) => http::HeaderValue::try_from(s),
+            Cow::Owned(s) => http::HeaderValue::try_from(s),
+        }
+    }
+}
+
+impl http::TryFromHeaderValue for AnnotationDirective {
+    type Error = http::ParseHeaderError;
+    fn try_from_header_value(val: &http::HeaderValue) -> Result<Self, Self::Error> {
+        let val = val.to_str().map_err(|_| http::ParseHeaderError::Enum)?;
+        Ok(Self::from(val.to_owned()))
+    }
+}
 
 impl http::TryIntoHeaderValue for ArchiveStatus {
     type Error = http::InvalidHeaderValue;
@@ -728,6 +750,8 @@ impl CopyObject {
 
         let acl: Option<ObjectCannedACL> = http::parse_opt_header(req, &X_AMZ_ACL)?;
 
+        let annotation_directive: Option<AnnotationDirective> = http::parse_opt_header(req, &X_AMZ_OBJECT_ANNOTATION_DIRECTIVE)?;
+
         let bucket_key_enabled: Option<BucketKeyEnabled> =
             http::parse_opt_header(req, &X_AMZ_SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED)?;
 
@@ -778,6 +802,10 @@ impl CopyObject {
         let grant_read_acp: Option<GrantReadACP> = http::parse_opt_header(req, &X_AMZ_GRANT_READ_ACP)?;
 
         let grant_write_acp: Option<GrantWriteACP> = http::parse_opt_header(req, &X_AMZ_GRANT_WRITE_ACP)?;
+
+        let if_match: Option<IfMatch> = http::parse_opt_header(req, &IF_MATCH)?;
+
+        let if_none_match: Option<IfNoneMatch> = http::parse_opt_header(req, &IF_NONE_MATCH)?;
 
         let metadata: Option<Metadata> = http::parse_opt_metadata(req)?;
 
@@ -819,6 +847,7 @@ impl CopyObject {
 
         Ok(CopyObjectInput {
             acl,
+            annotation_directive,
             bucket,
             bucket_key_enabled,
             cache_control,
@@ -842,6 +871,8 @@ impl CopyObject {
             grant_read,
             grant_read_acp,
             grant_write_acp,
+            if_match,
+            if_none_match,
             key,
             metadata,
             metadata_directive,
@@ -867,6 +898,8 @@ impl CopyObject {
         let (bucket, key) = http::unwrap_object(req);
 
         let acl: Option<ObjectCannedACL> = http::parse_opt_header(req, &X_AMZ_ACL)?;
+
+        let annotation_directive: Option<AnnotationDirective> = http::parse_opt_header(req, &X_AMZ_OBJECT_ANNOTATION_DIRECTIVE)?;
 
         let bucket_key_enabled: Option<BucketKeyEnabled> =
             http::parse_opt_header(req, &X_AMZ_SERVER_SIDE_ENCRYPTION_BUCKET_KEY_ENABLED)?;
@@ -918,6 +951,10 @@ impl CopyObject {
         let grant_read_acp: Option<GrantReadACP> = http::parse_opt_header(req, &X_AMZ_GRANT_READ_ACP)?;
 
         let grant_write_acp: Option<GrantWriteACP> = http::parse_opt_header(req, &X_AMZ_GRANT_WRITE_ACP)?;
+
+        let if_match: Option<IfMatch> = http::parse_opt_header(req, &IF_MATCH)?;
+
+        let if_none_match: Option<IfNoneMatch> = http::parse_opt_header(req, &IF_NONE_MATCH)?;
 
         let metadata: Option<Metadata> = http::parse_opt_metadata(req)?;
 
@@ -961,6 +998,7 @@ impl CopyObject {
 
         Ok(CopyObjectInput {
             acl,
+            annotation_directive,
             bucket,
             bucket_key_enabled,
             cache_control,
@@ -984,6 +1022,8 @@ impl CopyObject {
             grant_read,
             grant_read_acp,
             grant_write_acp,
+            if_match,
+            if_none_match,
             key,
             metadata,
             metadata_directive,
@@ -2561,6 +2601,78 @@ impl super::Operation for DeleteObject {
             access.delete_object(&mut s3_req).await?;
         }
         let result = s3.delete_object(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
+pub struct DeleteObjectAnnotation;
+
+impl DeleteObjectAnnotation {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<DeleteObjectAnnotationInput> {
+        let (bucket, key) = http::unwrap_object(req);
+
+        let annotation_name: AnnotationName = http::parse_query(req, "annotationName")?;
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        let object_if_match: Option<ObjectIfMatch> = http::parse_opt_header(req, &X_AMZ_OBJECT_IF_MATCH)?;
+
+        let request_payer: Option<RequestPayer> = http::parse_opt_header(req, &X_AMZ_REQUEST_PAYER)?;
+
+        let version_id: Option<ObjectVersionId> = http::parse_opt_query(req, "versionId")?;
+
+        Ok(DeleteObjectAnnotationInput {
+            annotation_name,
+            bucket,
+            expected_bucket_owner,
+            key,
+            object_if_match,
+            request_payer,
+            version_id,
+        })
+    }
+
+    pub fn serialize_http(x: DeleteObjectAnnotationOutput) -> S3Result<http::Response> {
+        let mut res = http::Response::with_status(http::StatusCode::NO_CONTENT);
+        http::add_opt_header(&mut res, X_AMZ_OBJECT_VERSION_ID, x.object_version_id)?;
+        http::add_opt_header(&mut res, X_AMZ_REQUEST_CHARGED, x.request_charged)?;
+        Ok(res)
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for DeleteObjectAnnotation {
+    fn name(&self) -> &'static str {
+        "DeleteObjectAnnotation"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
+    fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.delete_object_annotation(&mut s3_req).await?;
+        }
+        let result = s3.delete_object_annotation(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
             Err(err) => return super::serialize_error(err, false),
@@ -4383,6 +4495,97 @@ impl super::Operation for GetObjectAcl {
     }
 }
 
+pub struct GetObjectAnnotation;
+
+impl GetObjectAnnotation {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<GetObjectAnnotationInput> {
+        let (bucket, key) = http::unwrap_object(req);
+
+        let annotation_name: AnnotationName = http::parse_query(req, "annotationName")?;
+
+        let checksum_mode: Option<ChecksumMode> = http::parse_opt_header(req, &X_AMZ_CHECKSUM_MODE)?;
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        let request_payer: Option<RequestPayer> = http::parse_opt_header(req, &X_AMZ_REQUEST_PAYER)?;
+
+        let version_id: Option<ObjectVersionId> = http::parse_opt_query(req, "versionId")?;
+
+        Ok(GetObjectAnnotationInput {
+            annotation_name,
+            bucket,
+            checksum_mode,
+            expected_bucket_owner,
+            key,
+            request_payer,
+            version_id,
+        })
+    }
+
+    pub fn serialize_http(x: GetObjectAnnotationOutput) -> S3Result<http::Response> {
+        let mut res = http::Response::with_status(http::StatusCode::OK);
+        if let Some(val) = x.annotation_payload {
+            http::set_stream_body(&mut res, val);
+        }
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_CRC32, x.checksum_crc32)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_CRC32C, x.checksum_crc32c)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_CRC64NVME, x.checksum_crc64nvme)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_MD5, x.checksum_md5)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_SHA1, x.checksum_sha1)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_SHA256, x.checksum_sha256)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_SHA512, x.checksum_sha512)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_TYPE, x.checksum_type)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_XXHASH128, x.checksum_xxhash128)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_XXHASH3, x.checksum_xxhash3)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_XXHASH64, x.checksum_xxhash64)?;
+        http::add_opt_header(&mut res, CONTENT_LENGTH, x.content_length)?;
+        http::add_opt_header(&mut res, ETAG, x.e_tag)?;
+        http::add_opt_header_timestamp(&mut res, LAST_MODIFIED, x.last_modified, TimestampFormat::HttpDate)?;
+        http::add_opt_header(&mut res, X_AMZ_OBJECT_VERSION_ID, x.object_version_id)?;
+        http::add_opt_header(&mut res, X_AMZ_REPLICATION_STATUS, x.replication_status)?;
+        http::add_opt_header(&mut res, X_AMZ_REQUEST_CHARGED, x.request_charged)?;
+        http::add_opt_header(&mut res, X_AMZ_SERVER_SIDE_ENCRYPTION, x.server_side_encryption)?;
+        Ok(res)
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for GetObjectAnnotation {
+    fn name(&self) -> &'static str {
+        "GetObjectAnnotation"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
+    fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.get_object_annotation(&mut s3_req).await?;
+        }
+        let result = s3.get_object_annotation(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
 pub struct GetObjectAttributes;
 
 impl GetObjectAttributes {
@@ -5518,6 +5721,82 @@ impl super::Operation for ListMultipartUploads {
             access.list_multipart_uploads(&mut s3_req).await?;
         }
         let result = s3.list_multipart_uploads(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
+pub struct ListObjectAnnotations;
+
+impl ListObjectAnnotations {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<ListObjectAnnotationsInput> {
+        let (bucket, key) = http::unwrap_object(req);
+
+        let annotation_prefix: Option<AnnotationPrefix> = http::parse_opt_query(req, "annotation-prefix")?;
+
+        let continuation_token: Option<Token> = http::parse_opt_query(req, "continuation-token")?;
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        let max_annotation_results: Option<MaxAnnotationResults> = http::parse_opt_query(req, "max-annotation-results")?;
+
+        let request_payer: Option<RequestPayer> = http::parse_opt_header(req, &X_AMZ_REQUEST_PAYER)?;
+
+        let version_id: Option<ObjectVersionId> = http::parse_opt_query(req, "versionId")?;
+
+        Ok(ListObjectAnnotationsInput {
+            annotation_prefix,
+            bucket,
+            continuation_token,
+            expected_bucket_owner,
+            key,
+            max_annotation_results,
+            request_payer,
+            version_id,
+        })
+    }
+
+    pub fn serialize_http(x: ListObjectAnnotationsOutput) -> S3Result<http::Response> {
+        let mut res = http::Response::with_status(http::StatusCode::OK);
+        http::set_xml_body(&mut res, &x)?;
+        http::add_opt_header(&mut res, X_AMZ_OBJECT_VERSION_ID, x.object_version_id)?;
+        http::add_opt_header(&mut res, X_AMZ_REQUEST_CHARGED, x.request_charged)?;
+        Ok(res)
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for ListObjectAnnotations {
+    fn name(&self) -> &'static str {
+        "ListObjectAnnotations"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
+    fn has_request_payload(&self) -> bool {
+        false
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.list_object_annotations(&mut s3_req).await?;
+        }
+        let result = s3.list_object_annotations(s3_req).await;
         let s3_resp = match result {
             Ok(val) => val,
             Err(err) => return super::serialize_error(err, false),
@@ -8030,6 +8309,131 @@ impl super::Operation for PutObjectAcl {
     }
 }
 
+pub struct PutObjectAnnotation;
+
+impl PutObjectAnnotation {
+    pub fn deserialize_http(req: &mut http::Request) -> S3Result<PutObjectAnnotationInput> {
+        let (bucket, key) = http::unwrap_object(req);
+
+        let annotation_name: AnnotationName = http::parse_query(req, "annotationName")?;
+
+        let annotation_payload: Option<StreamingBlob> = Some(http::take_stream_body(req));
+
+        let checksum_algorithm: Option<ChecksumAlgorithm> = http::parse_checksum_algorithm_header(req)?;
+
+        let checksum_crc32: Option<ChecksumCRC32> = http::parse_opt_header(req, &X_AMZ_CHECKSUM_CRC32)?;
+
+        let checksum_crc32c: Option<ChecksumCRC32C> = http::parse_opt_header(req, &X_AMZ_CHECKSUM_CRC32C)?;
+
+        let checksum_crc64nvme: Option<ChecksumCRC64NVME> = http::parse_opt_header(req, &X_AMZ_CHECKSUM_CRC64NVME)?;
+
+        let checksum_md5: Option<ChecksumMD5> = http::parse_opt_header(req, &X_AMZ_CHECKSUM_MD5)?;
+
+        let checksum_sha1: Option<ChecksumSHA1> = http::parse_opt_header(req, &X_AMZ_CHECKSUM_SHA1)?;
+
+        let checksum_sha256: Option<ChecksumSHA256> = http::parse_opt_header(req, &X_AMZ_CHECKSUM_SHA256)?;
+
+        let checksum_sha512: Option<ChecksumSHA512> = http::parse_opt_header(req, &X_AMZ_CHECKSUM_SHA512)?;
+
+        let checksum_xxhash128: Option<ChecksumXXHASH128> = http::parse_opt_header(req, &X_AMZ_CHECKSUM_XXHASH128)?;
+
+        let checksum_xxhash3: Option<ChecksumXXHASH3> = http::parse_opt_header(req, &X_AMZ_CHECKSUM_XXHASH3)?;
+
+        let checksum_xxhash64: Option<ChecksumXXHASH64> = http::parse_opt_header(req, &X_AMZ_CHECKSUM_XXHASH64)?;
+
+        let content_md5: Option<ContentMD5> = http::parse_opt_header(req, &CONTENT_MD5)?;
+
+        let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
+
+        let object_if_match: Option<ObjectIfMatch> = http::parse_opt_header(req, &X_AMZ_OBJECT_IF_MATCH)?;
+
+        let request_payer: Option<RequestPayer> = http::parse_opt_header(req, &X_AMZ_REQUEST_PAYER)?;
+
+        let version_id: Option<ObjectVersionId> = http::parse_opt_query(req, "versionId")?;
+
+        Ok(PutObjectAnnotationInput {
+            annotation_name,
+            annotation_payload,
+            bucket,
+            checksum_algorithm,
+            checksum_crc32,
+            checksum_crc32c,
+            checksum_crc64nvme,
+            checksum_md5,
+            checksum_sha1,
+            checksum_sha256,
+            checksum_sha512,
+            checksum_xxhash128,
+            checksum_xxhash3,
+            checksum_xxhash64,
+            content_md5,
+            expected_bucket_owner,
+            key,
+            object_if_match,
+            request_payer,
+            version_id,
+        })
+    }
+
+    pub fn serialize_http(x: PutObjectAnnotationOutput) -> S3Result<http::Response> {
+        let mut res = http::Response::with_status(http::StatusCode::OK);
+        http::set_xml_body(&mut res, &x)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_CRC32, x.checksum_crc32)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_CRC32C, x.checksum_crc32c)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_CRC64NVME, x.checksum_crc64nvme)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_MD5, x.checksum_md5)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_SHA1, x.checksum_sha1)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_SHA256, x.checksum_sha256)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_SHA512, x.checksum_sha512)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_TYPE, x.checksum_type)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_XXHASH128, x.checksum_xxhash128)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_XXHASH3, x.checksum_xxhash3)?;
+        http::add_opt_header(&mut res, X_AMZ_CHECKSUM_XXHASH64, x.checksum_xxhash64)?;
+        http::add_opt_header(&mut res, ETAG, x.e_tag)?;
+        http::add_opt_header(&mut res, X_AMZ_OBJECT_VERSION_ID, x.object_version_id)?;
+        http::add_opt_header(&mut res, X_AMZ_REQUEST_CHARGED, x.request_charged)?;
+        http::add_opt_header(&mut res, X_AMZ_SERVER_SIDE_ENCRYPTION, x.server_side_encryption)?;
+        Ok(res)
+    }
+}
+
+#[async_trait::async_trait]
+impl super::Operation for PutObjectAnnotation {
+    fn name(&self) -> &'static str {
+        "PutObjectAnnotation"
+    }
+
+    fn needs_full_body(&self) -> bool {
+        false
+    }
+
+    fn has_request_payload(&self) -> bool {
+        true
+    }
+
+    fn has_streaming_body(&self) -> bool {
+        true
+    }
+
+    async fn call(&self, ccx: &CallContext<'_>, req: &mut http::Request) -> S3Result<http::Response> {
+        let input = Self::deserialize_http(req)?;
+        let mut s3_req = super::build_s3_request(input, req);
+        let s3 = ccx.s3;
+        if let Some(access) = ccx.access {
+            access.put_object_annotation(&mut s3_req).await?;
+        }
+        let result = s3.put_object_annotation(s3_req).await;
+        let s3_resp = match result {
+            Ok(val) => val,
+            Err(err) => return super::serialize_error(err, false),
+        };
+        let mut resp = Self::serialize_http(s3_resp.output)?;
+        resp.headers.extend(s3_resp.headers);
+        resp.extensions.extend(s3_resp.extensions);
+        Ok(resp)
+    }
+}
+
 pub struct PutObjectLegalHold;
 
 impl PutObjectLegalHold {
@@ -9650,16 +10054,16 @@ pub fn resolve_route(
                     if qs.has("publicAccessBlock") {
                         return Ok(&GetPublicAccessBlock as &'static dyn super::Operation);
                     }
-                    if qs.has("analytics") && !qs.has("id") {
+                    if qs.has("analytics") {
                         return Ok(&ListBucketAnalyticsConfigurations as &'static dyn super::Operation);
                     }
-                    if qs.has("intelligent-tiering") && !qs.has("id") {
+                    if qs.has("intelligent-tiering") {
                         return Ok(&ListBucketIntelligentTieringConfigurations as &'static dyn super::Operation);
                     }
-                    if qs.has("inventory") && !qs.has("id") {
+                    if qs.has("inventory") {
                         return Ok(&ListBucketInventoryConfigurations as &'static dyn super::Operation);
                     }
-                    if qs.has("metrics") && !qs.has("id") {
+                    if qs.has("metrics") {
                         return Ok(&ListBucketMetricsConfigurations as &'static dyn super::Operation);
                     }
                     if qs.has("uploads") {
@@ -9676,6 +10080,9 @@ pub fn resolve_route(
             }
             S3Path::Object { .. } => {
                 if let Some(qs) = qs {
+                    if qs.has("annotation") && qs.has("annotationName") {
+                        return Ok(&GetObjectAnnotation as &'static dyn super::Operation);
+                    }
                     if qs.has("attributes") {
                         return Ok(&GetObjectAttributes as &'static dyn super::Operation);
                     }
@@ -9693,6 +10100,9 @@ pub fn resolve_route(
                     }
                     if qs.has("torrent") {
                         return Ok(&GetObjectTorrent as &'static dyn super::Operation);
+                    }
+                    if qs.has("annotation") {
+                        return Ok(&ListObjectAnnotations as &'static dyn super::Operation);
                     }
                 }
                 if let Some(qs) = qs
@@ -9823,6 +10233,9 @@ pub fn resolve_route(
             }
             S3Path::Object { .. } => {
                 if let Some(qs) = qs {
+                    if qs.has("annotation") {
+                        return Ok(&PutObjectAnnotation as &'static dyn super::Operation);
+                    }
                     if qs.has("renameObject") {
                         return Ok(&RenameObject as &'static dyn super::Operation);
                     }
@@ -9915,6 +10328,9 @@ pub fn resolve_route(
             }
             S3Path::Object { .. } => {
                 if let Some(qs) = qs {
+                    if qs.has("annotation") {
+                        return Ok(&DeleteObjectAnnotation as &'static dyn super::Operation);
+                    }
                     if qs.has("tagging") {
                         return Ok(&DeleteObjectTagging as &'static dyn super::Operation);
                     }
@@ -10032,16 +10448,16 @@ pub fn resolve_route(
                     if qs.has("publicAccessBlock") {
                         return Ok(&GetPublicAccessBlock as &'static dyn super::Operation);
                     }
-                    if qs.has("analytics") && !qs.has("id") {
+                    if qs.has("analytics") {
                         return Ok(&ListBucketAnalyticsConfigurations as &'static dyn super::Operation);
                     }
-                    if qs.has("intelligent-tiering") && !qs.has("id") {
+                    if qs.has("intelligent-tiering") {
                         return Ok(&ListBucketIntelligentTieringConfigurations as &'static dyn super::Operation);
                     }
-                    if qs.has("inventory") && !qs.has("id") {
+                    if qs.has("inventory") {
                         return Ok(&ListBucketInventoryConfigurations as &'static dyn super::Operation);
                     }
-                    if qs.has("metrics") && !qs.has("id") {
+                    if qs.has("metrics") {
                         return Ok(&ListBucketMetricsConfigurations as &'static dyn super::Operation);
                     }
                     if qs.has("uploads") {
@@ -10061,6 +10477,9 @@ pub fn resolve_route(
             }
             S3Path::Object { .. } => {
                 if let Some(qs) = qs {
+                    if qs.has("annotation") && qs.has("annotationName") {
+                        return Ok(&GetObjectAnnotation as &'static dyn super::Operation);
+                    }
                     if qs.has("attributes") {
                         return Ok(&GetObjectAttributes as &'static dyn super::Operation);
                     }
@@ -10078,6 +10497,9 @@ pub fn resolve_route(
                     }
                     if qs.has("torrent") {
                         return Ok(&GetObjectTorrent as &'static dyn super::Operation);
+                    }
+                    if qs.has("annotation") {
+                        return Ok(&ListObjectAnnotations as &'static dyn super::Operation);
                     }
                 }
                 if let Some(qs) = qs
@@ -10208,6 +10630,9 @@ pub fn resolve_route(
             }
             S3Path::Object { .. } => {
                 if let Some(qs) = qs {
+                    if qs.has("annotation") {
+                        return Ok(&PutObjectAnnotation as &'static dyn super::Operation);
+                    }
                     if qs.has("renameObject") {
                         return Ok(&RenameObject as &'static dyn super::Operation);
                     }
@@ -10300,6 +10725,9 @@ pub fn resolve_route(
             }
             S3Path::Object { .. } => {
                 if let Some(qs) = qs {
+                    if qs.has("annotation") {
+                        return Ok(&DeleteObjectAnnotation as &'static dyn super::Operation);
+                    }
                     if qs.has("tagging") {
                         return Ok(&DeleteObjectTagging as &'static dyn super::Operation);
                     }

--- a/crates/s3s/src/ops/route_fixtures.json
+++ b/crates/s3s/src/ops/route_fixtures.json
@@ -3711,5 +3711,181 @@
     "zz"
    ]
   ]
+ },
+ {
+  "expect": "PutObjectAnnotation",
+  "headers": {},
+  "method": "PUT",
+  "nfb": false,
+  "note": "if:qs.has(\"annotation\")",
+  "path": "Object",
+  "qs": [
+   [
+    "annotation",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "PutObjectAnnotation",
+  "headers": {},
+  "method": "PUT",
+  "nfb": false,
+  "note": "noise:qs.has(\"annotation\")",
+  "path": "Object",
+  "qs": [
+   [
+    "annotation",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteObjectAnnotation",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "if:qs.has(\"annotation\")",
+  "path": "Object",
+  "qs": [
+   [
+    "annotation",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "DeleteObjectAnnotation",
+  "headers": {},
+  "method": "DELETE",
+  "nfb": false,
+  "note": "noise:qs.has(\"annotation\")",
+  "path": "Object",
+  "qs": [
+   [
+    "annotation",
+    ""
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "GetObjectAnnotation",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"annotationName\")",
+  "path": "Object",
+  "qs": [
+   [
+    "annotation",
+    ""
+   ],
+   [
+    "annotationName",
+    "foo"
+   ]
+  ]
+ },
+ {
+  "expect": "GetObjectAnnotation",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"annotationName\")",
+  "path": "Object",
+  "qs": [
+   [
+    "annotation",
+    ""
+   ],
+   [
+    "annotationName",
+    "foo"
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "ListObjectAnnotations",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "if:qs.has(\"annotation\") && !qs.has(\"annotationName\")",
+  "path": "Object",
+  "qs": [
+   [
+    "annotation",
+    ""
+   ],
+   [
+    "annotation-prefix",
+    "foo"
+   ]
+  ]
+ },
+ {
+  "expect": "ListObjectAnnotations",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "noise:qs.has(\"annotation\")",
+  "path": "Object",
+  "qs": [
+   [
+    "annotation",
+    ""
+   ],
+   [
+    "annotation-prefix",
+    "foo"
+   ],
+   [
+    "prefix",
+    "zz"
+   ]
+  ]
+ },
+ {
+  "expect": "ListObjectAnnotations",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "bare-tag:no-annotationName",
+  "path": "Object",
+  "qs": [
+   [
+    "annotation",
+    ""
+   ]
+  ]
+ },
+ {
+  "expect": "ListObjectAnnotations",
+  "headers": {},
+  "method": "GET",
+  "nfb": false,
+  "note": "x-id-ignored:no-annotationName",
+  "path": "Object",
+  "qs": [
+   [
+    "annotation",
+    ""
+   ],
+   [
+    "x-id",
+    "GetObjectAttributes"
+   ]
+  ]
  }
 ]

--- a/crates/s3s/src/s3_trait.rs
+++ b/crates/s3s/src/s3_trait.rs
@@ -1993,6 +1993,44 @@ pub trait S3: Send + Sync + 'static {
         Err(s3_error!(NotImplemented, "DeleteObject is not implemented yet"))
     }
 
+    /// <p>Deletes a specific annotation from an Amazon S3 object. Use the <code>x-amz-object-if-match</code>
+    /// header to perform a conditional delete that only succeeds if the object's ETag matches the
+    /// provided value, preventing race conditions during concurrent updates.</p>
+    /// <p>Deleting an annotation is permanent. Annotations are not independently versioned, so there is no
+    /// delete marker or way to recover a deleted annotation.</p>
+    /// <p>To use this operation, you must have the <code>s3:DeleteObjectAnnotation</code> permission. If
+    /// the object is protected by Object Lock in governance mode, you must also include the
+    /// <code>x-amz-bypass-governance-retention</code> header.</p>
+    /// <note>
+    /// <p>Annotations are not supported by the following features: S3 Inventory Reports,
+    /// API Gateway, S3 Storage Lens, Amazon S3 File Gateway, Amazon FSx, S3 on Outposts, and
+    /// S3 Express One Zone (directory buckets).</p>
+    /// </note>
+    /// <p>The following operations are related to <code>DeleteObjectAnnotation</code>:</p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectAnnotation.html">PutObjectAnnotation</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAnnotation.html">GetObjectAnnotation</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectAnnotations.html">ListObjectAnnotations</a>
+    /// </p>
+    /// </li>
+    /// </ul>
+    async fn delete_object_annotation(
+        &self,
+        _req: S3Request<DeleteObjectAnnotationInput>,
+    ) -> S3Result<S3Response<DeleteObjectAnnotationOutput>> {
+        Err(s3_error!(NotImplemented, "DeleteObjectAnnotation is not implemented yet"))
+    }
+
     /// <note>
     /// <p>This operation is not supported for directory buckets.</p>
     /// </note>
@@ -3332,6 +3370,40 @@ pub trait S3: Send + Sync + 'static {
         Err(s3_error!(NotImplemented, "GetObjectAcl is not implemented yet"))
     }
 
+    /// <p>Retrieves an annotation from an Amazon S3 object. To use this operation, you must have the
+    /// <code>s3:GetObjectAnnotation</code> permission.</p>
+    /// <p>If checksum mode is enabled via the <code>x-amz-checksum-mode</code> header, Amazon S3
+    /// returns the stored checksum in the response headers for client-side validation.</p>
+    /// <note>
+    /// <p>Annotations are not supported by the following features: S3 Inventory Reports,
+    /// API Gateway, S3 Storage Lens, Amazon S3 File Gateway, Amazon FSx, S3 on Outposts, and
+    /// S3 Express One Zone (directory buckets).</p>
+    /// </note>
+    /// <p>The following operations are related to <code>GetObjectAnnotation</code>:</p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectAnnotation.html">PutObjectAnnotation</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectAnnotations.html">ListObjectAnnotations</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectAnnotation.html">DeleteObjectAnnotation</a>
+    /// </p>
+    /// </li>
+    /// </ul>
+    async fn get_object_annotation(
+        &self,
+        _req: S3Request<GetObjectAnnotationInput>,
+    ) -> S3Result<S3Response<GetObjectAnnotationOutput>> {
+        Err(s3_error!(NotImplemented, "GetObjectAnnotation is not implemented yet"))
+    }
+
     /// <p>Retrieves all the metadata from an object without returning the object itself. This
     /// operation is useful if you're interested only in an object's metadata. </p>
     /// <p>
@@ -4357,6 +4429,40 @@ pub trait S3: Send + Sync + 'static {
         _req: S3Request<ListMultipartUploadsInput>,
     ) -> S3Result<S3Response<ListMultipartUploadsOutput>> {
         Err(s3_error!(NotImplemented, "ListMultipartUploads is not implemented yet"))
+    }
+
+    /// <p>Lists the annotations attached to an Amazon S3 object. Results are paginated, with a maximum of
+    /// 1,000 annotations per object. Use the <code>AnnotationPrefix</code> parameter to filter the
+    /// results by name prefix.</p>
+    /// <p>To use this operation, you must have the <code>s3:ListObjectAnnotations</code> permission.</p>
+    /// <note>
+    /// <p>Annotations are not supported by the following features: S3 Inventory Reports,
+    /// API Gateway, S3 Storage Lens, Amazon S3 File Gateway, Amazon FSx, S3 on Outposts, and
+    /// S3 Express One Zone (directory buckets).</p>
+    /// </note>
+    /// <p>The following operations are related to <code>ListObjectAnnotations</code>:</p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectAnnotation.html">PutObjectAnnotation</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAnnotation.html">GetObjectAnnotation</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectAnnotation.html">DeleteObjectAnnotation</a>
+    /// </p>
+    /// </li>
+    /// </ul>
+    async fn list_object_annotations(
+        &self,
+        _req: S3Request<ListObjectAnnotationsInput>,
+    ) -> S3Result<S3Response<ListObjectAnnotationsOutput>> {
+        Err(s3_error!(NotImplemented, "ListObjectAnnotations is not implemented yet"))
     }
 
     /// <note>
@@ -6571,6 +6677,46 @@ pub trait S3: Send + Sync + 'static {
     /// </ul>
     async fn put_object_acl(&self, _req: S3Request<PutObjectAclInput>) -> S3Result<S3Response<PutObjectAclOutput>> {
         Err(s3_error!(NotImplemented, "PutObjectAcl is not implemented yet"))
+    }
+
+    /// <p>Attaches an annotation to an Amazon S3 object. An annotation is a named payload of 1 byte to 1 MiB
+    /// that you can associate with a specific object or object version. Each object can have up to 1,000
+    /// annotations.</p>
+    /// <p>For annotation naming rules and restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/annotations-overview.html">Annotation naming guidelines</a>
+    /// in the <i>Amazon S3 User Guide</i>.</p>
+    /// <p>Annotations inherit the encryption of their parent object. For objects without server-side
+    /// encryption, annotations are encrypted with SSE-S3 (the default for new objects). Objects
+    /// encrypted with SSE-C cannot have annotations.</p>
+    /// <p>To use this operation, you must have the <code>s3:PutObjectAnnotation</code> permission. If the
+    /// bucket has Requester Pays enabled, you must include the <code>x-amz-request-payer</code> header.</p>
+    /// <note>
+    /// <p>Annotations are not supported by the following features: S3 Inventory Reports,
+    /// API Gateway, S3 Storage Lens, Amazon S3 File Gateway, Amazon FSx, S3 on Outposts, and
+    /// S3 Express One Zone (directory buckets).</p>
+    /// </note>
+    /// <p>The following operations are related to <code>PutObjectAnnotation</code>:</p>
+    /// <ul>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAnnotation.html">GetObjectAnnotation</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectAnnotations.html">ListObjectAnnotations</a>
+    /// </p>
+    /// </li>
+    /// <li>
+    /// <p>
+    /// <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectAnnotation.html">DeleteObjectAnnotation</a>
+    /// </p>
+    /// </li>
+    /// </ul>
+    async fn put_object_annotation(
+        &self,
+        _req: S3Request<PutObjectAnnotationInput>,
+    ) -> S3Result<S3Response<PutObjectAnnotationOutput>> {
+        Err(s3_error!(NotImplemented, "PutObjectAnnotation is not implemented yet"))
     }
 
     /// <note>

--- a/crates/s3s/src/xml/generated.rs
+++ b/crates/s3s/src/xml/generated.rs
@@ -89,6 +89,7 @@ use std::io::Write;
 //   Serialize: ListDirectoryBucketsOutput
 // Deserialize: ListDirectoryBucketsOutput
 //   Serialize: ListMultipartUploadsOutput
+//   Serialize: ListObjectAnnotationsOutput
 //   Serialize: ListObjectVersionsOutput
 //   Serialize: ListObjectsOutput
 //   Serialize: ListObjectsV2Output
@@ -117,6 +118,7 @@ use std::io::Write;
 // Deserialize: Progress
 //   Serialize: PublicAccessBlockConfiguration
 // Deserialize: PublicAccessBlockConfiguration
+//   Serialize: PutObjectAnnotationOutput
 //   Serialize: ReplicationConfiguration
 // Deserialize: ReplicationConfiguration
 //   Serialize: RequestPaymentConfiguration
@@ -180,6 +182,14 @@ use std::io::Write;
 // DeserializeContent: AnalyticsS3ExportFileFormat
 //   SerializeContent: AnnotationConfigurationState
 // DeserializeContent: AnnotationConfigurationState
+//   SerializeContent: AnnotationCount
+// DeserializeContent: AnnotationCount
+//   SerializeContent: AnnotationEntry
+// DeserializeContent: AnnotationEntry
+//   SerializeContent: AnnotationName
+// DeserializeContent: AnnotationName
+//   SerializeContent: AnnotationPrefix
+// DeserializeContent: AnnotationPrefix
 //   SerializeContent: AnnotationTableConfiguration
 // DeserializeContent: AnnotationTableConfiguration
 //   SerializeContent: AnnotationTableConfigurationResult
@@ -539,6 +549,7 @@ use std::io::Write;
 //   SerializeContent: ListDirectoryBucketsOutput
 // DeserializeContent: ListDirectoryBucketsOutput
 //   SerializeContent: ListMultipartUploadsOutput
+//   SerializeContent: ListObjectAnnotationsOutput
 //   SerializeContent: ListObjectVersionsOutput
 //   SerializeContent: ListObjectsOutput
 //   SerializeContent: ListObjectsV2Output
@@ -563,6 +574,8 @@ use std::io::Write;
 // DeserializeContent: Marker
 //   SerializeContent: MaxAgeSeconds
 // DeserializeContent: MaxAgeSeconds
+//   SerializeContent: MaxAnnotationResults
+// DeserializeContent: MaxAnnotationResults
 //   SerializeContent: MaxKeys
 // DeserializeContent: MaxKeys
 //   SerializeContent: MaxParts
@@ -717,6 +730,7 @@ use std::io::Write;
 // DeserializeContent: Protocol
 //   SerializeContent: PublicAccessBlockConfiguration
 // DeserializeContent: PublicAccessBlockConfiguration
+//   SerializeContent: PutObjectAnnotationOutput
 //   SerializeContent: QueueArn
 // DeserializeContent: QueueArn
 //   SerializeContent: QueueConfiguration
@@ -759,6 +773,8 @@ use std::io::Write;
 // DeserializeContent: ReplicationRuleFilter
 //   SerializeContent: ReplicationRuleStatus
 // DeserializeContent: ReplicationRuleStatus
+//   SerializeContent: ReplicationStatus
+// DeserializeContent: ReplicationStatus
 //   SerializeContent: ReplicationTime
 // DeserializeContent: ReplicationTime
 //   SerializeContent: ReplicationTimeStatus
@@ -3261,6 +3277,42 @@ impl SerializeContent for ListMultipartUploadsOutput {
     }
 }
 
+impl Serialize for ListObjectAnnotationsOutput {
+    fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content_with_ns("ListObjectAnnotationsOutput", XMLNS_S3, self)
+    }
+}
+
+impl SerializeContent for ListObjectAnnotationsOutput {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.annotation_count {
+            s.content("AnnotationCount", val)?;
+        }
+        if let Some(ref val) = self.annotation_prefix {
+            s.content("AnnotationPrefix", val)?;
+        }
+        if let Some(iter) = &self.annotations {
+            s.list("Annotations", "AnnotationEntry", iter)?;
+        }
+        if let Some(ref val) = self.bucket {
+            s.content("Bucket", val)?;
+        }
+        if let Some(ref val) = self.continuation_token {
+            s.content("ContinuationToken", val)?;
+        }
+        if let Some(ref val) = self.key {
+            s.content("Key", val)?;
+        }
+        if let Some(ref val) = self.max_annotation_results {
+            s.content("MaxAnnotationResults", val)?;
+        }
+        if let Some(ref val) = self.next_continuation_token {
+            s.content("NextContinuationToken", val)?;
+        }
+        Ok(())
+    }
+}
+
 impl Serialize for ListObjectVersionsOutput {
     fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
         s.content_with_ns("ListVersionsResult", XMLNS_S3, self)
@@ -4076,6 +4128,23 @@ impl<'xml> DeserializeContent<'xml> for PublicAccessBlockConfiguration {
             ignore_public_acls,
             restrict_public_buckets,
         })
+    }
+}
+
+impl Serialize for PutObjectAnnotationOutput {
+    fn serialize<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content_with_ns("PutObjectAnnotationOutput", XMLNS_S3, self)
+    }
+}
+impl SerializeContent for PutObjectAnnotationOutput {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.annotation_name {
+            s.content("AnnotationName", val)?;
+        }
+        if let Some(ref val) = self.key {
+            s.content("Key", val)?;
+        }
+        Ok(())
     }
 }
 
@@ -4937,6 +5006,86 @@ impl<'xml> DeserializeContent<'xml> for AnnotationConfigurationState {
             "DISABLED" => Ok(Self::from_static(AnnotationConfigurationState::DISABLED)),
             "ENABLED" => Ok(Self::from_static(AnnotationConfigurationState::ENABLED)),
             _ => Ok(Self::from(s.to_owned())),
+        })
+    }
+}
+
+impl SerializeContent for AnnotationEntry {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        s.content("AnnotationName", &self.annotation_name)?;
+        if let Some(iter) = &self.checksum_algorithm {
+            s.flattened_list("ChecksumAlgorithm", iter)?;
+        }
+        if let Some(ref val) = self.e_tag {
+            s.content("ETag", val)?;
+        }
+        s.timestamp("LastModified", &self.last_modified, TimestampFormat::DateTime)?;
+        if let Some(ref val) = self.replication_status {
+            s.content("ReplicationStatus", val)?;
+        }
+        s.content("Size", &self.size)?;
+        Ok(())
+    }
+}
+
+impl<'xml> DeserializeContent<'xml> for AnnotationEntry {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut annotation_name: Option<AnnotationName> = None;
+        let mut checksum_algorithm: Option<ChecksumAlgorithmList> = None;
+        let mut e_tag: Option<ETag> = None;
+        let mut last_modified: Option<LastModified> = None;
+        let mut replication_status: Option<ReplicationStatus> = None;
+        let mut size: Option<Size> = None;
+        d.for_each_element(|d, x| match x {
+            b"AnnotationName" => {
+                if annotation_name.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                annotation_name = Some(d.content()?);
+                Ok(())
+            }
+            b"ChecksumAlgorithm" => {
+                let ans: ChecksumAlgorithm = d.content()?;
+                checksum_algorithm.get_or_insert_with(List::new).push(ans);
+                Ok(())
+            }
+            b"ETag" => {
+                if e_tag.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                e_tag = Some(d.content()?);
+                Ok(())
+            }
+            b"LastModified" => {
+                if last_modified.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                last_modified = Some(d.timestamp(TimestampFormat::DateTime)?);
+                Ok(())
+            }
+            b"ReplicationStatus" => {
+                if replication_status.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                replication_status = Some(d.content()?);
+                Ok(())
+            }
+            b"Size" => {
+                if size.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                size = Some(d.content()?);
+                Ok(())
+            }
+            _ => Err(DeError::UnexpectedTagName),
+        })?;
+        Ok(Self {
+            annotation_name: annotation_name.ok_or(DeError::MissingField)?,
+            checksum_algorithm,
+            e_tag,
+            last_modified: last_modified.ok_or(DeError::MissingField)?,
+            replication_status,
+            size: size.ok_or(DeError::MissingField)?,
         })
     }
 }
@@ -11111,6 +11260,24 @@ impl<'xml> DeserializeContent<'xml> for ReplicationRuleStatus {
         d.text(|s| match s {
             "Disabled" => Ok(Self::from_static(ReplicationRuleStatus::DISABLED)),
             "Enabled" => Ok(Self::from_static(ReplicationRuleStatus::ENABLED)),
+            _ => Ok(Self::from(s.to_owned())),
+        })
+    }
+}
+
+impl SerializeContent for ReplicationStatus {
+    fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        self.as_str().serialize_content(s)
+    }
+}
+impl<'xml> DeserializeContent<'xml> for ReplicationStatus {
+    fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        d.text(|s| match s {
+            "COMPLETE" => Ok(Self::from_static(ReplicationStatus::COMPLETE)),
+            "COMPLETED" => Ok(Self::from_static(ReplicationStatus::COMPLETED)),
+            "FAILED" => Ok(Self::from_static(ReplicationStatus::FAILED)),
+            "PENDING" => Ok(Self::from_static(ReplicationStatus::PENDING)),
+            "REPLICA" => Ok(Self::from_static(ReplicationStatus::REPLICA)),
             _ => Ok(Self::from(s.to_owned())),
         })
     }

--- a/data/s3.json
+++ b/data/s3.json
@@ -27295,6 +27295,107 @@
                 }
             }
         },
+        "com.amazonaws.s3#AnnotationCount": {
+            "type": "integer"
+        },
+        "com.amazonaws.s3#AnnotationDirective": {
+            "type": "enum",
+            "members": {
+                "COPY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "COPY"
+                    }
+                },
+                "EXCLUDE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "EXCLUDE"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3#AnnotationEntry": {
+            "type": "structure",
+            "members": {
+                "AnnotationName": {
+                    "target": "com.amazonaws.s3#AnnotationName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the annotation.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "LastModified": {
+                    "target": "com.amazonaws.s3#LastModified",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time the annotation was last modified.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ETag": {
+                    "target": "com.amazonaws.s3#ETag",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The entity tag of the annotation.</p>"
+                    }
+                },
+                "ChecksumAlgorithm": {
+                    "target": "com.amazonaws.s3#ChecksumAlgorithmList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The checksum algorithm used for the annotation.</p>",
+                        "smithy.api#xmlFlattened": {}
+                    }
+                },
+                "Size": {
+                    "target": "com.amazonaws.s3#Size",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The size of the annotation payload, in bytes.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ReplicationStatus": {
+                    "target": "com.amazonaws.s3#ReplicationStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The replication status of the annotation.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Describes a single annotation attached to an object, including its name, last modified time,\n      size, ETag, checksum algorithm, and replication status. Returned in the response from\n      <code>ListObjectAnnotations</code>.</p>"
+            }
+        },
+        "com.amazonaws.s3#AnnotationLimitExceeded": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>The request would exceed the maximum number of annotations allowed per object.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.s3#AnnotationList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.s3#AnnotationEntry",
+                "traits": {
+                    "smithy.api#xmlName": "AnnotationEntry"
+                }
+            }
+        },
+        "com.amazonaws.s3#AnnotationName": {
+            "type": "string"
+        },
+        "com.amazonaws.s3#AnnotationNameTooLong": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>The annotation name exceeds 512 bytes.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.s3#AnnotationPrefix": {
+            "type": "string"
+        },
         "com.amazonaws.s3#AnnotationTableConfiguration": {
             "type": "structure",
             "members": {
@@ -28983,14 +29084,14 @@
                 "ACL": {
                     "target": "com.amazonaws.s3#ObjectCannedACL",
                     "traits": {
-                        "smithy.api#documentation": "<p>The canned access control list (ACL) to apply to the object.</p>\n         <p>When you copy an object, the ACL metadata is not preserved and is set to\n            <code>private</code> by default. Only the owner has full access control. To override the\n         default ACL setting, specify a new ACL when you generate a copy request. For more\n         information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html\">Using ACLs</a>. </p>\n         <p>If the destination bucket that you're copying objects to uses the bucket owner enforced\n         setting for S3 Object Ownership, ACLs are disabled and no longer affect permissions.\n         Buckets that use this setting only accept <code>PUT</code> requests that don't specify an\n         ACL or <code>PUT</code> requests that specify bucket owner full control ACLs, such as the\n            <code>bucket-owner-full-control</code> canned ACL or an equivalent form of this ACL\n         expressed in the XML format. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html\">Controlling ownership of\n            objects and disabling ACLs</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>If your destination bucket uses the bucket owner enforced setting for Object\n                  Ownership, all objects written to the bucket by any account will be owned by the\n                  bucket owner.</p>\n               </li>\n               <li>\n                  <p>This functionality is not supported for directory buckets.</p>\n               </li>\n               <li>\n                  <p>This functionality is not supported for Amazon S3 on Outposts.</p>\n               </li>\n            </ul>\n         </note>",
+                        "smithy.api#documentation": "<p>The canned access control list (ACL) to apply to the object.</p>\n         <p>When you copy an object, the ACL metadata is not preserved and is set to <code>private</code> by\n      default. Only the owner has full access control. To override the default ACL setting, specify a new ACL\n      when you generate a copy request. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html\">Using ACLs</a>. </p>\n         <p>If the destination bucket that you're copying objects to uses the bucket owner enforced setting for\n      S3 Object Ownership, ACLs are disabled and no longer affect permissions. Buckets that use this setting\n      only accept <code>PUT</code> requests that don't specify an ACL or <code>PUT</code> requests that\n      specify bucket owner full control ACLs, such as the <code>bucket-owner-full-control</code> canned ACL or\n      an equivalent form of this ACL expressed in the XML format. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html\">Controlling ownership\n        of objects and disabling ACLs</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <ul>\n               <li>\n                  <p>If your destination bucket uses the bucket owner enforced setting for Object Ownership, all\n            objects written to the bucket by any account will be owned by the bucket owner.</p>\n               </li>\n               <li>\n                  <p>This functionality is not supported for directory buckets.</p>\n               </li>\n               <li>\n                  <p>This functionality is not supported for Amazon S3 on Outposts.</p>\n               </li>\n            </ul>\n         </note>",
                         "smithy.api#httpHeader": "x-amz-acl"
                     }
                 },
                 "Bucket": {
                     "target": "com.amazonaws.s3#BucketName",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the destination bucket.</p>\n         <p>\n            <b>Directory buckets</b> - When you use this operation with a directory bucket, you must use virtual-hosted-style requests in the format <code>\n               <i>Bucket-name</i>.s3express-<i>zone-id</i>.<i>region-code</i>.amazonaws.com</code>. Path-style requests are not supported.  Directory bucket names must be unique in the chosen Zone (Availability Zone or Local Zone). Bucket names must follow the format <code>\n               <i>bucket-base-name</i>--<i>zone-id</i>--x-s3</code> (for example, <code>\n               <i>amzn-s3-demo-bucket</i>--<i>usw2-az1</i>--x-s3</code>). For information about bucket naming\n         restrictions, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html\">Directory bucket naming\n            rules</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <p>Copying objects across different Amazon Web Services Regions isn't supported when the source or destination bucket is in Amazon Web Services Local Zones. The source and destination buckets must have the same parent Amazon Web Services Region. Otherwise, \n      you get an HTTP <code>400 Bad Request</code> error with the error code <code>InvalidRequest</code>.</p>\n         </note>\n         <p>\n            <b>Access points</b> - When you use this action with an access point, you must provide the alias of the access point in place of the bucket name or specify the access point ARN. When using the access point ARN, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html\">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <p>Access points and Object Lambda access points are not supported by directory buckets.</p>\n         </note>\n         <p>\n            <b>S3 on Outposts</b> - When you use this action with S3 on Outposts, you must use the Outpost bucket access point ARN or the access point alias for the destination bucket. \n         \n         You can only copy objects within the same Outpost bucket. It's not supported to copy objects across different Amazon Web Services Outposts, between buckets on the same Outposts, or between Outposts buckets and any other bucket types. \n         For more information about S3 on Outposts, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html\">What is S3 on Outposts?</a> in the <i>S3 on Outposts guide</i>. \n         When you use this action with S3 on Outposts through the REST API, you must direct requests to the S3 on Outposts hostname, in the format \n         <code>\n               <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com</code>. The hostname isn't required when you use the Amazon Web Services CLI or SDKs.\n      </p>",
+                        "smithy.api#documentation": "<p>The name of the destination bucket.</p>\n         <p>\n            <b>Directory buckets</b> - When you use this operation with a directory bucket, you must use virtual-hosted-style requests in the format <code>\n               <i>Bucket-name</i>.s3express-<i>zone-id</i>.<i>region-code</i>.amazonaws.com</code>. Path-style requests are not supported.  Directory bucket names must be unique in the chosen Zone (Availability Zone or Local Zone). Bucket names must follow the format <code>\n               <i>bucket-base-name</i>--<i>zone-id</i>--x-s3</code> (for example, <code>\n               <i>amzn-s3-demo-bucket</i>--<i>usw2-az1</i>--x-s3</code>). For information about bucket naming\n         restrictions, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html\">Directory bucket naming\n            rules</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <p>Copying objects across different Amazon Web Services Regions isn't supported when the source or destination\n        bucket is in Amazon Web Services Local Zones. The source and destination buckets must have the same parent Amazon Web Services Region.\n        Otherwise, you get an HTTP <code>400 Bad Request</code> error with the error code\n          <code>InvalidRequest</code>.</p>\n         </note>\n         <p>\n            <b>Access points</b> - When you use this action with an access point for general purpose buckets, you must provide the alias of the access point in place of the bucket name or specify the access point ARN. When you use this action with an access point for directory buckets, you must provide the access point name in place of the bucket name. When using the access point ARN, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html\">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <p>Object Lambda access points are not supported by directory buckets.</p>\n         </note>\n         <p>\n            <b>S3 on Outposts</b> - When you use this action with S3 on Outposts,\n      you must use the Outpost bucket access point ARN or the access point alias for the destination bucket.\n      You can only copy objects within the same Outpost bucket. It's not supported to copy objects across\n      different Amazon Web Services Outposts, between buckets on the same Outposts, or between Outposts buckets and any\n      other bucket types. For more information about S3 on Outposts, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html\">What is S3 on Outposts?</a> in the\n        <i>S3 on Outposts guide</i>. When you use this action with S3 on Outposts through the REST\n      API, you must direct requests to the S3 on Outposts hostname, in the format\n          <code>\n               <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com</code>.\n      The hostname isn't required when you use the Amazon Web Services CLI or SDKs. </p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
@@ -29008,21 +29109,21 @@
                 "ChecksumAlgorithm": {
                     "target": "com.amazonaws.s3#ChecksumAlgorithm",
                     "traits": {
-                        "smithy.api#documentation": "<p>Indicates the algorithm that you want Amazon S3 to use to create the checksum for the object. For more information, see\n    <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking object integrity</a> in\n    the <i>Amazon S3 User Guide</i>.</p>\n         <p>When you copy an object, if the source object has a checksum, that checksum value will\n         be copied to the new object by default. If the <code>CopyObject</code> request does not\n         include this <code>x-amz-checksum-algorithm</code> header, the checksum algorithm will be\n         copied from the source object to the destination object (if it's present on the source\n         object). You can optionally specify a different checksum algorithm to use with the\n            <code>x-amz-checksum-algorithm</code> header. Unrecognized or unsupported values will\n         respond with the HTTP status code <code>400 Bad Request</code>.</p>\n         <note>\n            <p>For directory buckets, when you use Amazon Web Services SDKs, <code>CRC32</code> is the default checksum algorithm that's used for performance.</p>\n         </note>",
+                        "smithy.api#documentation": "<p>Indicates the algorithm that you want Amazon S3 to use to create the checksum for the object. For more information, see\n    <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking object integrity</a> in\n    the <i>Amazon S3 User Guide</i>.</p>\n         <p>When you copy an object, if the source object has a checksum, that checksum value will be copied to\n      the new object by default. If the <code>CopyObject</code> request does not include this\n        <code>x-amz-checksum-algorithm</code> header, the checksum algorithm will be copied from the source\n      object to the destination object (if it's present on the source object). You can optionally specify a\n      different checksum algorithm to use with the <code>x-amz-checksum-algorithm</code> header. Unrecognized\n      or unsupported values will respond with the HTTP status code <code>400 Bad Request</code>.</p>\n         <note>\n            <p>For directory buckets, when you use Amazon Web Services SDKs, <code>CRC32</code> is the default checksum algorithm that's used for performance.</p>\n         </note>",
                         "smithy.api#httpHeader": "x-amz-checksum-algorithm"
                     }
                 },
                 "ContentDisposition": {
                     "target": "com.amazonaws.s3#ContentDisposition",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies presentational information for the object. Indicates whether an object should\n         be displayed in a web browser or downloaded as a file. It allows specifying the desired\n         filename for the downloaded file.</p>",
+                        "smithy.api#documentation": "<p>Specifies presentational information for the object. Indicates whether an object should be displayed\n      in a web browser or downloaded as a file. It allows specifying the desired filename for the downloaded\n      file.</p>",
                         "smithy.api#httpHeader": "Content-Disposition"
                     }
                 },
                 "ContentEncoding": {
                     "target": "com.amazonaws.s3#ContentEncoding",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies what content encodings have been applied to the object and thus what decoding\n         mechanisms must be applied to obtain the media-type referenced by the Content-Type header\n         field.</p>\n         <note>\n            <p>For directory buckets, only the <code>aws-chunked</code> value is supported in this header field.</p>\n         </note>",
+                        "smithy.api#documentation": "<p>Specifies what content encodings have been applied to the object and thus what decoding mechanisms\n      must be applied to obtain the media-type referenced by the Content-Type header field.</p>\n         <note>\n            <p>For directory buckets, only the <code>aws-chunked</code> value is supported in this header field.</p>\n         </note>",
                         "smithy.api#httpHeader": "Content-Encoding"
                     }
                 },
@@ -29043,7 +29144,7 @@
                 "CopySource": {
                     "target": "com.amazonaws.s3#CopySource",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the source object for the copy operation. The source object can be up to 5 GB.\n         If the source object is an object that was uploaded by using a multipart upload, the object\n         copy will be a single part object after the source object is copied to the destination\n         bucket.</p>\n         <p>You specify the value of the copy source in one of two formats, depending on whether you\n         want to access the source object through an <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points.html\">access point</a>:</p>\n         <ul>\n            <li>\n               <p>For objects not accessed through an access point, specify the name of the source bucket\n               and the key of the source object, separated by a slash (/). For example, to copy the\n               object <code>reports/january.pdf</code> from the general purpose bucket\n                  <code>awsexamplebucket</code>, use\n                  <code>awsexamplebucket/reports/january.pdf</code>. The value must be URL-encoded.\n               To copy the object <code>reports/january.pdf</code> from the directory bucket\n                  <code>awsexamplebucket--use1-az5--x-s3</code>, use\n                  <code>awsexamplebucket--use1-az5--x-s3/reports/january.pdf</code>. The value must\n               be URL-encoded.</p>\n            </li>\n            <li>\n               <p>For objects accessed through access points, specify the Amazon Resource Name (ARN) of the object as accessed through the access point, in the format <code>arn:aws:s3:<Region>:<account-id>:accesspoint/<access-point-name>/object/<key></code>. For example, to copy the object <code>reports/january.pdf</code> through access point <code>my-access-point</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3:us-west-2:123456789012:accesspoint/my-access-point/object/reports/january.pdf</code>. The value must be URL encoded.</p>\n               <note>\n                  <ul>\n                     <li>\n                        <p>Amazon S3 supports copy operations using Access points only when the source and destination buckets are in the same Amazon Web Services Region.</p>\n                     </li>\n                     <li>\n                        <p>Access points are not supported by directory buckets.</p>\n                     </li>\n                  </ul>\n               </note>\n               <p>Alternatively, for objects accessed through Amazon S3 on Outposts, specify the ARN of the object as accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/object/<key></code>. For example, to copy the object <code>reports/january.pdf</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/object/reports/january.pdf</code>. The value must be URL-encoded.  </p>\n            </li>\n         </ul>\n         <p>If your source bucket versioning is enabled, the <code>x-amz-copy-source</code> header\n         by default identifies the current version of an object to copy. If the current version is a\n         delete marker, Amazon S3 behaves as if the object was deleted. To copy a different version, use\n         the <code>versionId</code> query parameter. Specifically, append\n            <code>?versionId=<version-id></code> to the value (for example,\n            <code>awsexamplebucket/reports/january.pdf?versionId=QUpfdndhfd8438MNFDN93jdnJFkdmqnh893</code>).\n         If you don't specify a version ID, Amazon S3 copies the latest version of the source\n         object.</p>\n         <p>If you enable versioning on the destination bucket, Amazon S3 generates a unique version ID\n         for the copied object. This version ID is different from the version ID of the source\n         object. Amazon S3 returns the version ID of the copied object in the\n            <code>x-amz-version-id</code> response header in the response.</p>\n         <p>If you do not enable versioning or suspend it on the destination bucket, the version ID\n         that Amazon S3 generates in the <code>x-amz-version-id</code> response header is always\n         null.</p>\n         <note>\n            <p>\n               <b>Directory buckets</b> -\n            S3 Versioning isn't enabled and supported for directory buckets.</p>\n         </note>",
+                        "smithy.api#documentation": "<p>Specifies the source object for the copy operation. The source object can be up to 5 GB. If the\n      source object is an object that was uploaded by using a multipart upload, the object copy will be a\n      single part object after the source object is copied to the destination bucket.</p>\n         <p>You specify the value of the copy source in one of two formats, depending on whether you want to\n      access the source object through an <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points.html\">access point</a>:</p>\n         <ul>\n            <li>\n               <p>For objects not accessed through an access point, specify the name of the source bucket and the key of\n          the source object, separated by a slash (/). For example, to copy the object\n            <code>reports/january.pdf</code> from the general purpose bucket <code>awsexamplebucket</code>, use\n            <code>awsexamplebucket/reports/january.pdf</code>. The value must be URL-encoded. To copy the\n          object <code>reports/january.pdf</code> from the directory bucket\n            <code>awsexamplebucket--use1-az5--x-s3</code>, use\n            <code>awsexamplebucket--use1-az5--x-s3/reports/january.pdf</code>. The value must be\n          URL-encoded.</p>\n            </li>\n            <li>\n               <p>For objects accessed through access points, specify the Amazon Resource Name (ARN) of the object as accessed through the access point, in the format <code>arn:aws:s3:<Region>:<account-id>:accesspoint/<access-point-name>/object/<key></code>. For example, to copy the object <code>reports/january.pdf</code> through access point <code>my-access-point</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3:us-west-2:123456789012:accesspoint/my-access-point/object/reports/january.pdf</code>. The value must be URL encoded.</p>\n               <note>\n                  <ul>\n                     <li>\n                        <p>Amazon S3 supports copy operations using Access points only when the source and destination buckets are in the same Amazon Web Services Region.</p>\n                     </li>\n                     <li>\n                        <p>Access points are not supported by directory buckets.</p>\n                     </li>\n                  </ul>\n               </note>\n               <p>Alternatively, for objects accessed through Amazon S3 on Outposts, specify the ARN of the object as accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/object/<key></code>. For example, to copy the object <code>reports/january.pdf</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/object/reports/january.pdf</code>. The value must be URL-encoded.  </p>\n            </li>\n         </ul>\n         <p>If your source bucket versioning is enabled, the <code>x-amz-copy-source</code> header by default\n      identifies the current version of an object to copy. If the current version is a delete marker, Amazon S3\n      behaves as if the object was deleted. To copy a different version, use the <code>versionId</code> query\n      parameter. Specifically, append <code>?versionId=<version-id></code> to the value (for example,\n        <code>awsexamplebucket/reports/january.pdf?versionId=QUpfdndhfd8438MNFDN93jdnJFkdmqnh893</code>). If\n      you don't specify a version ID, Amazon S3 copies the latest version of the source object.</p>\n         <p>If you enable versioning on the destination bucket, Amazon S3 generates a unique version ID for the\n      copied object. This version ID is different from the version ID of the source object. Amazon S3 returns the\n      version ID of the copied object in the <code>x-amz-version-id</code> response header in the\n      response.</p>\n         <p>If you do not enable versioning or suspend it on the destination bucket, the version ID that Amazon S3\n      generates in the <code>x-amz-version-id</code> response header is always null.</p>\n         <note>\n            <p>\n               <b>Directory buckets</b> - S3 Versioning isn't enabled and supported for directory buckets.</p>\n         </note>",
                         "smithy.api#httpHeader": "x-amz-copy-source",
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
@@ -29054,28 +29155,28 @@
                 "CopySourceIfMatch": {
                     "target": "com.amazonaws.s3#CopySourceIfMatch",
                     "traits": {
-                        "smithy.api#documentation": "<p>Copies the object if its entity tag (ETag) matches the specified tag.</p>\n         <p> If both the <code>x-amz-copy-source-if-match</code> and\n            <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the request\n         and evaluate as follows, Amazon S3 returns <code>200 OK</code> and copies the data:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>x-amz-copy-source-if-match</code> condition evaluates to true</p>\n            </li>\n            <li>\n               <p>\n                  <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to\n               false</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>Copies the object if its entity tag (ETag) matches the specified tag.</p>\n         <p> If both the <code>x-amz-copy-source-if-match</code> and\n        <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the request and evaluate as\n      follows, Amazon S3 returns <code>200 OK</code> and copies the data:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>x-amz-copy-source-if-match</code> condition evaluates to true</p>\n            </li>\n            <li>\n               <p>\n                  <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to false</p>\n            </li>\n         </ul>",
                         "smithy.api#httpHeader": "x-amz-copy-source-if-match"
                     }
                 },
                 "CopySourceIfModifiedSince": {
                     "target": "com.amazonaws.s3#CopySourceIfModifiedSince",
                     "traits": {
-                        "smithy.api#documentation": "<p>Copies the object if it has been modified since the specified time.</p>\n         <p>If both the <code>x-amz-copy-source-if-none-match</code> and\n            <code>x-amz-copy-source-if-modified-since</code> headers are present in the request and\n         evaluate as follows, Amazon S3 returns the <code>412 Precondition Failed</code> response\n         code:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>x-amz-copy-source-if-none-match</code> condition evaluates to false</p>\n            </li>\n            <li>\n               <p>\n                  <code>x-amz-copy-source-if-modified-since</code> condition evaluates to\n               true</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>Copies the object if it has been modified since the specified time.</p>\n         <p>If both the <code>x-amz-copy-source-if-none-match</code> and\n        <code>x-amz-copy-source-if-modified-since</code> headers are present in the request and evaluate as\n      follows, Amazon S3 returns the <code>412 Precondition Failed</code> response code:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>x-amz-copy-source-if-none-match</code> condition evaluates to false</p>\n            </li>\n            <li>\n               <p>\n                  <code>x-amz-copy-source-if-modified-since</code> condition evaluates to true</p>\n            </li>\n         </ul>",
                         "smithy.api#httpHeader": "x-amz-copy-source-if-modified-since"
                     }
                 },
                 "CopySourceIfNoneMatch": {
                     "target": "com.amazonaws.s3#CopySourceIfNoneMatch",
                     "traits": {
-                        "smithy.api#documentation": "<p>Copies the object if its entity tag (ETag) is different than the specified ETag.</p>\n         <p>If both the <code>x-amz-copy-source-if-none-match</code> and\n            <code>x-amz-copy-source-if-modified-since</code> headers are present in the request and\n         evaluate as follows, Amazon S3 returns the <code>412 Precondition Failed</code> response\n         code:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>x-amz-copy-source-if-none-match</code> condition evaluates to false</p>\n            </li>\n            <li>\n               <p>\n                  <code>x-amz-copy-source-if-modified-since</code> condition evaluates to\n               true</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>Copies the object if its entity tag (ETag) is different than the specified ETag.</p>\n         <p>If both the <code>x-amz-copy-source-if-none-match</code> and\n        <code>x-amz-copy-source-if-modified-since</code> headers are present in the request and evaluate as\n      follows, Amazon S3 returns the <code>412 Precondition Failed</code> response code:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>x-amz-copy-source-if-none-match</code> condition evaluates to false</p>\n            </li>\n            <li>\n               <p>\n                  <code>x-amz-copy-source-if-modified-since</code> condition evaluates to true</p>\n            </li>\n         </ul>",
                         "smithy.api#httpHeader": "x-amz-copy-source-if-none-match"
                     }
                 },
                 "CopySourceIfUnmodifiedSince": {
                     "target": "com.amazonaws.s3#CopySourceIfUnmodifiedSince",
                     "traits": {
-                        "smithy.api#documentation": "<p>Copies the object if it hasn't been modified since the specified time.</p>\n         <p> If both the <code>x-amz-copy-source-if-match</code> and\n            <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the request\n         and evaluate as follows, Amazon S3 returns <code>200 OK</code> and copies the data:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>x-amz-copy-source-if-match</code> condition evaluates to true</p>\n            </li>\n            <li>\n               <p>\n                  <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to\n               false</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>Copies the object if it hasn't been modified since the specified time.</p>\n         <p> If both the <code>x-amz-copy-source-if-match</code> and\n        <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the request and evaluate as\n      follows, Amazon S3 returns <code>200 OK</code> and copies the data:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>x-amz-copy-source-if-match</code> condition evaluates to true</p>\n            </li>\n            <li>\n               <p>\n                  <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to false</p>\n            </li>\n         </ul>",
                         "smithy.api#httpHeader": "x-amz-copy-source-if-unmodified-since"
                     }
                 },
@@ -29114,6 +29215,20 @@
                         "smithy.api#httpHeader": "x-amz-grant-write-acp"
                     }
                 },
+                "IfMatch": {
+                    "target": "com.amazonaws.s3#IfMatch",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Copies the object if the entity tag (ETag) of the destination object matches the specified\n      tag. If the ETag values do not match, the operation returns a <code>412 Precondition\n        Failed</code> error. If a concurrent operation occurs during the upload S3 returns a\n        <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should fetch the\n      object's ETag and retry the upload.</p>\n         <p>Expects the ETag value as a string.</p>\n         <p>For more information about conditional requests, see <a href=\"https://tools.ietf.org/html/rfc7232\">RFC 7232</a>.</p>",
+                        "smithy.api#httpHeader": "If-Match"
+                    }
+                },
+                "IfNoneMatch": {
+                    "target": "com.amazonaws.s3#IfNoneMatch",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Copies the object only if the object key name at the destination does not already exist in\n      the bucket specified. Otherwise, Amazon S3 returns a <code>412 Precondition Failed</code> error. If a\n      concurrent operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code>\n      response. On a 409 failure you should retry the upload.</p>\n         <p>Expects the '*' (asterisk) character.</p>\n         <p>For more information about conditional requests, see <a href=\"https://tools.ietf.org/html/rfc7232\">RFC 7232</a>.</p>",
+                        "smithy.api#httpHeader": "If-None-Match"
+                    }
+                },
                 "Key": {
                     "target": "com.amazonaws.s3#ObjectKey",
                     "traits": {
@@ -29135,98 +29250,105 @@
                 "MetadataDirective": {
                     "target": "com.amazonaws.s3#MetadataDirective",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies whether the metadata is copied from the source object or replaced with\n         metadata that's provided in the request. When copying an object, you can preserve all\n         metadata (the default) or specify new metadata. If this header isn’t specified,\n            <code>COPY</code> is the default behavior. </p>\n         <p>\n            <b>General purpose bucket</b> - For general purpose buckets, when you\n         grant permissions, you can use the <code>s3:x-amz-metadata-directive</code> condition key\n         to enforce certain metadata behavior when objects are uploaded. For more information, see\n            <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html\">Amazon S3\n            condition key examples</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <p>\n               <code>x-amz-website-redirect-location</code> is unique to each object and is not\n            copied when using the <code>x-amz-metadata-directive</code> header. To copy the value,\n            you must specify <code>x-amz-website-redirect-location</code> in the request\n            header.</p>\n         </note>",
+                        "smithy.api#documentation": "<p>Specifies whether the metadata is copied from the source object or replaced with metadata that's\n      provided in the request. When copying an object, you can preserve all metadata (the default) or specify\n      new metadata. If this header isn’t specified, <code>COPY</code> is the default behavior. </p>\n         <p>\n            <b>General purpose bucket</b> - For general purpose buckets, when you grant\n      permissions, you can use the <code>s3:x-amz-metadata-directive</code> condition key to enforce certain\n      metadata behavior when objects are uploaded. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html\">Amazon S3 condition key examples</a> in the\n        <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <p>\n               <code>x-amz-website-redirect-location</code> is unique to each object and is not copied when using\n        the <code>x-amz-metadata-directive</code> header. To copy the value, you must specify\n          <code>x-amz-website-redirect-location</code> in the request header.</p>\n         </note>",
                         "smithy.api#httpHeader": "x-amz-metadata-directive"
                     }
                 },
                 "TaggingDirective": {
                     "target": "com.amazonaws.s3#TaggingDirective",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies whether the object tag-set is copied from the source object or replaced with\n         the tag-set that's provided in the request.</p>\n         <p>The default value is <code>COPY</code>.</p>\n         <note>\n            <p>\n               <b>Directory buckets</b> - For directory buckets in a <code>CopyObject</code> operation, only the empty tag-set is supported. Any requests that attempt to write non-empty tags into directory buckets will receive a <code>501 Not Implemented</code> status code. \nWhen the destination bucket is a directory bucket, you will receive a <code>501 Not Implemented</code> response in any of the following situations:</p>\n            <ul>\n               <li>\n                  <p>When you attempt to <code>COPY</code> the tag-set from an S3 source object that has non-empty tags.</p>\n               </li>\n               <li>\n                  <p>When you attempt to <code>REPLACE</code> the tag-set of a source object and set a non-empty value to <code>x-amz-tagging</code>.</p>\n               </li>\n               <li>\n                  <p>When you don't set the <code>x-amz-tagging-directive</code> header and the source object has non-empty tags. This is because the default value of <code>x-amz-tagging-directive</code> is <code>COPY</code>.</p>\n               </li>\n            </ul>\n            <p>Because only the empty tag-set is supported for directory buckets in a <code>CopyObject</code> operation, the following situations are allowed:</p>\n            <ul>\n               <li>\n                  <p>When you attempt to <code>COPY</code> the tag-set from a directory bucket source object that has no tags to a general purpose bucket. It copies an empty tag-set to the destination object.</p>\n               </li>\n               <li>\n                  <p>When you attempt to <code>REPLACE</code> the tag-set of a directory bucket source object and set the <code>x-amz-tagging</code> value of the directory bucket destination object to empty.</p>\n               </li>\n               <li>\n                  <p>When you attempt to <code>REPLACE</code> the tag-set of a general purpose bucket source object that has non-empty tags and set the <code>x-amz-tagging</code> value of the directory bucket destination object to empty.</p>\n               </li>\n               <li>\n                  <p>When you attempt to <code>REPLACE</code> the tag-set of a directory bucket source object and don't set the <code>x-amz-tagging</code> value of the directory bucket destination object. This is because the default value of <code>x-amz-tagging</code> is the empty value.</p>\n               </li>\n            </ul>\n         </note>",
+                        "smithy.api#documentation": "<p>Specifies whether the object tag-set is copied from the source object or replaced with the tag-set\n      that's provided in the request.</p>\n         <p>The default value is <code>COPY</code>.</p>\n         <note>\n            <p>\n               <b>Directory buckets</b> - For directory buckets in a <code>CopyObject</code> operation, only the empty tag-set is supported. Any requests that attempt to write non-empty tags into directory buckets will receive a <code>501 Not Implemented</code> status code. \nWhen the destination bucket is a directory bucket, you will receive a <code>501 Not Implemented</code> response in any of the following situations:</p>\n            <ul>\n               <li>\n                  <p>When you attempt to <code>COPY</code> the tag-set from an S3 source object that has non-empty tags.</p>\n               </li>\n               <li>\n                  <p>When you attempt to <code>REPLACE</code> the tag-set of a source object and set a non-empty value to <code>x-amz-tagging</code>.</p>\n               </li>\n               <li>\n                  <p>When you don't set the <code>x-amz-tagging-directive</code> header and the source object has non-empty tags. This is because the default value of <code>x-amz-tagging-directive</code> is <code>COPY</code>.</p>\n               </li>\n            </ul>\n            <p>Because only the empty tag-set is supported for directory buckets in a <code>CopyObject</code> operation, the following situations are allowed:</p>\n            <ul>\n               <li>\n                  <p>When you attempt to <code>COPY</code> the tag-set from a directory bucket source object that has no tags to a general purpose bucket. It copies an empty tag-set to the destination object.</p>\n               </li>\n               <li>\n                  <p>When you attempt to <code>REPLACE</code> the tag-set of a directory bucket source object and set the <code>x-amz-tagging</code> value of the directory bucket destination object to empty.</p>\n               </li>\n               <li>\n                  <p>When you attempt to <code>REPLACE</code> the tag-set of a general purpose bucket source object that has non-empty tags and set the <code>x-amz-tagging</code> value of the directory bucket destination object to empty.</p>\n               </li>\n               <li>\n                  <p>When you attempt to <code>REPLACE</code> the tag-set of a directory bucket source object and don't set the <code>x-amz-tagging</code> value of the directory bucket destination object. This is because the default value of <code>x-amz-tagging</code> is the empty value.</p>\n               </li>\n            </ul>\n         </note>",
                         "smithy.api#httpHeader": "x-amz-tagging-directive"
+                    }
+                },
+                "AnnotationDirective": {
+                    "target": "com.amazonaws.s3#AnnotationDirective",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether you want to copy annotations from the source object or exclude them. If this\n      header isn't specified, <code>COPY</code> is the default behavior.</p>\n         <p>Valid Values: <code>COPY | EXCLUDE</code>\n         </p>\n         <p>You can specify this directive as either an HTTP header\n      (<code>x-amz-object-annotation-directive</code>) or as a query string parameter. Use the query\n      string form when generating presigned URLs that need to control annotation copy behavior.</p>\n         <p>When set to <code>COPY</code>, you must have <code>s3:GetObjectAnnotation</code> permission on\n      the source object and <code>s3:PutObjectAnnotation</code> permission on the destination. Each\n      annotation copied is billed as a separate PUT request. If annotations on the source are modified\n      during the copy, Amazon S3 returns a retryable error.</p>\n         <note>\n            <p>For directory buckets, annotations are not supported. Use <code>EXCLUDE</code> to copy\n      objects to directory buckets without errors. If you specify <code>COPY</code> for a directory\n      bucket, the request returns HTTP 501 (Not Implemented).</p>\n         </note>\n         <note>\n            <p>When you copy objects using multipart upload (for example, when the Amazon Web Services CLI or Amazon Web Services SDKs\n      use Transfer Manager for objects larger than approximately 8 MB), annotations are not copied by\n      default. To include annotations, specify <code>--copy-props default</code> in the Amazon Web Services CLI or the\n      equivalent SDK configuration. With this opt-in, the SDK reads source annotations, completes the\n      multipart upload, and then writes each annotation to the destination. Between the upload completion\n      and the last annotation write, the destination object exists without all its annotations.</p>\n         </note>",
+                        "smithy.api#httpHeader": "x-amz-object-annotation-directive"
                     }
                 },
                 "ServerSideEncryption": {
                     "target": "com.amazonaws.s3#ServerSideEncryption",
                     "traits": {
-                        "smithy.api#documentation": "<p>The server-side encryption algorithm used when storing this object in Amazon S3. Unrecognized\n         or unsupported values won’t write a destination object and will receive a <code>400 Bad\n            Request</code> response. </p>\n         <p>Amazon S3 automatically encrypts all new objects that are copied to an S3 bucket. When\n         copying an object, if you don't specify encryption information in your copy request, the\n         encryption setting of the target object is set to the default encryption configuration of\n         the destination bucket. By default, all buckets have a base level of encryption\n         configuration that uses server-side encryption with Amazon S3 managed keys (SSE-S3). If the\n         destination bucket has a different default encryption configuration, Amazon S3 uses the\n         corresponding encryption key to encrypt the target object copy.</p>\n         <p>With server-side encryption, Amazon S3 encrypts your data as it writes your data to disks in\n         its data centers and decrypts the data when you access it. For more information about\n         server-side encryption, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html\">Using Server-Side Encryption</a>\n         in the <i>Amazon S3 User Guide</i>.</p>\n         <p>\n            <b>General purpose buckets </b>\n         </p>\n         <ul>\n            <li>\n               <p>For general purpose buckets, there are the following supported options for server-side\n               encryption: server-side encryption with Key Management Service (KMS) keys (SSE-KMS), dual-layer\n               server-side encryption with Amazon Web Services KMS keys (DSSE-KMS), and server-side encryption\n               with customer-provided encryption keys (SSE-C). Amazon S3 uses the corresponding\n               KMS key, or a customer-provided key to encrypt the target object copy.</p>\n            </li>\n            <li>\n               <p>When you perform a <code>CopyObject</code> operation, if you want to use a\n               different type of encryption setting for the target object, you can specify\n               appropriate encryption-related headers to encrypt the target object with an Amazon S3\n               managed key, a KMS key, or a customer-provided key. If the encryption setting in\n               your request is different from the default encryption configuration of the\n               destination bucket, the encryption setting in your request takes precedence. </p>\n            </li>\n         </ul>\n         <p>\n            <b>Directory buckets </b>\n         </p>\n         <ul>\n            <li>\n               <p>For directory buckets, there are only two supported options for server-side encryption: server-side encryption with Amazon S3 managed keys (SSE-S3) (<code>AES256</code>) and server-side encryption with KMS keys (SSE-KMS) (<code>aws:kms</code>). We recommend that the bucket's default encryption uses the desired encryption configuration and you don't override the bucket default encryption in your \n            <code>CreateSession</code> requests or <code>PUT</code> object requests. Then, new objects \n are automatically encrypted with the desired encryption settings. For more\n         information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-serv-side-encryption.html\">Protecting data with server-side encryption</a> in the <i>Amazon S3 User Guide</i>. For more information about the encryption overriding behaviors in directory buckets, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-specifying-kms-encryption.html\">Specifying server-side encryption with KMS for new object uploads</a>.</p>\n            </li>\n            <li>\n               <p>To encrypt new object copies to a directory bucket with SSE-KMS, we recommend you\n               specify SSE-KMS as the directory bucket's default encryption configuration with\n               a KMS key (specifically, a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed key</a>).\n               The <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed key</a> (<code>aws/s3</code>) isn't supported. Your SSE-KMS\n               configuration can only support 1 <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed key</a> per\n               directory bucket for the lifetime of the bucket. After you specify a customer managed key for\n               SSE-KMS, you can't override the customer managed key for the bucket's SSE-KMS\n               configuration. Then, when you perform a <code>CopyObject</code> operation and want to\n               specify server-side encryption settings for new object copies with SSE-KMS in the\n               encryption-related request headers, you must ensure the encryption key is the same\n               customer managed key that you specified for the directory bucket's default encryption\n               configuration.\n               </p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>The server-side encryption algorithm used when storing this object in Amazon S3. Unrecognized or\n      unsupported values won’t write a destination object and will receive a <code>400 Bad Request</code>\n      response. </p>\n         <p>Amazon S3 automatically encrypts all new objects that are copied to an S3 bucket. When copying an object,\n      if you don't specify encryption information in your copy request, the encryption setting of the target\n      object is set to the default encryption configuration of the destination bucket. By default, all buckets\n      have a base level of encryption configuration that uses server-side encryption with Amazon S3 managed keys\n      (SSE-S3). If the destination bucket has a different default encryption configuration, Amazon S3 uses the\n      corresponding encryption key to encrypt the target object copy.</p>\n         <p>With server-side encryption, Amazon S3 encrypts your data as it writes your data to disks in its data\n      centers and decrypts the data when you access it. For more information about server-side encryption, see\n        <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html\">Using Server-Side\n        Encryption</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <p>\n            <b>General purpose buckets </b>\n         </p>\n         <ul>\n            <li>\n               <p>For general purpose buckets, there are the following supported options for server-side encryption:\n          server-side encryption with Key Management Service (KMS) keys (SSE-KMS), dual-layer server-side encryption with\n          Amazon Web Services KMS keys (DSSE-KMS), and server-side encryption with customer-provided encryption keys\n          (SSE-C). Amazon S3 uses the corresponding KMS key, or a customer-provided key to encrypt the target\n          object copy.</p>\n            </li>\n            <li>\n               <p>When you perform a <code>CopyObject</code> operation, if you want to use a different type of\n          encryption setting for the target object, you can specify appropriate encryption-related headers to\n          encrypt the target object with an Amazon S3 managed key, a KMS key, or a customer-provided key. If the\n          encryption setting in your request is different from the default encryption configuration of the\n          destination bucket, the encryption setting in your request takes precedence. </p>\n            </li>\n         </ul>\n         <p>\n            <b>Directory buckets </b>\n         </p>\n         <ul>\n            <li>\n               <p>For directory buckets, there are only two supported options for server-side encryption: server-side encryption with Amazon S3 managed keys (SSE-S3) (<code>AES256</code>) and server-side encryption with KMS keys (SSE-KMS) (<code>aws:kms</code>). We recommend that the bucket's default encryption uses the desired encryption configuration and you don't override the bucket default encryption in your \n            <code>CreateSession</code> requests or <code>PUT</code> object requests. Then, new objects \n are automatically encrypted with the desired encryption settings. For more\n         information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-serv-side-encryption.html\">Protecting data with server-side encryption</a> in the <i>Amazon S3 User Guide</i>. For more information about the encryption overriding behaviors in directory buckets, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-specifying-kms-encryption.html\">Specifying server-side encryption with KMS for new object uploads</a>.</p>\n            </li>\n            <li>\n               <p>To encrypt new object copies to a directory bucket with SSE-KMS, we recommend you specify\n          SSE-KMS as the directory bucket's default encryption configuration with a KMS key\n          (specifically, a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed key</a>). The <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed key</a> (<code>aws/s3</code>) isn't supported. Your SSE-KMS configuration can\n          only support 1 <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed key</a> per\n          directory bucket for the lifetime of the bucket. After you specify a customer managed key for SSE-KMS, you\n          can't override the customer managed key for the bucket's SSE-KMS configuration. Then, when you\n          perform a <code>CopyObject</code> operation and want to specify server-side encryption settings for\n          new object copies with SSE-KMS in the encryption-related request headers, you must ensure the\n          encryption key is the same customer managed key that you specified for the directory bucket's default\n          encryption configuration.\n          </p>\n            </li>\n            <li>\n               <p>\n                  <b>S3 access points for Amazon FSx </b> - When accessing data stored in\n          Amazon FSx file systems using S3 access points, the only valid server side encryption option is\n            <code>aws:fsx</code>. All Amazon FSx file systems have encryption configured by default and are\n          encrypted at rest. Data is automatically encrypted before being written to the file system, and\n          automatically decrypted as it is read. These processes are handled transparently by Amazon FSx.</p>\n            </li>\n         </ul>",
                         "smithy.api#httpHeader": "x-amz-server-side-encryption"
                     }
                 },
                 "StorageClass": {
                     "target": "com.amazonaws.s3#StorageClass",
                     "traits": {
-                        "smithy.api#documentation": "<p>If the <code>x-amz-storage-class</code> header is not used, the copied object will be\n         stored in the <code>STANDARD</code> Storage Class by default. The <code>STANDARD</code>\n         storage class provides high durability and high availability. Depending on performance\n         needs, you can specify a different Storage Class. </p>\n         <note>\n            <ul>\n               <li>\n                  <p>\n                     <b>Directory buckets </b> -\n                  For directory buckets, only the S3 Express One Zone storage class is supported to store newly created objects. \nUnsupported storage class values won't write a destination object and will respond with the HTTP status code <code>400 Bad Request</code>.</p>\n               </li>\n               <li>\n                  <p>\n                     <b>Amazon S3 on Outposts </b> - S3 on Outposts only\n                  uses the <code>OUTPOSTS</code> Storage Class.</p>\n               </li>\n            </ul>\n         </note>\n         <p>You can use the <code>CopyObject</code> action to change the storage class of an object\n         that is already stored in Amazon S3 by using the <code>x-amz-storage-class</code> header. For\n         more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html\">Storage Classes</a> in the\n            <i>Amazon S3 User Guide</i>.</p>\n         <p>Before using an object as a source object for the copy operation, you must restore a\n         copy of it if it meets any of the following conditions:</p>\n         <ul>\n            <li>\n               <p>The storage class of the source object is <code>GLACIER</code> or\n                  <code>DEEP_ARCHIVE</code>.</p>\n            </li>\n            <li>\n               <p>The storage class of the source object is <code>INTELLIGENT_TIERING</code> and\n               it's <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering-overview.html#intel-tiering-tier-definition\">S3 Intelligent-Tiering access tier</a> is <code>Archive Access</code> or\n                  <code>Deep Archive Access</code>.</p>\n            </li>\n         </ul>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html\">RestoreObject</a> and <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjectsExamples.html\">Copying\n            Objects</a> in the <i>Amazon S3 User Guide</i>.</p>",
+                        "smithy.api#documentation": "<p>If the <code>x-amz-storage-class</code> header is not used, the copied object will be stored in the\n        <code>STANDARD</code> Storage Class by default. The <code>STANDARD</code> storage class provides high\n      durability and high availability. Depending on performance needs, you can specify a different Storage\n      Class. </p>\n         <note>\n            <ul>\n               <li>\n                  <p>\n                     <b>Directory buckets </b> -\n            Directory buckets only support <code>EXPRESS_ONEZONE</code> (the S3 Express One Zone storage class) in Availability Zones and <code>ONEZONE_IA</code> (the S3 One Zone-Infrequent Access storage class) in Dedicated Local Zones.  \nUnsupported storage class values won't write a destination object and will respond with the HTTP status code <code>400 Bad Request</code>.</p>\n               </li>\n               <li>\n                  <p>\n                     <b>Amazon S3 on Outposts </b> - S3 on Outposts only uses the\n              <code>OUTPOSTS</code> Storage Class.</p>\n               </li>\n            </ul>\n         </note>\n         <p>You can use the <code>CopyObject</code> action to change the storage class of an object that is\n      already stored in Amazon S3 by using the <code>x-amz-storage-class</code> header. For more information, see\n        <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html\">Storage Classes</a>\n      in the <i>Amazon S3 User Guide</i>.</p>\n         <p>Before using an object as a source object for the copy operation, you must restore a copy of it if\n      it meets any of the following conditions:</p>\n         <ul>\n            <li>\n               <p>The storage class of the source object is <code>GLACIER</code> or\n          <code>DEEP_ARCHIVE</code>.</p>\n            </li>\n            <li>\n               <p>The storage class of the source object is <code>INTELLIGENT_TIERING</code> and it's <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering-overview.html#intel-tiering-tier-definition\">S3\n            Intelligent-Tiering access tier</a> is <code>Archive Access</code> or <code>Deep Archive\n            Access</code>.</p>\n            </li>\n         </ul>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html\">RestoreObject</a> and <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjectsExamples.html\">Copying Objects</a> in the\n        <i>Amazon S3 User Guide</i>.</p>",
                         "smithy.api#httpHeader": "x-amz-storage-class"
                     }
                 },
                 "WebsiteRedirectLocation": {
                     "target": "com.amazonaws.s3#WebsiteRedirectLocation",
                     "traits": {
-                        "smithy.api#documentation": "<p>If the destination bucket is configured as a website, redirects requests for this object\n         copy to another object in the same bucket or to an external URL. Amazon S3 stores the value of\n         this header in the object metadata. This value is unique to each object and is not copied\n         when using the <code>x-amz-metadata-directive</code> header. Instead, you may opt to\n         provide this header in combination with the <code>x-amz-metadata-directive</code>\n         header.</p>\n         <note>\n            <p>This functionality is not supported for directory buckets.</p>\n         </note>",
+                        "smithy.api#documentation": "<p>If the destination bucket is configured as a website, redirects requests for this object copy to\n      another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the\n      object metadata. This value is unique to each object and is not copied when using the\n        <code>x-amz-metadata-directive</code> header. Instead, you may opt to provide this header in\n      combination with the <code>x-amz-metadata-directive</code> header.</p>\n         <note>\n            <p>This functionality is not supported for directory buckets.</p>\n         </note>",
                         "smithy.api#httpHeader": "x-amz-website-redirect-location"
                     }
                 },
                 "SSECustomerAlgorithm": {
                     "target": "com.amazonaws.s3#SSECustomerAlgorithm",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the algorithm to use when encrypting the object (for example,\n            <code>AES256</code>).</p>\n         <p>When you perform a <code>CopyObject</code> operation, if you want to use a different\n         type of encryption setting for the target object, you can specify appropriate\n         encryption-related headers to encrypt the target object with an Amazon S3 managed key, a\n         KMS key, or a customer-provided key. If the encryption setting in your request is\n         different from the default encryption configuration of the destination bucket, the\n         encryption setting in your request takes precedence. </p>\n         <note>\n            <p>This functionality is not supported when the destination bucket is a directory bucket.</p>\n         </note>",
+                        "smithy.api#documentation": "<p>Specifies the algorithm to use when encrypting the object (for example, <code>AES256</code>).</p>\n         <p>When you perform a <code>CopyObject</code> operation, if you want to use a different type of\n      encryption setting for the target object, you can specify appropriate encryption-related headers to\n      encrypt the target object with an Amazon S3 managed key, a KMS key, or a customer-provided key. If the\n      encryption setting in your request is different from the default encryption configuration of the\n      destination bucket, the encryption setting in your request takes precedence. </p>\n         <note>\n            <p>This functionality is not supported when the destination bucket is a directory bucket.</p>\n         </note>",
                         "smithy.api#httpHeader": "x-amz-server-side-encryption-customer-algorithm"
                     }
                 },
                 "SSECustomerKey": {
                     "target": "com.amazonaws.s3#SSECustomerKey",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This\n         value is used to store the object and then it is discarded. Amazon S3 does not store the\n         encryption key. The key must be appropriate for use with the algorithm specified in the\n            <code>x-amz-server-side-encryption-customer-algorithm</code> header.</p>\n         <note>\n            <p>This functionality is not supported when the destination bucket is a directory bucket.</p>\n         </note>",
+                        "smithy.api#documentation": "<p>Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This value is\n      used to store the object and then it is discarded. Amazon S3 does not store the encryption key. The key must\n      be appropriate for use with the algorithm specified in the\n        <code>x-amz-server-side-encryption-customer-algorithm</code> header.</p>\n         <note>\n            <p>This functionality is not supported when the destination bucket is a directory bucket.</p>\n         </note>",
                         "smithy.api#httpHeader": "x-amz-server-side-encryption-customer-key"
                     }
                 },
                 "SSECustomerKeyMD5": {
                     "target": "com.amazonaws.s3#SSECustomerKeyMD5",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses\n         this header for a message integrity check to ensure that the encryption key was transmitted\n         without error.</p>\n         <note>\n            <p>This functionality is not supported when the destination bucket is a directory bucket.</p>\n         </note>",
+                        "smithy.api#documentation": "<p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses this header\n      for a message integrity check to ensure that the encryption key was transmitted without error.</p>\n         <note>\n            <p>This functionality is not supported when the destination bucket is a directory bucket.</p>\n         </note>",
                         "smithy.api#httpHeader": "x-amz-server-side-encryption-customer-key-MD5"
                     }
                 },
                 "SSEKMSKeyId": {
                     "target": "com.amazonaws.s3#SSEKMSKeyId",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the KMS key ID (Key ID, Key ARN, or Key Alias) to use for object encryption.\n         All GET and PUT requests for an object protected by KMS will fail if they're not made via\n         SSL or using SigV4. For information about configuring any of the officially supported Amazon Web Services\n         SDKs and Amazon Web Services CLI, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version\">Specifying the\n            Signature Version in Request Authentication</a> in the\n            <i>Amazon S3 User Guide</i>.</p>\n         <p>\n            <b>Directory buckets</b> -\n         To encrypt data using SSE-KMS, it's recommended to specify the \n<code>x-amz-server-side-encryption</code> header to <code>aws:kms</code>. Then, the <code>x-amz-server-side-encryption-aws-kms-key-id</code> header implicitly uses \nthe bucket's default KMS customer managed key ID. If you want to explicitly set the <code>\n         x-amz-server-side-encryption-aws-kms-key-id</code> header, it must match the bucket's default customer managed key (using key ID or ARN, not alias). Your SSE-KMS configuration can only support 1 <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed key</a> per directory bucket's lifetime. \nThe <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed key</a> (<code>aws/s3</code>) isn't supported. \n                            \n Incorrect key specification results in an HTTP <code>400 Bad Request</code> error. </p>",
+                        "smithy.api#documentation": "<p>Specifies the KMS key ID (Key ID, Key ARN, or Key Alias) to use for object encryption. All GET and\n      PUT requests for an object protected by KMS will fail if they're not made via SSL or using SigV4. For\n      information about configuring any of the officially supported Amazon Web Services SDKs and Amazon Web Services CLI, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version\">Specifying\n        the Signature Version in Request Authentication</a> in the\n      <i>Amazon S3 User Guide</i>.</p>\n         <p>\n            <b>Directory buckets</b> -\n      To encrypt data using SSE-KMS, it's recommended to specify the \n<code>x-amz-server-side-encryption</code> header to <code>aws:kms</code>. Then, the <code>x-amz-server-side-encryption-aws-kms-key-id</code> header implicitly uses \nthe bucket's default KMS customer managed key ID. If you want to explicitly set the <code>\n         x-amz-server-side-encryption-aws-kms-key-id</code> header, it must match the bucket's default customer managed key (using key ID or ARN, not alias). Your SSE-KMS configuration can only support 1 <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed key</a> per directory bucket's lifetime. \nThe <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed key</a> (<code>aws/s3</code>) isn't supported. \n                            \n Incorrect key specification results in an HTTP <code>400 Bad Request</code> error. </p>",
                         "smithy.api#httpHeader": "x-amz-server-side-encryption-aws-kms-key-id"
                     }
                 },
                 "SSEKMSEncryptionContext": {
                     "target": "com.amazonaws.s3#SSEKMSEncryptionContext",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the Amazon Web Services KMS Encryption Context as an additional encryption context to use\n         for the destination object encryption. The value of this header is a base64-encoded UTF-8 string holding JSON with the encryption context key-value pairs.</p>\n         <p>\n            <b>General purpose buckets</b> - This value must be explicitly\n         added to specify encryption context for <code>CopyObject</code> requests if you want an\n         additional encryption context for your destination object. The additional encryption\n         context of the source object won't be copied to the destination object. For more\n         information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html#encryption-context\">Encryption\n            context</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <p>\n            <b>Directory buckets</b> - You can optionally provide an explicit encryption context value. The value must match the default encryption context - the bucket Amazon Resource Name (ARN). An additional encryption context value is not supported. </p>",
+                        "smithy.api#documentation": "<p>Specifies the Amazon Web Services KMS Encryption Context as an additional encryption context to use for the\n      destination object encryption. The value of this header is a base64-encoded UTF-8 string holding JSON\n      with the encryption context key-value pairs.</p>\n         <p>\n            <b>General purpose buckets</b> - This value must be explicitly added to\n      specify encryption context for <code>CopyObject</code> requests if you want an additional encryption\n      context for your destination object. The additional encryption context of the source object won't be\n      copied to the destination object. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html#encryption-context\">Encryption context</a>\n      in the <i>Amazon S3 User Guide</i>.</p>\n         <p>\n            <b>Directory buckets</b> - You can optionally provide an explicit encryption context value. The value must match the default encryption context - the bucket Amazon Resource Name (ARN). An additional encryption context value is not supported. </p>",
                         "smithy.api#httpHeader": "x-amz-server-side-encryption-context"
                     }
                 },
                 "BucketKeyEnabled": {
                     "target": "com.amazonaws.s3#BucketKeyEnabled",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies whether Amazon S3 should use an S3 Bucket Key for object encryption with\n         server-side encryption using Key Management Service (KMS) keys (SSE-KMS). If a target object uses\n         SSE-KMS, you can enable an S3 Bucket Key for the object.</p>\n         <p>Setting this header to <code>true</code> causes Amazon S3 to use an S3 Bucket Key for object\n         encryption with SSE-KMS. Specifying this header with a COPY action doesn’t affect\n         bucket-level settings for S3 Bucket Key.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html\">Amazon S3 Bucket Keys</a> in the\n            <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <p>\n               <b>Directory buckets</b> -\n            S3 Bucket Keys aren't supported, when you copy SSE-KMS encrypted objects from general purpose buckets  \nto directory buckets, from directory buckets to general purpose buckets, or between directory buckets, through <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html\">CopyObject</a>. In this case, Amazon S3 makes a call to KMS every time a copy request is made for a KMS-encrypted object.</p>\n         </note>",
+                        "smithy.api#documentation": "<p>Specifies whether Amazon S3 should use an S3 Bucket Key for object encryption with server-side encryption\n      using Key Management Service (KMS) keys (SSE-KMS). If a target object uses SSE-KMS, you can enable an S3 Bucket Key\n      for the object.</p>\n         <p>Setting this header to <code>true</code> causes Amazon S3 to use an S3 Bucket Key for object encryption\n      with SSE-KMS. Specifying this header with a COPY action doesn’t affect bucket-level settings for S3\n      Bucket Key.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html\">Amazon S3\n        Bucket Keys</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <p>\n               <b>Directory buckets</b> -\n        S3 Bucket Keys aren't supported, when you copy SSE-KMS encrypted objects from general purpose buckets  \nto directory buckets, from directory buckets to general purpose buckets, or between directory buckets, through <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html\">CopyObject</a>. In this case, Amazon S3 makes a call to KMS every time a copy request is made for a KMS-encrypted object.</p>\n         </note>",
                         "smithy.api#httpHeader": "x-amz-server-side-encryption-bucket-key-enabled"
                     }
                 },
                 "CopySourceSSECustomerAlgorithm": {
                     "target": "com.amazonaws.s3#CopySourceSSECustomerAlgorithm",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the algorithm to use when decrypting the source object (for example,\n            <code>AES256</code>).</p>\n         <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the\n         necessary encryption information in your request so that Amazon S3 can decrypt the object for\n         copying.</p>\n         <note>\n            <p>This functionality is not supported when the source object is in a directory bucket.</p>\n         </note>",
+                        "smithy.api#documentation": "<p>Specifies the algorithm to use when decrypting the source object (for example,\n      <code>AES256</code>).</p>\n         <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the necessary\n      encryption information in your request so that Amazon S3 can decrypt the object for copying.</p>\n         <note>\n            <p>This functionality is not supported when the source object is in a directory bucket.</p>\n         </note>",
                         "smithy.api#httpHeader": "x-amz-copy-source-server-side-encryption-customer-algorithm"
                     }
                 },
                 "CopySourceSSECustomerKey": {
                     "target": "com.amazonaws.s3#CopySourceSSECustomerKey",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the customer-provided encryption key for Amazon S3 to use to decrypt the source\n         object. The encryption key provided in this header must be the same one that was used when\n         the source object was created.</p>\n         <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the\n         necessary encryption information in your request so that Amazon S3 can decrypt the object for\n         copying.</p>\n         <note>\n            <p>This functionality is not supported when the source object is in a directory bucket.</p>\n         </note>",
+                        "smithy.api#documentation": "<p>Specifies the customer-provided encryption key for Amazon S3 to use to decrypt the source object. The\n      encryption key provided in this header must be the same one that was used when the source object was\n      created.</p>\n         <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the necessary\n      encryption information in your request so that Amazon S3 can decrypt the object for copying.</p>\n         <note>\n            <p>This functionality is not supported when the source object is in a directory bucket.</p>\n         </note>",
                         "smithy.api#httpHeader": "x-amz-copy-source-server-side-encryption-customer-key"
                     }
                 },
                 "CopySourceSSECustomerKeyMD5": {
                     "target": "com.amazonaws.s3#CopySourceSSECustomerKeyMD5",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses\n         this header for a message integrity check to ensure that the encryption key was transmitted\n         without error.</p>\n         <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the\n         necessary encryption information in your request so that Amazon S3 can decrypt the object for\n         copying.</p>\n         <note>\n            <p>This functionality is not supported when the source object is in a directory bucket.</p>\n         </note>",
+                        "smithy.api#documentation": "<p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses this header\n      for a message integrity check to ensure that the encryption key was transmitted without error.</p>\n         <p>If the source object for the copy is stored in Amazon S3 using SSE-C, you must provide the necessary\n      encryption information in your request so that Amazon S3 can decrypt the object for copying.</p>\n         <note>\n            <p>This functionality is not supported when the source object is in a directory bucket.</p>\n         </note>",
                         "smithy.api#httpHeader": "x-amz-copy-source-server-side-encryption-customer-key-MD5"
                     }
                 },
@@ -29239,7 +29361,7 @@
                 "Tagging": {
                     "target": "com.amazonaws.s3#TaggingHeader",
                     "traits": {
-                        "smithy.api#documentation": "<p>The tag-set for the object copy in the destination bucket. This value must be used in\n         conjunction with the <code>x-amz-tagging-directive</code> if you choose\n            <code>REPLACE</code> for the <code>x-amz-tagging-directive</code>. If you choose\n            <code>COPY</code> for the <code>x-amz-tagging-directive</code>, you don't need to set\n         the <code>x-amz-tagging</code> header, because the tag-set will be copied from the source\n         object directly. The tag-set must be encoded as URL Query parameters.</p>\n         <p>The default value is the empty value.</p>\n         <note>\n            <p>\n               <b>Directory buckets</b> - For directory buckets in a <code>CopyObject</code> operation, only the empty tag-set is supported. Any requests that attempt to write non-empty tags into directory buckets will receive a <code>501 Not Implemented</code> status code. \nWhen the destination bucket is a directory bucket, you will receive a <code>501 Not Implemented</code> response in any of the following situations:</p>\n            <ul>\n               <li>\n                  <p>When you attempt to <code>COPY</code> the tag-set from an S3 source object that has non-empty tags.</p>\n               </li>\n               <li>\n                  <p>When you attempt to <code>REPLACE</code> the tag-set of a source object and set a non-empty value to <code>x-amz-tagging</code>.</p>\n               </li>\n               <li>\n                  <p>When you don't set the <code>x-amz-tagging-directive</code> header and the source object has non-empty tags. This is because the default value of <code>x-amz-tagging-directive</code> is <code>COPY</code>.</p>\n               </li>\n            </ul>\n            <p>Because only the empty tag-set is supported for directory buckets in a <code>CopyObject</code> operation, the following situations are allowed:</p>\n            <ul>\n               <li>\n                  <p>When you attempt to <code>COPY</code> the tag-set from a directory bucket source object that has no tags to a general purpose bucket. It copies an empty tag-set to the destination object.</p>\n               </li>\n               <li>\n                  <p>When you attempt to <code>REPLACE</code> the tag-set of a directory bucket source object and set the <code>x-amz-tagging</code> value of the directory bucket destination object to empty.</p>\n               </li>\n               <li>\n                  <p>When you attempt to <code>REPLACE</code> the tag-set of a general purpose bucket source object that has non-empty tags and set the <code>x-amz-tagging</code> value of the directory bucket destination object to empty.</p>\n               </li>\n               <li>\n                  <p>When you attempt to <code>REPLACE</code> the tag-set of a directory bucket source object and don't set the <code>x-amz-tagging</code> value of the directory bucket destination object. This is because the default value of <code>x-amz-tagging</code> is the empty value.</p>\n               </li>\n            </ul>\n         </note>",
+                        "smithy.api#documentation": "<p>The tag-set for the object copy in the destination bucket. This value must be used in conjunction\n      with the <code>x-amz-tagging-directive</code> if you choose <code>REPLACE</code> for the\n        <code>x-amz-tagging-directive</code>. If you choose <code>COPY</code> for the\n        <code>x-amz-tagging-directive</code>, you don't need to set the <code>x-amz-tagging</code> header,\n      because the tag-set will be copied from the source object directly. The tag-set must be encoded as URL\n      Query parameters.</p>\n         <p>The default value is the empty value.</p>\n         <note>\n            <p>\n               <b>Directory buckets</b> - For directory buckets in a <code>CopyObject</code> operation, only the empty tag-set is supported. Any requests that attempt to write non-empty tags into directory buckets will receive a <code>501 Not Implemented</code> status code. \nWhen the destination bucket is a directory bucket, you will receive a <code>501 Not Implemented</code> response in any of the following situations:</p>\n            <ul>\n               <li>\n                  <p>When you attempt to <code>COPY</code> the tag-set from an S3 source object that has non-empty tags.</p>\n               </li>\n               <li>\n                  <p>When you attempt to <code>REPLACE</code> the tag-set of a source object and set a non-empty value to <code>x-amz-tagging</code>.</p>\n               </li>\n               <li>\n                  <p>When you don't set the <code>x-amz-tagging-directive</code> header and the source object has non-empty tags. This is because the default value of <code>x-amz-tagging-directive</code> is <code>COPY</code>.</p>\n               </li>\n            </ul>\n            <p>Because only the empty tag-set is supported for directory buckets in a <code>CopyObject</code> operation, the following situations are allowed:</p>\n            <ul>\n               <li>\n                  <p>When you attempt to <code>COPY</code> the tag-set from a directory bucket source object that has no tags to a general purpose bucket. It copies an empty tag-set to the destination object.</p>\n               </li>\n               <li>\n                  <p>When you attempt to <code>REPLACE</code> the tag-set of a directory bucket source object and set the <code>x-amz-tagging</code> value of the directory bucket destination object to empty.</p>\n               </li>\n               <li>\n                  <p>When you attempt to <code>REPLACE</code> the tag-set of a general purpose bucket source object that has non-empty tags and set the <code>x-amz-tagging</code> value of the directory bucket destination object to empty.</p>\n               </li>\n               <li>\n                  <p>When you attempt to <code>REPLACE</code> the tag-set of a directory bucket source object and don't set the <code>x-amz-tagging</code> value of the directory bucket destination object. This is because the default value of <code>x-amz-tagging</code> is the empty value.</p>\n               </li>\n            </ul>\n         </note>",
                         "smithy.api#httpHeader": "x-amz-tagging"
                     }
                 },
@@ -31330,6 +31452,114 @@
                 }
             }
         },
+        "com.amazonaws.s3#DeleteObjectAnnotation": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.s3#DeleteObjectAnnotationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.s3#DeleteObjectAnnotationOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.s3#NoSuchBucket"
+                },
+                {
+                    "target": "com.amazonaws.s3#NoSuchKey"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a specific annotation from an Amazon S3 object. Use the <code>x-amz-object-if-match</code>\n      header to perform a conditional delete that only succeeds if the object's ETag matches the\n      provided value, preventing race conditions during concurrent updates.</p>\n         <p>Deleting an annotation is permanent. Annotations are not independently versioned, so there is no\n      delete marker or way to recover a deleted annotation.</p>\n         <p>To use this operation, you must have the <code>s3:DeleteObjectAnnotation</code> permission. If\n      the object is protected by Object Lock in governance mode, you must also include the\n      <code>x-amz-bypass-governance-retention</code> header.</p>\n         <note>\n            <p>Annotations are not supported by the following features: S3 Inventory Reports,\n      API Gateway, S3 Storage Lens, Amazon S3 File Gateway, Amazon FSx, S3 on Outposts, and\n      S3 Express One Zone (directory buckets).</p>\n         </note>\n         <p>The following operations are related to <code>DeleteObjectAnnotation</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectAnnotation.html\">PutObjectAnnotation</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAnnotation.html\">GetObjectAnnotation</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectAnnotations.html\">ListObjectAnnotations</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/{Bucket}/{Key+}?annotation",
+                    "code": 204
+                }
+            }
+        },
+        "com.amazonaws.s3#DeleteObjectAnnotationOutput": {
+            "type": "structure",
+            "members": {
+                "ObjectVersionId": {
+                    "target": "com.amazonaws.s3#ObjectVersionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version ID of the object that the annotation was deleted from.</p>",
+                        "smithy.api#httpHeader": "x-amz-object-version-id"
+                    }
+                },
+                "RequestCharged": {
+                    "target": "com.amazonaws.s3#RequestCharged",
+                    "traits": {
+                        "smithy.api#httpHeader": "x-amz-request-charged"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.s3#DeleteObjectAnnotationRequest": {
+            "type": "structure",
+            "members": {
+                "Bucket": {
+                    "target": "com.amazonaws.s3#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the bucket that contains the object.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Bucket"
+                        }
+                    }
+                },
+                "Key": {
+                    "target": "com.amazonaws.s3#ObjectKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The object key.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "AnnotationName": {
+                    "target": "com.amazonaws.s3#AnnotationName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the annotation to delete. Annotation names are UTF-8 encoded and cannot start with\n      <code>aws</code> or <code>s3</code> (case-insensitive).</p>\n         <p>Length Constraints: Minimum length of 1. Maximum length of 512 bytes.</p>",
+                        "smithy.api#httpQuery": "annotationName",
+                        "smithy.api#required": {}
+                    }
+                },
+                "VersionId": {
+                    "target": "com.amazonaws.s3#ObjectVersionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version ID of the object.</p>",
+                        "smithy.api#httpQuery": "versionId"
+                    }
+                },
+                "RequestPayer": {
+                    "target": "com.amazonaws.s3#RequestPayer",
+                    "traits": {
+                        "smithy.api#httpHeader": "x-amz-request-payer"
+                    }
+                },
+                "ExpectedBucketOwner": {
+                    "target": "com.amazonaws.s3#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The account ID of the expected bucket owner.</p>",
+                        "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
+                    }
+                },
+                "ObjectIfMatch": {
+                    "target": "com.amazonaws.s3#ObjectIfMatch",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If specified, the operation only succeeds if the object's ETag matches the provided value.</p>",
+                        "smithy.api#httpHeader": "x-amz-object-if-match"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
         "com.amazonaws.s3#DeleteObjectOutput": {
             "type": "structure",
             "members": {
@@ -32252,6 +32482,24 @@
                     "target": "smithy.api#Unit",
                     "traits": {
                         "smithy.api#enumValue": "s3:ObjectTagging:Delete"
+                    }
+                },
+                "s3_ObjectAnnotation_": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "s3:ObjectAnnotation:*"
+                    }
+                },
+                "s3_ObjectAnnotation_Put": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "s3:ObjectAnnotation:Put"
+                    }
+                },
+                "s3_ObjectAnnotation_Delete": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "s3:ObjectAnnotation:Delete"
                     }
                 }
             },
@@ -34386,6 +34634,255 @@
                     "traits": {
                         "smithy.api#documentation": "<p>The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code> (access denied).</p>",
                         "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.s3#GetObjectAnnotation": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.s3#GetObjectAnnotationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.s3#GetObjectAnnotationOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.s3#NoSuchAnnotation"
+                },
+                {
+                    "target": "com.amazonaws.s3#NoSuchBucket"
+                },
+                {
+                    "target": "com.amazonaws.s3#NoSuchKey"
+                }
+            ],
+            "traits": {
+                "aws.protocols#httpChecksum": {
+                    "requestValidationModeMember": "ChecksumMode",
+                    "responseAlgorithms": [
+                        "CRC64NVME",
+                        "CRC32",
+                        "CRC32C",
+                        "SHA256",
+                        "SHA1",
+                        "SHA512",
+                        "MD5",
+                        "XXHASH64",
+                        "XXHASH3",
+                        "XXHASH128"
+                    ]
+                },
+                "smithy.api#documentation": "<p>Retrieves an annotation from an Amazon S3 object. To use this operation, you must have the\n      <code>s3:GetObjectAnnotation</code> permission.</p>\n         <p>If checksum mode is enabled via the <code>x-amz-checksum-mode</code> header, Amazon S3\n      returns the stored checksum in the response headers for client-side validation.</p>\n         <note>\n            <p>Annotations are not supported by the following features: S3 Inventory Reports,\n      API Gateway, S3 Storage Lens, Amazon S3 File Gateway, Amazon FSx, S3 on Outposts, and\n      S3 Express One Zone (directory buckets).</p>\n         </note>\n         <p>The following operations are related to <code>GetObjectAnnotation</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectAnnotation.html\">PutObjectAnnotation</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectAnnotations.html\">ListObjectAnnotations</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectAnnotation.html\">DeleteObjectAnnotation</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/{Bucket}/{Key+}?annotation&x-id=GetObjectAnnotation",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.s3#GetObjectAnnotationOutput": {
+            "type": "structure",
+            "members": {
+                "AnnotationPayload": {
+                    "target": "com.amazonaws.s3#StreamingBlob",
+                    "traits": {
+                        "smithy.api#default": "",
+                        "smithy.api#documentation": "<p>The annotation payload.</p>",
+                        "smithy.api#httpPayload": {}
+                    }
+                },
+                "ObjectVersionId": {
+                    "target": "com.amazonaws.s3#ObjectVersionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version ID of the object that the annotation is attached to.</p>",
+                        "smithy.api#httpHeader": "x-amz-object-version-id"
+                    }
+                },
+                "LastModified": {
+                    "target": "com.amazonaws.s3#LastModified",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time the annotation was last modified.</p>",
+                        "smithy.api#httpHeader": "Last-Modified"
+                    }
+                },
+                "ContentLength": {
+                    "target": "com.amazonaws.s3#ContentLength",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The size of the annotation payload, in bytes.</p>",
+                        "smithy.api#httpHeader": "Content-Length"
+                    }
+                },
+                "ETag": {
+                    "target": "com.amazonaws.s3#ETag",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The entity tag of the annotation.</p>",
+                        "smithy.api#httpHeader": "ETag"
+                    }
+                },
+                "ChecksumCRC32": {
+                    "target": "com.amazonaws.s3#ChecksumCRC32",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The CRC32 checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-crc32"
+                    }
+                },
+                "ChecksumCRC32C": {
+                    "target": "com.amazonaws.s3#ChecksumCRC32C",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The CRC32C checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-crc32c"
+                    }
+                },
+                "ChecksumCRC64NVME": {
+                    "target": "com.amazonaws.s3#ChecksumCRC64NVME",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The CRC64NVME checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-crc64nvme"
+                    }
+                },
+                "ChecksumSHA1": {
+                    "target": "com.amazonaws.s3#ChecksumSHA1",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The SHA1 checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-sha1"
+                    }
+                },
+                "ChecksumSHA256": {
+                    "target": "com.amazonaws.s3#ChecksumSHA256",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The SHA256 checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-sha256"
+                    }
+                },
+                "ChecksumSHA512": {
+                    "target": "com.amazonaws.s3#ChecksumSHA512",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The SHA512 checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-sha512"
+                    }
+                },
+                "ChecksumMD5": {
+                    "target": "com.amazonaws.s3#ChecksumMD5",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The MD5 checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-md5"
+                    }
+                },
+                "ChecksumXXHASH64": {
+                    "target": "com.amazonaws.s3#ChecksumXXHASH64",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The XXHASH64 checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-xxhash64"
+                    }
+                },
+                "ChecksumXXHASH3": {
+                    "target": "com.amazonaws.s3#ChecksumXXHASH3",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The XXHASH3 checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-xxhash3"
+                    }
+                },
+                "ChecksumXXHASH128": {
+                    "target": "com.amazonaws.s3#ChecksumXXHASH128",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The XXHASH128 checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-xxhash128"
+                    }
+                },
+                "ChecksumType": {
+                    "target": "com.amazonaws.s3#ChecksumType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of checksum used.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-type"
+                    }
+                },
+                "ServerSideEncryption": {
+                    "target": "com.amazonaws.s3#ServerSideEncryption",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The server-side encryption algorithm used.</p>",
+                        "smithy.api#httpHeader": "x-amz-server-side-encryption"
+                    }
+                },
+                "RequestCharged": {
+                    "target": "com.amazonaws.s3#RequestCharged",
+                    "traits": {
+                        "smithy.api#httpHeader": "x-amz-request-charged"
+                    }
+                },
+                "ReplicationStatus": {
+                    "target": "com.amazonaws.s3#ReplicationStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The replication status of the annotation. Possible values include <code>PENDING</code>, <code>COMPLETED</code>, <code>FAILED</code>, and <code>REPLICA</code>.</p>",
+                        "smithy.api#httpHeader": "x-amz-replication-status"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.s3#GetObjectAnnotationRequest": {
+            "type": "structure",
+            "members": {
+                "Bucket": {
+                    "target": "com.amazonaws.s3#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the bucket that contains the object.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Bucket"
+                        }
+                    }
+                },
+                "Key": {
+                    "target": "com.amazonaws.s3#ObjectKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The object key.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Key"
+                        }
+                    }
+                },
+                "AnnotationName": {
+                    "target": "com.amazonaws.s3#AnnotationName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the annotation to retrieve.</p>\n         <p>Length Constraints: Minimum length of 1. Maximum length of 512 bytes.</p>",
+                        "smithy.api#httpQuery": "annotationName",
+                        "smithy.api#required": {}
+                    }
+                },
+                "VersionId": {
+                    "target": "com.amazonaws.s3#ObjectVersionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version ID of the object.</p>",
+                        "smithy.api#httpQuery": "versionId"
+                    }
+                },
+                "RequestPayer": {
+                    "target": "com.amazonaws.s3#RequestPayer",
+                    "traits": {
+                        "smithy.api#httpHeader": "x-amz-request-payer"
+                    }
+                },
+                "ExpectedBucketOwner": {
+                    "target": "com.amazonaws.s3#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The account ID of the expected bucket owner. If the bucket is owned by a different account, the request fails with an HTTP 403 (Access Denied) error.</p>",
+                        "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
+                    }
+                },
+                "ChecksumMode": {
+                    "target": "com.amazonaws.s3#ChecksumMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Set to <code>ENABLED</code> to validate the checksum of the annotation payload on retrieval.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-mode"
                     }
                 }
             },
@@ -36598,6 +37095,15 @@
                 }
             }
         },
+        "com.amazonaws.s3#InvalidAnnotationName": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>The annotation name you provided is invalid.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
         "com.amazonaws.s3#InvalidObjectState": {
             "type": "structure",
             "members": {
@@ -36612,6 +37118,15 @@
                 "smithy.api#documentation": "<p>Object is archived and inaccessible until restored.</p>\n         <p>If the object you are retrieving is stored in the S3 Glacier Flexible Retrieval storage\n         class, the S3 Glacier Deep Archive storage class, the S3 Intelligent-Tiering Archive Access\n         tier, or the S3 Intelligent-Tiering Deep Archive Access tier, before you can retrieve the object you\n         must first restore a copy using <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html\">RestoreObject</a>. Otherwise, this\n         operation returns an <code>InvalidObjectState</code> error. For information about restoring\n         archived objects, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/restoring-objects.html\">Restoring Archived Objects</a> in\n         the <i>Amazon S3 User Guide</i>.</p>",
                 "smithy.api#error": "client",
                 "smithy.api#httpError": 403
+            }
+        },
+        "com.amazonaws.s3#InvalidPrefix": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>The annotation prefix you provided is invalid.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
             }
         },
         "com.amazonaws.s3#InvalidRequest": {
@@ -38247,6 +38762,177 @@
                 "smithy.api#input": {}
             }
         },
+        "com.amazonaws.s3#ListObjectAnnotations": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.s3#ListObjectAnnotationsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.s3#ListObjectAnnotationsOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.s3#InvalidPrefix"
+                },
+                {
+                    "target": "com.amazonaws.s3#NoSuchBucket"
+                },
+                {
+                    "target": "com.amazonaws.s3#NoSuchKey"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists the annotations attached to an Amazon S3 object. Results are paginated, with a maximum of\n      1,000 annotations per object. Use the <code>AnnotationPrefix</code> parameter to filter the\n      results by name prefix.</p>\n         <p>To use this operation, you must have the <code>s3:ListObjectAnnotations</code> permission.</p>\n         <note>\n            <p>Annotations are not supported by the following features: S3 Inventory Reports,\n      API Gateway, S3 Storage Lens, Amazon S3 File Gateway, Amazon FSx, S3 on Outposts, and\n      S3 Express One Zone (directory buckets).</p>\n         </note>\n         <p>The following operations are related to <code>ListObjectAnnotations</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectAnnotation.html\">PutObjectAnnotation</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAnnotation.html\">GetObjectAnnotation</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectAnnotation.html\">DeleteObjectAnnotation</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/{Bucket}/{Key+}?annotation&x-id=ListObjectAnnotations",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "ContinuationToken",
+                    "outputToken": "NextContinuationToken",
+                    "items": "Annotations",
+                    "pageSize": "MaxAnnotationResults"
+                }
+            }
+        },
+        "com.amazonaws.s3#ListObjectAnnotationsOutput": {
+            "type": "structure",
+            "members": {
+                "Annotations": {
+                    "target": "com.amazonaws.s3#AnnotationList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of annotations attached to the object.</p>"
+                    }
+                },
+                "Bucket": {
+                    "target": "com.amazonaws.s3#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The bucket name.</p>"
+                    }
+                },
+                "Key": {
+                    "target": "com.amazonaws.s3#ObjectKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The object key.</p>"
+                    }
+                },
+                "ObjectVersionId": {
+                    "target": "com.amazonaws.s3#ObjectVersionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version ID of the object.</p>",
+                        "smithy.api#httpHeader": "x-amz-object-version-id"
+                    }
+                },
+                "AnnotationPrefix": {
+                    "target": "com.amazonaws.s3#AnnotationPrefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The prefix used to filter the response.</p>"
+                    }
+                },
+                "MaxAnnotationResults": {
+                    "target": "com.amazonaws.s3#MaxAnnotationResults",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of annotations returned in the response.</p>"
+                    }
+                },
+                "AnnotationCount": {
+                    "target": "com.amazonaws.s3#AnnotationCount",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of annotations returned.</p>"
+                    }
+                },
+                "ContinuationToken": {
+                    "target": "com.amazonaws.s3#Token",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The continuation token used in this request.</p>"
+                    }
+                },
+                "NextContinuationToken": {
+                    "target": "com.amazonaws.s3#NextToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The continuation token to use to retrieve the next page of results.</p>"
+                    }
+                },
+                "RequestCharged": {
+                    "target": "com.amazonaws.s3#RequestCharged",
+                    "traits": {
+                        "smithy.api#httpHeader": "x-amz-request-charged"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.s3#ListObjectAnnotationsRequest": {
+            "type": "structure",
+            "members": {
+                "Bucket": {
+                    "target": "com.amazonaws.s3#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the bucket that contains the object.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Bucket"
+                        }
+                    }
+                },
+                "Key": {
+                    "target": "com.amazonaws.s3#ObjectKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The object key.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "VersionId": {
+                    "target": "com.amazonaws.s3#ObjectVersionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version ID of the object.</p>",
+                        "smithy.api#httpQuery": "versionId"
+                    }
+                },
+                "MaxAnnotationResults": {
+                    "target": "com.amazonaws.s3#MaxAnnotationResults",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of annotations to return in the response. Maximum is 1,000.</p>",
+                        "smithy.api#httpQuery": "max-annotation-results"
+                    }
+                },
+                "AnnotationPrefix": {
+                    "target": "com.amazonaws.s3#AnnotationPrefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Filter results to annotations whose name begins with the specified prefix.</p>",
+                        "smithy.api#httpQuery": "annotation-prefix"
+                    }
+                },
+                "ContinuationToken": {
+                    "target": "com.amazonaws.s3#Token",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Continuation token returned by a previous request to retrieve the next page.</p>",
+                        "smithy.api#httpQuery": "continuation-token"
+                    }
+                },
+                "RequestPayer": {
+                    "target": "com.amazonaws.s3#RequestPayer",
+                    "traits": {
+                        "smithy.api#httpHeader": "x-amz-request-payer"
+                    }
+                },
+                "ExpectedBucketOwner": {
+                    "target": "com.amazonaws.s3#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The account ID of the expected bucket owner.</p>",
+                        "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
         "com.amazonaws.s3#ListObjectVersions": {
             "type": "operation",
             "input": {
@@ -39317,6 +40003,15 @@
         "com.amazonaws.s3#MaxAgeSeconds": {
             "type": "integer"
         },
+        "com.amazonaws.s3#MaxAnnotationResults": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 1000
+                }
+            }
+        },
         "com.amazonaws.s3#MaxBuckets": {
             "type": "integer",
             "traits": {
@@ -39733,6 +40428,15 @@
         "com.amazonaws.s3#NextVersionIdMarker": {
             "type": "string"
         },
+        "com.amazonaws.s3#NoSuchAnnotation": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>The specified annotation does not exist on this object.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
         "com.amazonaws.s3#NoSuchBucket": {
             "type": "structure",
             "members": {},
@@ -40108,6 +40812,9 @@
             "member": {
                 "target": "com.amazonaws.s3#ObjectIdentifier"
             }
+        },
+        "com.amazonaws.s3#ObjectIfMatch": {
+            "type": "string"
         },
         "com.amazonaws.s3#ObjectKey": {
             "type": "string",
@@ -42973,6 +43680,330 @@
                     "target": "com.amazonaws.s3#AccountId",
                     "traits": {
                         "smithy.api#documentation": "<p>The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code <code>403 Forbidden</code> (access denied).</p>",
+                        "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.s3#PutObjectAnnotation": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.s3#PutObjectAnnotationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.s3#PutObjectAnnotationOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.s3#AnnotationLimitExceeded"
+                },
+                {
+                    "target": "com.amazonaws.s3#AnnotationNameTooLong"
+                },
+                {
+                    "target": "com.amazonaws.s3#InvalidAnnotationName"
+                },
+                {
+                    "target": "com.amazonaws.s3#InvalidRequest"
+                },
+                {
+                    "target": "com.amazonaws.s3#NoSuchBucket"
+                },
+                {
+                    "target": "com.amazonaws.s3#NoSuchKey"
+                },
+                {
+                    "target": "com.amazonaws.s3#UnsupportedMediaType"
+                }
+            ],
+            "traits": {
+                "aws.protocols#httpChecksum": {
+                    "requestAlgorithmMember": "ChecksumAlgorithm"
+                },
+                "smithy.api#documentation": "<p>Attaches an annotation to an Amazon S3 object. An annotation is a named payload of 1 byte to 1 MiB\n      that you can associate with a specific object or object version. Each object can have up to 1,000\n      annotations.</p>\n         <p>For annotation naming rules and restrictions, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/annotations-overview.html\">Annotation naming guidelines</a>\n      in the <i>Amazon S3 User Guide</i>.</p>\n         <p>Annotations inherit the encryption of their parent object. For objects without server-side\n      encryption, annotations are encrypted with SSE-S3 (the default for new objects). Objects\n      encrypted with SSE-C cannot have annotations.</p>\n         <p>To use this operation, you must have the <code>s3:PutObjectAnnotation</code> permission. If the\n      bucket has Requester Pays enabled, you must include the <code>x-amz-request-payer</code> header.</p>\n         <note>\n            <p>Annotations are not supported by the following features: S3 Inventory Reports,\n      API Gateway, S3 Storage Lens, Amazon S3 File Gateway, Amazon FSx, S3 on Outposts, and\n      S3 Express One Zone (directory buckets).</p>\n         </note>\n         <p>The following operations are related to <code>PutObjectAnnotation</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAnnotation.html\">GetObjectAnnotation</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectAnnotations.html\">ListObjectAnnotations</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectAnnotation.html\">DeleteObjectAnnotation</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/{Bucket}/{Key+}?annotation",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.s3#PutObjectAnnotationOutput": {
+            "type": "structure",
+            "members": {
+                "Key": {
+                    "target": "com.amazonaws.s3#ObjectKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The object key.</p>"
+                    }
+                },
+                "AnnotationName": {
+                    "target": "com.amazonaws.s3#AnnotationName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the annotation.</p>"
+                    }
+                },
+                "ObjectVersionId": {
+                    "target": "com.amazonaws.s3#ObjectVersionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version ID of the object that the annotation was attached to.</p>",
+                        "smithy.api#httpHeader": "x-amz-object-version-id"
+                    }
+                },
+                "ETag": {
+                    "target": "com.amazonaws.s3#ETag",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The entity tag of the annotation.</p>",
+                        "smithy.api#httpHeader": "ETag"
+                    }
+                },
+                "ChecksumCRC32": {
+                    "target": "com.amazonaws.s3#ChecksumCRC32",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The CRC32 checksum of the stored annotation.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-crc32"
+                    }
+                },
+                "ChecksumCRC32C": {
+                    "target": "com.amazonaws.s3#ChecksumCRC32C",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The CRC32C checksum of the stored annotation.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-crc32c"
+                    }
+                },
+                "ChecksumCRC64NVME": {
+                    "target": "com.amazonaws.s3#ChecksumCRC64NVME",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The CRC64NVME checksum of the stored annotation.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-crc64nvme"
+                    }
+                },
+                "ChecksumSHA1": {
+                    "target": "com.amazonaws.s3#ChecksumSHA1",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The SHA1 checksum of the stored annotation.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-sha1"
+                    }
+                },
+                "ChecksumSHA256": {
+                    "target": "com.amazonaws.s3#ChecksumSHA256",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The SHA256 checksum of the stored annotation.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-sha256"
+                    }
+                },
+                "ChecksumSHA512": {
+                    "target": "com.amazonaws.s3#ChecksumSHA512",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The SHA512 checksum of the stored annotation.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-sha512"
+                    }
+                },
+                "ChecksumMD5": {
+                    "target": "com.amazonaws.s3#ChecksumMD5",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The MD5 checksum of the stored annotation.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-md5"
+                    }
+                },
+                "ChecksumXXHASH64": {
+                    "target": "com.amazonaws.s3#ChecksumXXHASH64",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The XXHASH64 checksum of the stored annotation.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-xxhash64"
+                    }
+                },
+                "ChecksumXXHASH3": {
+                    "target": "com.amazonaws.s3#ChecksumXXHASH3",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The XXHASH3 checksum of the stored annotation.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-xxhash3"
+                    }
+                },
+                "ChecksumXXHASH128": {
+                    "target": "com.amazonaws.s3#ChecksumXXHASH128",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The XXHASH128 checksum of the stored annotation.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-xxhash128"
+                    }
+                },
+                "ChecksumType": {
+                    "target": "com.amazonaws.s3#ChecksumType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of checksum used.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-type"
+                    }
+                },
+                "ServerSideEncryption": {
+                    "target": "com.amazonaws.s3#ServerSideEncryption",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The server-side encryption algorithm used to encrypt the annotation.</p>",
+                        "smithy.api#httpHeader": "x-amz-server-side-encryption"
+                    }
+                },
+                "RequestCharged": {
+                    "target": "com.amazonaws.s3#RequestCharged",
+                    "traits": {
+                        "smithy.api#httpHeader": "x-amz-request-charged"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.s3#PutObjectAnnotationRequest": {
+            "type": "structure",
+            "members": {
+                "Bucket": {
+                    "target": "com.amazonaws.s3#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the bucket that contains the object.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Bucket"
+                        }
+                    }
+                },
+                "Key": {
+                    "target": "com.amazonaws.s3#ObjectKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The object key.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Key"
+                        }
+                    }
+                },
+                "VersionId": {
+                    "target": "com.amazonaws.s3#ObjectVersionId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version ID of the object to attach the annotation to.</p>",
+                        "smithy.api#httpQuery": "versionId"
+                    }
+                },
+                "AnnotationName": {
+                    "target": "com.amazonaws.s3#AnnotationName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the annotation.</p>\n         <p>Length Constraints: Minimum length of 1. Maximum length of 512 bytes.</p>",
+                        "smithy.api#httpQuery": "annotationName",
+                        "smithy.api#required": {}
+                    }
+                },
+                "AnnotationPayload": {
+                    "target": "com.amazonaws.s3#StreamingBlob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The annotation payload. Must be between 1 byte and 1 MiB in size, and must be valid UTF-8\n      encoded text. If the payload contains invalid UTF-8 bytes, the request fails with HTTP 415\n      (Unsupported Media Type). To store binary data, encode the payload using Base64 before\n      uploading.</p>",
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "ObjectIfMatch": {
+                    "target": "com.amazonaws.s3#ObjectIfMatch",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If specified, the operation only succeeds if the object's ETag matches the provided value.</p>",
+                        "smithy.api#httpHeader": "x-amz-object-if-match"
+                    }
+                },
+                "ChecksumAlgorithm": {
+                    "target": "com.amazonaws.s3#ChecksumAlgorithm",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The checksum algorithm to use. Supported values: <code>CRC32</code>, <code>CRC32C</code>, <code>CRC64NVME</code>, <code>SHA1</code>, <code>SHA256</code>, <code>SHA512</code>, <code>MD5</code>, <code>XXHASH64</code>, <code>XXHASH3</code>, <code>XXHASH128</code>.</p>",
+                        "smithy.api#httpHeader": "x-amz-sdk-checksum-algorithm"
+                    }
+                },
+                "ChecksumCRC32": {
+                    "target": "com.amazonaws.s3#ChecksumCRC32",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Base64-encoded CRC32 checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-crc32"
+                    }
+                },
+                "ChecksumCRC32C": {
+                    "target": "com.amazonaws.s3#ChecksumCRC32C",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Base64-encoded CRC32C checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-crc32c"
+                    }
+                },
+                "ChecksumCRC64NVME": {
+                    "target": "com.amazonaws.s3#ChecksumCRC64NVME",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Base64-encoded CRC64NVME checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-crc64nvme"
+                    }
+                },
+                "ChecksumSHA1": {
+                    "target": "com.amazonaws.s3#ChecksumSHA1",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Base64-encoded SHA1 checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-sha1"
+                    }
+                },
+                "ChecksumSHA256": {
+                    "target": "com.amazonaws.s3#ChecksumSHA256",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Base64-encoded SHA256 checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-sha256"
+                    }
+                },
+                "ChecksumSHA512": {
+                    "target": "com.amazonaws.s3#ChecksumSHA512",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Base64-encoded SHA512 checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-sha512"
+                    }
+                },
+                "ChecksumMD5": {
+                    "target": "com.amazonaws.s3#ChecksumMD5",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Base64-encoded MD5 checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-md5"
+                    }
+                },
+                "ChecksumXXHASH64": {
+                    "target": "com.amazonaws.s3#ChecksumXXHASH64",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Base64-encoded XXHASH64 checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-xxhash64"
+                    }
+                },
+                "ChecksumXXHASH3": {
+                    "target": "com.amazonaws.s3#ChecksumXXHASH3",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Base64-encoded XXHASH3 checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-xxhash3"
+                    }
+                },
+                "ChecksumXXHASH128": {
+                    "target": "com.amazonaws.s3#ChecksumXXHASH128",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Base64-encoded XXHASH128 checksum of the annotation payload.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-xxhash128"
+                    }
+                },
+                "ContentMD5": {
+                    "target": "com.amazonaws.s3#ContentMD5",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Base64-encoded MD5 digest of the message.</p>",
+                        "smithy.api#httpHeader": "Content-MD5"
+                    }
+                },
+                "RequestPayer": {
+                    "target": "com.amazonaws.s3#RequestPayer",
+                    "traits": {
+                        "smithy.api#httpHeader": "x-amz-request-payer"
+                    }
+                },
+                "ExpectedBucketOwner": {
+                    "target": "com.amazonaws.s3#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The account ID of the expected bucket owner. If the bucket is owned by a different account, the request fails with an HTTP 403 (Access Denied) error.</p>",
                         "smithy.api#httpHeader": "x-amz-expected-bucket-owner"
                     }
                 }
@@ -46198,6 +47229,15 @@
         },
         "com.amazonaws.s3#URI": {
             "type": "string"
+        },
+        "com.amazonaws.s3#UnsupportedMediaType": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>The annotation payload is not valid UTF-8 encoded text.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 415
+            }
         },
         "com.amazonaws.s3#UpdateBucketMetadataAnnotationTableConfiguration": {
             "type": "operation",


### PR DESCRIPTION
## Summary

Add the four object annotation operations to the S3 model, continuing the Smithy model refresh toward upstream `db89911` (see #676). All operations get default stubs on the `S3Service` trait that return `NotImplemented` like the other new operations.

## Changes

### `data/s3.json`

- +4 operations: `PutObjectAnnotation` (`PUT /{Bucket}/{Key+}?annotation`), `GetObjectAnnotation` (`GET /{Bucket}/{Key+}?annotation`), `ListObjectAnnotations` (`GET /{Bucket}/{Key+}?annotation`), `DeleteObjectAnnotation` (`DELETE /{Bucket}/{Key+}?annotation`)
- +29 shapes: request/response types, `AnnotationEntry`/`AnnotationList` pagination types, annotation name/condition types, and new error structures (`AnnotationLimitExceeded`, `AnnotationNameTooLong`, `InvalidAnnotationName`, `NoSuchAnnotation`, `InvalidPrefix`, `UnsupportedMediaType`)
- `CopyObjectRequest` gains `AnnotationDirective`, `IfMatch`, `IfNoneMatch`; `Event` gains three annotation notification variants (`s3:ObjectAnnotation:*`, `s3:ObjectAnnotation:Put`, `s3:ObjectAnnotation:Delete`)
- All changed shapes are byte-identical to upstream `db89911`

### codegen

- `ops.rs`: router disambiguates operations that share a query tag by the presence of a required query member. `GetObjectAnnotation` and `ListObjectAnnotations` both use `?annotation` and are distinguished by `annotationName` (the official wire form), replacing the previous `x-id`-based routing that did not match the documented API
- `dto.rs`: `StreamingBlob` payloads are always `Option` (a required streaming payload without a `default` trait now follows the same convention as the existing ones)

### Generated code (`just codegen`)

- dto: new input/output types and builders
- ops: HTTP deserialization (checksum headers, `x-amz-object-if-match`, query parameters), streaming payload handling, router rules for `?annotation`
- s3_trait: four methods with `NotImplemented` stubs
- access: access hooks for each new operation
- s3s-aws conv/proxy: field wiring to `aws_sdk_s3`

### Route fixtures and tests

- +route fixture entries covering the `?annotation` rules in the official form: `annotationName` presence routes to `GetObjectAnnotation`; bare tag / `annotation-prefix` routes to `ListObjectAnnotations`

## Verification

- `just codegen` idempotent (second run produces no diff)
- `route_fixtures_match` passes (official-form routing locked)
- `just dev` all green
- CI-style `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean
- changed model shapes verified byte-identical to upstream `db89911`

Refs #676
