### PR TITLE
feat(data): add bucket ARN, tags and tag count to S3 model

### DIFF
--- a/crates/s3s-aws/src/conv/generated.rs
+++ b/crates/s3s-aws/src/conv/generated.rs
@@ -473,6 +473,7 @@ impl AwsConversion for s3s::dto::Bucket {
 
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(Self {
+            bucket_arn: try_from_aws(x.bucket_arn)?,
             bucket_region: try_from_aws(x.bucket_region)?,
             creation_date: try_from_aws(x.creation_date)?,
             name: try_from_aws(x.name)?,
@@ -481,6 +482,7 @@ impl AwsConversion for s3s::dto::Bucket {
 
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         let mut y = Self::Target::builder();
+        y = y.set_bucket_arn(try_into_aws(x.bucket_arn)?);
         y = y.set_bucket_region(try_into_aws(x.bucket_region)?);
         y = y.set_creation_date(try_into_aws(x.creation_date)?);
         y = y.set_name(try_into_aws(x.name)?);
@@ -1475,6 +1477,7 @@ impl AwsConversion for s3s::dto::CreateBucketConfiguration {
             bucket: try_from_aws(x.bucket)?,
             location: try_from_aws(x.location)?,
             location_constraint: try_from_aws(x.location_constraint)?,
+            tags: try_from_aws(x.tags)?,
         })
     }
 
@@ -1483,6 +1486,7 @@ impl AwsConversion for s3s::dto::CreateBucketConfiguration {
         y = y.set_bucket(try_into_aws(x.bucket)?);
         y = y.set_location(try_into_aws(x.location)?);
         y = y.set_location_constraint(try_into_aws(x.location_constraint)?);
+        y = y.set_tags(try_into_aws(x.tags)?);
         Ok(y.build())
     }
 }
@@ -1612,12 +1616,14 @@ impl AwsConversion for s3s::dto::CreateBucketOutput {
 
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(Self {
+            bucket_arn: try_from_aws(x.bucket_arn)?,
             location: try_from_aws(x.location)?,
         })
     }
 
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         let mut y = Self::Target::builder();
+        y = y.set_bucket_arn(try_into_aws(x.bucket_arn)?);
         y = y.set_location(try_into_aws(x.location)?);
         Ok(y.build())
     }
@@ -4728,6 +4734,7 @@ impl AwsConversion for s3s::dto::HeadBucketOutput {
     fn try_from_aws(x: Self::Target) -> S3Result<Self> {
         Ok(Self {
             access_point_alias: try_from_aws(x.access_point_alias)?,
+            bucket_arn: try_from_aws(x.bucket_arn)?,
             bucket_location_name: try_from_aws(x.bucket_location_name)?,
             bucket_location_type: try_from_aws(x.bucket_location_type)?,
             bucket_region: try_from_aws(x.bucket_region)?,
@@ -4737,6 +4744,7 @@ impl AwsConversion for s3s::dto::HeadBucketOutput {
     fn try_into_aws(x: Self) -> S3Result<Self::Target> {
         let mut y = Self::Target::builder();
         y = y.set_access_point_alias(try_into_aws(x.access_point_alias)?);
+        y = y.set_bucket_arn(try_into_aws(x.bucket_arn)?);
         y = y.set_bucket_location_name(try_into_aws(x.bucket_location_name)?);
         y = y.set_bucket_location_type(try_into_aws(x.bucket_location_type)?);
         y = y.set_bucket_region(try_into_aws(x.bucket_region)?);
@@ -4848,6 +4856,7 @@ impl AwsConversion for s3s::dto::HeadObjectOutput {
             ssekms_key_id: try_from_aws(x.ssekms_key_id)?,
             server_side_encryption: try_from_aws(x.server_side_encryption)?,
             storage_class: try_from_aws(x.storage_class)?,
+            tag_count: try_from_aws(x.tag_count)?,
             version_id: try_from_aws(x.version_id)?,
             website_redirect_location: try_from_aws(x.website_redirect_location)?,
         })
@@ -4896,6 +4905,7 @@ impl AwsConversion for s3s::dto::HeadObjectOutput {
         y = y.set_ssekms_key_id(try_into_aws(x.ssekms_key_id)?);
         y = y.set_server_side_encryption(try_into_aws(x.server_side_encryption)?);
         y = y.set_storage_class(try_into_aws(x.storage_class)?);
+        y = y.set_tag_count(try_into_aws(x.tag_count)?);
         y = y.set_version_id(try_into_aws(x.version_id)?);
         y = y.set_website_redirect_location(try_into_aws(x.website_redirect_location)?);
         Ok(y.build())

--- a/crates/s3s-fs/src/s3.rs
+++ b/crates/s3s-fs/src/s3.rs
@@ -619,6 +619,7 @@ impl S3 for FileSystem {
                 creation_date: Some(created_or_modified_date),
                 name: Some(name.to_owned()),
                 bucket_region: None,
+                bucket_arn: None,
             };
             buckets.push(bucket);
         }

--- a/crates/s3s/src/dto/generated.rs
+++ b/crates/s3s/src/dto/generated.rs
@@ -1390,6 +1390,13 @@ impl DtoExt for BlockedEncryptionTypes {
 /// <p> In terms of implementation, a Bucket is a resource. </p>
 #[derive(Clone, Default, PartialEq)]
 pub struct Bucket {
+    /// <p>The Amazon Resource Name (ARN) of the S3 bucket. ARNs uniquely identify Amazon Web Services resources across all
+    /// of Amazon Web Services.</p>
+    /// <note>
+    /// <p>This parameter is only supported for S3 directory buckets. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-tagging.html">Using tags with
+    /// directory buckets</a>.</p>
+    /// </note>
+    pub bucket_arn: Option<S3RegionalOrS3ExpressBucketArnString>,
     /// <p>
     /// <code>BucketRegion</code> indicates the Amazon Web Services region where the bucket is located. If the
     /// request contains at least one valid parameter, it is included in the response.</p>
@@ -1404,6 +1411,9 @@ pub struct Bucket {
 impl fmt::Debug for Bucket {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("Bucket");
+        if let Some(ref val) = self.bucket_arn {
+            d.field("bucket_arn", val);
+        }
         if let Some(ref val) = self.bucket_region {
             d.field("bucket_region", val);
         }
@@ -1418,6 +1428,9 @@ impl fmt::Debug for Bucket {
 }
 impl DtoExt for Bucket {
     fn ignore_empty_strings(&mut self) {
+        if self.bucket_arn.as_deref() == Some("") {
+            self.bucket_arn = None;
+        }
         if self.bucket_region.as_deref() == Some("") {
             self.bucket_region = None;
         }
@@ -5430,6 +5443,11 @@ pub struct CreateBucketConfiguration {
     /// <p>This functionality is not supported for directory buckets.</p>
     /// </note>
     pub location_constraint: Option<BucketLocationConstraint>,
+    /// <p>An array of tags that you can apply to the bucket that you're creating. Tags are key-value pairs of metadata used to categorize and organize your buckets, track costs, and control access. </p>
+    /// <p>You must have the <code>s3:TagResource</code> permission to create a general
+    /// purpose bucket with tags or the <code>s3express:TagResource</code> permission to create a directory bucket with tags.</p>
+    /// <p>When creating buckets with tags, note that tag-based conditions using <code>aws:ResourceTag</code> and <code>s3:BucketTag</code> condition keys are applicable only after ABAC is enabled on the bucket. To learn more, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging-enable-abac.html">Enabling ABAC in general purpose buckets</a>.</p>
+    pub tags: Option<TagSet>,
 }
 
 impl fmt::Debug for CreateBucketConfiguration {
@@ -5443,6 +5461,9 @@ impl fmt::Debug for CreateBucketConfiguration {
         }
         if let Some(ref val) = self.location_constraint {
             d.field("location_constraint", val);
+        }
+        if let Some(ref val) = self.tags {
+            d.field("tags", val);
         }
         d.finish_non_exhaustive()
     }
@@ -5769,6 +5790,13 @@ impl fmt::Debug for CreateBucketMetadataTableConfigurationOutput {
 
 #[derive(Clone, Default, PartialEq)]
 pub struct CreateBucketOutput {
+    /// <p>The Amazon Resource Name (ARN) of the S3 bucket. ARNs uniquely identify Amazon Web Services resources across all
+    /// of Amazon Web Services.</p>
+    /// <note>
+    /// <p>This parameter is only supported for S3 directory buckets. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-tagging.html">Using tags with
+    /// directory buckets</a>.</p>
+    /// </note>
+    pub bucket_arn: Option<S3RegionalOrS3ExpressBucketArnString>,
     /// <p>A forward slash followed by the name of the bucket.</p>
     pub location: Option<Location>,
 }
@@ -5776,6 +5804,9 @@ pub struct CreateBucketOutput {
 impl fmt::Debug for CreateBucketOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("CreateBucketOutput");
+        if let Some(ref val) = self.bucket_arn {
+            d.field("bucket_arn", val);
+        }
         if let Some(ref val) = self.location {
             d.field("location", val);
         }
@@ -5784,6 +5815,9 @@ impl fmt::Debug for CreateBucketOutput {
 }
 impl DtoExt for CreateBucketOutput {
     fn ignore_empty_strings(&mut self) {
+        if self.bucket_arn.as_deref() == Some("") {
+            self.bucket_arn = None;
+        }
         if self.location.as_deref() == Some("") {
             self.location = None;
         }
@@ -15521,6 +15555,13 @@ pub struct HeadBucketOutput {
     /// <p>For directory buckets, the value of this field is <code>false</code>.</p>
     /// </note>
     pub access_point_alias: Option<AccessPointAlias>,
+    /// <p>The Amazon Resource Name (ARN) of the S3 bucket. ARNs uniquely identify Amazon Web Services resources across all
+    /// of Amazon Web Services.</p>
+    /// <note>
+    /// <p>This parameter is only supported for S3 directory buckets. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-tagging.html">Using tags with
+    /// directory buckets</a>.</p>
+    /// </note>
+    pub bucket_arn: Option<S3RegionalOrS3ExpressBucketArnString>,
     /// <p>The name of the location where the bucket will be created.</p>
     /// <p>For directory buckets, the Zone ID of the Availability Zone or the Local Zone where the bucket is created. An example Zone ID value for an Availability Zone is <code>usw2-az1</code>.</p>
     /// <note>
@@ -15542,6 +15583,9 @@ impl fmt::Debug for HeadBucketOutput {
         if let Some(ref val) = self.access_point_alias {
             d.field("access_point_alias", val);
         }
+        if let Some(ref val) = self.bucket_arn {
+            d.field("bucket_arn", val);
+        }
         if let Some(ref val) = self.bucket_location_name {
             d.field("bucket_location_name", val);
         }
@@ -15556,6 +15600,9 @@ impl fmt::Debug for HeadBucketOutput {
 }
 impl DtoExt for HeadBucketOutput {
     fn ignore_empty_strings(&mut self) {
+        if self.bucket_arn.as_deref() == Some("") {
+            self.bucket_arn = None;
+        }
         if self.bucket_location_name.as_deref() == Some("") {
             self.bucket_location_name = None;
         }
@@ -16066,6 +16113,13 @@ pub struct HeadObjectOutput {
     /// Only the S3 Express One Zone storage class is supported by directory buckets to store objects.</p>
     /// </note>
     pub storage_class: Option<StorageClass>,
+    /// <p>The number of tags, if any, on the object, when you have the relevant permission to read object
+    /// tags.</p>
+    /// <p>You can use <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html">GetObjectTagging</a> to retrieve the tag set associated with an object.</p>
+    /// <note>
+    /// <p>This functionality is not supported for directory buckets.</p>
+    /// </note>
+    pub tag_count: Option<TagCount>,
     /// <p>Version ID of the object.</p>
     /// <note>
     /// <p>This functionality is not supported for directory buckets.</p>
@@ -16202,6 +16256,9 @@ impl fmt::Debug for HeadObjectOutput {
         }
         if let Some(ref val) = self.storage_class {
             d.field("storage_class", val);
+        }
+        if let Some(ref val) = self.tag_count {
+            d.field("tag_count", val);
         }
         if let Some(ref val) = self.version_id {
             d.field("version_id", val);
@@ -30487,6 +30544,8 @@ impl DtoExt for S3Location {
         }
     }
 }
+
+pub type S3RegionalOrS3ExpressBucketArnString = String;
 
 pub type S3TablesArn = String;
 

--- a/crates/s3s/src/header/generated.rs
+++ b/crates/s3s/src/header/generated.rs
@@ -57,6 +57,8 @@ pub const X_AMZ_ACL: HeaderName = HeaderName::from_static("x-amz-acl");
 
 pub const X_AMZ_ARCHIVE_STATUS: HeaderName = HeaderName::from_static("x-amz-archive-status");
 
+pub const X_AMZ_BUCKET_ARN: HeaderName = HeaderName::from_static("x-amz-bucket-arn");
+
 pub const X_AMZ_BUCKET_LOCATION_NAME: HeaderName = HeaderName::from_static("x-amz-bucket-location-name");
 
 pub const X_AMZ_BUCKET_LOCATION_TYPE: HeaderName = HeaderName::from_static("x-amz-bucket-location-type");

--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -1145,6 +1145,7 @@ impl CreateBucket {
 
     pub fn serialize_http(x: CreateBucketOutput) -> S3Result<http::Response> {
         let mut res = http::Response::with_status(http::StatusCode::OK);
+        http::add_opt_header(&mut res, X_AMZ_BUCKET_ARN, x.bucket_arn)?;
         http::add_opt_header(&mut res, LOCATION, x.location)?;
         Ok(res)
     }
@@ -5077,6 +5078,7 @@ impl HeadBucket {
     pub fn serialize_http(x: HeadBucketOutput) -> S3Result<http::Response> {
         let mut res = http::Response::with_status(http::StatusCode::OK);
         http::add_opt_header(&mut res, X_AMZ_ACCESS_POINT_ALIAS, x.access_point_alias)?;
+        http::add_opt_header(&mut res, X_AMZ_BUCKET_ARN, x.bucket_arn)?;
         http::add_opt_header(&mut res, X_AMZ_BUCKET_LOCATION_NAME, x.bucket_location_name)?;
         http::add_opt_header(&mut res, X_AMZ_BUCKET_LOCATION_TYPE, x.bucket_location_type)?;
         http::add_opt_header(&mut res, X_AMZ_BUCKET_REGION, x.bucket_region)?;
@@ -5243,6 +5245,7 @@ impl HeadObject {
         http::add_opt_header(&mut res, X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID, x.ssekms_key_id)?;
         http::add_opt_header(&mut res, X_AMZ_SERVER_SIDE_ENCRYPTION, x.server_side_encryption)?;
         http::add_opt_header(&mut res, X_AMZ_STORAGE_CLASS, x.storage_class)?;
+        http::add_opt_header(&mut res, X_AMZ_TAGGING_COUNT, x.tag_count)?;
         http::add_opt_header(&mut res, X_AMZ_VERSION_ID, x.version_id)?;
         http::add_opt_header(&mut res, X_AMZ_WEBSITE_REDIRECT_LOCATION, x.website_redirect_location)?;
         Ok(res)

--- a/crates/s3s/src/xml/generated.rs
+++ b/crates/s3s/src/xml/generated.rs
@@ -801,6 +801,8 @@ use std::io::Write;
 // DeserializeContent: S3KeyFilter
 //   SerializeContent: S3Location
 // DeserializeContent: S3Location
+//   SerializeContent: S3RegionalOrS3ExpressBucketArnString
+// DeserializeContent: S3RegionalOrS3ExpressBucketArnString
 //   SerializeContent: S3TablesArn
 // DeserializeContent: S3TablesArn
 //   SerializeContent: S3TablesBucketArn
@@ -1823,6 +1825,9 @@ impl SerializeContent for CreateBucketConfiguration {
         if let Some(ref val) = self.location_constraint {
             s.content("LocationConstraint", val)?;
         }
+        if let Some(iter) = &self.tags {
+            s.list("Tags", "Tag", iter)?;
+        }
         Ok(())
     }
 }
@@ -1832,6 +1837,7 @@ impl<'xml> DeserializeContent<'xml> for CreateBucketConfiguration {
         let mut bucket: Option<BucketInfo> = None;
         let mut location: Option<LocationInfo> = None;
         let mut location_constraint: Option<BucketLocationConstraint> = None;
+        let mut tags: Option<TagSet> = None;
         d.for_each_element(|d, x| match x {
             b"Bucket" => {
                 if bucket.is_some() {
@@ -1854,6 +1860,13 @@ impl<'xml> DeserializeContent<'xml> for CreateBucketConfiguration {
                 location_constraint = Some(d.content()?);
                 Ok(())
             }
+            b"Tags" => {
+                if tags.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                tags = Some(d.list_content("Tag")?);
+                Ok(())
+            }
             _ => {
                 d.skip_element_content()?;
                 Ok(())
@@ -1863,6 +1876,7 @@ impl<'xml> DeserializeContent<'xml> for CreateBucketConfiguration {
             bucket,
             location,
             location_constraint,
+            tags,
         })
     }
 }
@@ -5352,6 +5366,9 @@ impl<'xml> DeserializeContent<'xml> for BlockedEncryptionTypes {
 
 impl SerializeContent for Bucket {
     fn serialize_content<W: Write>(&self, s: &mut Serializer<W>) -> SerResult {
+        if let Some(ref val) = self.bucket_arn {
+            s.content("BucketArn", val)?;
+        }
         if let Some(ref val) = self.bucket_region {
             s.content("BucketRegion", val)?;
         }
@@ -5367,10 +5384,18 @@ impl SerializeContent for Bucket {
 
 impl<'xml> DeserializeContent<'xml> for Bucket {
     fn deserialize_content(d: &mut Deserializer<'xml>) -> DeResult<Self> {
+        let mut bucket_arn: Option<S3RegionalOrS3ExpressBucketArnString> = None;
         let mut bucket_region: Option<BucketRegion> = None;
         let mut creation_date: Option<CreationDate> = None;
         let mut name: Option<BucketName> = None;
         d.for_each_element(|d, x| match x {
+            b"BucketArn" => {
+                if bucket_arn.is_some() {
+                    return Err(DeError::DuplicateField);
+                }
+                bucket_arn = Some(d.content()?);
+                Ok(())
+            }
             b"BucketRegion" => {
                 if bucket_region.is_some() {
                     return Err(DeError::DuplicateField);
@@ -5395,6 +5420,7 @@ impl<'xml> DeserializeContent<'xml> for Bucket {
             _ => Err(DeError::UnexpectedTagName),
         })?;
         Ok(Self {
+            bucket_arn,
             bucket_region,
             creation_date,
             name,

--- a/data/s3.json
+++ b/data/s3.json
@@ -27541,6 +27541,12 @@
                     "traits": {
                         "smithy.api#documentation": "<p>\n            <code>BucketRegion</code> indicates the Amazon Web Services region where the bucket is located. If the\n         request contains at least one valid parameter, it is included in the response.</p>"
                     }
+                },
+                "BucketArn": {
+                    "target": "com.amazonaws.s3#S3RegionalOrS3ExpressBucketArnString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the S3 bucket. ARNs uniquely identify Amazon Web Services resources across all\n      of Amazon Web Services.</p>\n         <note>\n            <p>This parameter is only supported for S3 directory buckets. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-tagging.html\">Using tags with\n          directory buckets</a>.</p>\n         </note>"
+                    }
                 }
             },
             "traits": {
@@ -29685,6 +29691,12 @@
                     "traits": {
                         "smithy.api#documentation": "<p>Specifies the information about the bucket that will be created.</p>\n         <note>\n            <p>This functionality is only supported by directory buckets.</p>\n         </note>"
                     }
+                },
+                "Tags": {
+                    "target": "com.amazonaws.s3#TagSet",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of tags that you can apply to the bucket that you're creating. Tags are key-value pairs of metadata used to categorize and organize your buckets, track costs, and control access. </p>\n         <p>You must have the <code>s3:TagResource</code> permission to create a general\n      purpose bucket with tags or the <code>s3express:TagResource</code> permission to create a directory bucket with tags.</p>\n         <p>When creating buckets with tags, note that tag-based conditions using <code>aws:ResourceTag</code> and <code>s3:BucketTag</code> condition keys are applicable only after ABAC is enabled on the bucket. To learn more, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging-enable-abac.html\">Enabling ABAC in general purpose buckets</a>.</p>"
+                    }
                 }
             },
             "traits": {
@@ -29849,6 +29861,13 @@
                     "traits": {
                         "smithy.api#documentation": "<p>A forward slash followed by the name of the bucket.</p>",
                         "smithy.api#httpHeader": "Location"
+                    }
+                },
+                "BucketArn": {
+                    "target": "com.amazonaws.s3#S3RegionalOrS3ExpressBucketArnString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the S3 bucket. ARNs uniquely identify Amazon Web Services resources across all\n      of Amazon Web Services.</p>\n         <note>\n            <p>This parameter is only supported for S3 directory buckets. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-tagging.html\">Using tags with\n          directory buckets</a>.</p>\n         </note>",
+                        "smithy.api#httpHeader": "x-amz-bucket-arn"
                     }
                 }
             },
@@ -36256,6 +36275,13 @@
         "com.amazonaws.s3#HeadBucketOutput": {
             "type": "structure",
             "members": {
+                "BucketArn": {
+                    "target": "com.amazonaws.s3#S3RegionalOrS3ExpressBucketArnString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the S3 bucket. ARNs uniquely identify Amazon Web Services resources across all\n      of Amazon Web Services.</p>\n         <note>\n            <p>This parameter is only supported for S3 directory buckets. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-tagging.html\">Using tags with\n          directory buckets</a>.</p>\n         </note>",
+                        "smithy.api#httpHeader": "x-amz-bucket-arn"
+                    }
+                },
                 "BucketLocationType": {
                     "target": "com.amazonaws.s3#LocationType",
                     "traits": {
@@ -36473,6 +36499,41 @@
                         "smithy.api#httpHeader": "x-amz-checksum-sha256"
                     }
                 },
+                "ChecksumSHA512": {
+                    "target": "com.amazonaws.s3#ChecksumSHA512",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Base64 encoded, 512-bit <code>SHA512</code> digest of the object. For more information, see\n        <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking\n        object integrity in the Amazon S3 User Guide</a>.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-sha512"
+                    }
+                },
+                "ChecksumMD5": {
+                    "target": "com.amazonaws.s3#ChecksumMD5",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Base64 encoded, 128-bit <code>MD5</code> digest of the object. For more information, see\n        <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking\n        object integrity in the Amazon S3 User Guide</a>.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-md5"
+                    }
+                },
+                "ChecksumXXHASH64": {
+                    "target": "com.amazonaws.s3#ChecksumXXHASH64",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Base64 encoded, 64-bit <code>XXHASH64</code> checksum of the object. For more information, see\n        <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking\n        object integrity in the Amazon S3 User Guide</a>.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-xxhash64"
+                    }
+                },
+                "ChecksumXXHASH3": {
+                    "target": "com.amazonaws.s3#ChecksumXXHASH3",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Base64 encoded, 64-bit <code>XXHASH3</code> checksum of the object. For more information, see\n        <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking\n        object integrity in the Amazon S3 User Guide</a>.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-xxhash3"
+                    }
+                },
+                "ChecksumXXHASH128": {
+                    "target": "com.amazonaws.s3#ChecksumXXHASH128",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Base64 encoded, 128-bit <code>XXHASH128</code> checksum of the object. For more information, see\n        <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking\n        object integrity in the Amazon S3 User Guide</a>.</p>",
+                        "smithy.api#httpHeader": "x-amz-checksum-xxhash128"
+                    }
+                },
                 "ChecksumType": {
                     "target": "com.amazonaws.s3#ChecksumType",
                     "traits": {
@@ -36626,6 +36687,13 @@
                         "smithy.api#httpHeader": "x-amz-mp-parts-count"
                     }
                 },
+                "TagCount": {
+                    "target": "com.amazonaws.s3#TagCount",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of tags, if any, on the object, when you have the relevant permission to read object\n      tags.</p>\n         <p>You can use <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html\">GetObjectTagging</a> to retrieve the tag set associated with an object.</p>\n         <note>\n            <p>This functionality is not supported for directory buckets.</p>\n         </note>",
+                        "smithy.api#httpHeader": "x-amz-tagging-count"
+                    }
+                },
                 "ObjectLockMode": {
                     "target": "com.amazonaws.s3#ObjectLockMode",
                     "traits": {
@@ -36645,41 +36713,6 @@
                     "traits": {
                         "smithy.api#documentation": "<p>Specifies whether a legal hold is in effect for this object. This header is only\n         returned if the requester has the <code>s3:GetObjectLegalHold</code> permission. This\n         header is not returned if the specified version of this object has never had a legal hold\n         applied. For more information about S3 Object Lock, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html\">Object Lock</a>.</p>\n         <note>\n            <p>This functionality is not supported for directory buckets.</p>\n         </note>",
                         "smithy.api#httpHeader": "x-amz-object-lock-legal-hold"
-                    }
-                },
-                "ChecksumMD5": {
-                    "target": "com.amazonaws.s3#ChecksumMD5",
-                    "traits": {
-                        "smithy.api#documentation": "<p>The Base64 encoded, 128-bit <code>MD5</code> digest of the object. For more information, see\n        <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking\n        object integrity in the Amazon S3 User Guide</a>.</p>",
-                        "smithy.api#httpHeader": "x-amz-checksum-md5"
-                    }
-                },
-                "ChecksumSHA512": {
-                    "target": "com.amazonaws.s3#ChecksumSHA512",
-                    "traits": {
-                        "smithy.api#documentation": "<p>The Base64 encoded, 512-bit <code>SHA512</code> digest of the object. For more information, see\n        <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking\n        object integrity in the Amazon S3 User Guide</a>.</p>",
-                        "smithy.api#httpHeader": "x-amz-checksum-sha512"
-                    }
-                },
-                "ChecksumXXHASH128": {
-                    "target": "com.amazonaws.s3#ChecksumXXHASH128",
-                    "traits": {
-                        "smithy.api#documentation": "<p>The Base64 encoded, 128-bit <code>XXHASH128</code> checksum of the object. For more information, see\n        <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking\n        object integrity in the Amazon S3 User Guide</a>.</p>",
-                        "smithy.api#httpHeader": "x-amz-checksum-xxhash128"
-                    }
-                },
-                "ChecksumXXHASH3": {
-                    "target": "com.amazonaws.s3#ChecksumXXHASH3",
-                    "traits": {
-                        "smithy.api#documentation": "<p>The Base64 encoded, 64-bit <code>XXHASH3</code> checksum of the object. For more information, see\n        <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking\n        object integrity in the Amazon S3 User Guide</a>.</p>",
-                        "smithy.api#httpHeader": "x-amz-checksum-xxhash3"
-                    }
-                },
-                "ChecksumXXHASH64": {
-                    "target": "com.amazonaws.s3#ChecksumXXHASH64",
-                    "traits": {
-                        "smithy.api#documentation": "<p>The Base64 encoded, 64-bit <code>XXHASH64</code> checksum of the object. For more information, see\n        <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking\n        object integrity in the Amazon S3 User Guide</a>.</p>",
-                        "smithy.api#httpHeader": "x-amz-checksum-xxhash64"
                     }
                 }
             },
@@ -46044,6 +46077,16 @@
             },
             "traits": {
                 "smithy.api#documentation": "<p>Describes an Amazon S3 location that will receive the results of the restore request.</p>"
+            }
+        },
+        "com.amazonaws.s3#S3RegionalOrS3ExpressBucketArnString": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 128
+                },
+                "smithy.api#pattern": "^arn:[^:]+:(s3|s3express):"
             }
         },
         "com.amazonaws.s3#S3TablesArn": {


### PR DESCRIPTION
## Summary

Add bucket ARN, bucket tags and object tag count to the S3 model, continuing the
Smithy model refresh toward upstream `db89911` (see #676). This is the additive
half of the "core extensions" domain: new fields only, no breaking changes.

## Changes

### `data/s3.json`

- New shape `S3RegionalOrS3ExpressBucketArnString` (string, length 1..128,
  pattern `^arn:[^:]+:(s3|s3express):`)
- `Bucket.BucketArn` → `S3RegionalOrS3ExpressBucketArnString`
- `CreateBucketConfiguration.Tags` → `TagSet` (XML payload member)
- `CreateBucketOutput.BucketArn` → `S3RegionalOrS3ExpressBucketArnString`
  (response header `x-amz-bucket-arn`)
- `HeadBucketOutput.BucketArn` → `S3RegionalOrS3ExpressBucketArnString`
  (response header `x-amz-bucket-arn`)
- `HeadObjectOutput.TagCount` → `TagCount` (response header `x-amz-tagging-count`)
- `HeadObjectOutput` checksum members reordered to match upstream: `ChecksumMD5`,
  `ChecksumSHA512`, `ChecksumXXHASH128`, `ChecksumXXHASH3`, `ChecksumXXHASH64`
  move from the tail to after `ChecksumSHA256`
- All changed shapes are byte-identical to upstream `db89911`

### `s3s-fs`

- `Bucket { .. }` literal in `create_bucket` gains `bucket_arn: None` (compile
  fix for the new field)

### Generated code (`just codegen`)

- dto: `bucket_arn` fields on `Bucket`/`CreateBucketOutput`/`HeadBucketOutput`,
  `tags` on `CreateBucketConfiguration`, `tag_count` on `HeadObjectOutput`, and
  the `S3RegionalOrS3ExpressBucketArnString` type
- header: `X_AMZ_BUCKET_ARN` constant (`x-amz-tagging-count` already existed)
- ops: response header emission for `x-amz-bucket-arn` and `x-amz-tagging-count`
- xml: `Tags` list serde for `CreateBucketConfiguration`, `BucketArn` content for
  `Bucket`
- s3s-aws conv: field wiring to `aws_sdk_s3`

Note: `Expires` stays `Timestamp` — the `Expires` → `String` change is deferred
(breaking; it was a hand-edited generated file with no codegen support, so it
would break codegen idempotency).

## Verification

- model changes verified byte-identical to upstream `db89911`
- `just codegen` idempotent (second run produces no diff)
- `just dev` all green
- CI-style `cargo clippy --workspace --all-features --all-targets -- -D warnings`
  clean

Refs #676
