### PR TITLE
feat(data)!: change Expires to a raw string to match the S3 model

### DIFF
--- a/codegen/src/v1/aws_conv.rs
+++ b/codegen/src/v1/aws_conv.rs
@@ -60,6 +60,10 @@ pub fn codegen(ops: &Operations, rust_types: &RustTypes) {
         let s3s_path = f!("s3s::dto::{name}");
         let aws_path = aws_ty_path(name, ops, rust_types);
 
+        // `expires_string` (raw, unparsed) only exists on SDK output types;
+        // SDK input types expose `expires` as `DateTime` instead.
+        let is_expires_output = matches!(name.as_str(), "GetObjectOutput" | "HeadObjectOutput");
+
         g!("impl AwsConversion for {s3s_path} {{");
         g!("    type Target = {aws_path};");
         g!("type Error = S3Error;");
@@ -81,6 +85,7 @@ pub fn codegen(ops: &Operations, rust_types: &RustTypes) {
                     let aws_field_name = match s3s_field_name {
                         "checksum_crc32c" => "checksum_crc32_c",
                         "checksum_crc64nvme" => "checksum_crc64_nvme",
+                        "expires" if is_expires_output => "expires_string",
                         "type_" => "r#type",
                         s => s,
                     };
@@ -106,6 +111,12 @@ pub fn codegen(ops: &Operations, rust_types: &RustTypes) {
 
                     if field.type_ == "PartNumberMarker" || field.type_ == "NextPartNumberMarker" {
                         g!("{s3s_field_name}: x.{aws_field_name}.as_deref().map(integer_from_string).transpose()?,");
+                        continue;
+                    }
+
+                    if field.type_ == "Expires" && !is_expires_output {
+                        // SDK input types carry `expires` as `DateTime`; s3s keeps the raw string.
+                        g!("{s3s_field_name}: expires_from_aws(x.{aws_field_name})?,");
                         continue;
                     }
 
@@ -200,12 +211,19 @@ pub fn codegen(ops: &Operations, rust_types: &RustTypes) {
                     let aws_field_name = match s3s_field_name {
                         "checksum_crc32c" => "checksum_crc32_c",
                         "checksum_crc64nvme" => "checksum_crc64_nvme",
+                        "expires" if is_expires_output => "expires_string",
                         "type_" => "type",
                         s => s,
                     };
 
                     if field.type_ == "PartNumberMarker" || field.type_ == "NextPartNumberMarker" {
                         g!("y = y.set_{aws_field_name}(x.{s3s_field_name}.map(string_from_integer));");
+                        continue;
+                    }
+
+                    if field.type_ == "Expires" && !is_expires_output {
+                        // SDK input types carry `expires` as `DateTime`; s3s keeps the raw string.
+                        g!("y = y.set_{aws_field_name}(expires_into_aws(x.{s3s_field_name})?);");
                         continue;
                     }
 

--- a/codegen/src/v1/aws_proxy.rs
+++ b/codegen/src/v1/aws_proxy.rs
@@ -19,7 +19,7 @@ pub fn codegen(ops: &Operations, rust_types: &RustTypes) {
         "use super::*;",
         "",
         "use crate::conv::{try_from_aws, try_into_aws};",
-        "use crate::conv::string_from_integer;",
+        "use crate::conv::{expires_into_aws, string_from_integer};",
         "",
         "use s3s::S3;",
         "use s3s::{S3Request, S3Response};",
@@ -104,6 +104,12 @@ pub fn codegen(ops: &Operations, rust_types: &RustTypes) {
 
                 if field.type_ == "PartNumberMarker" || field.type_ == "NextPartNumberMarker" {
                     g!("b = b.set_{aws_field_name}(input.{s3s_field_name}.map(string_from_integer));");
+                    continue;
+                }
+
+                if field.type_ == "Expires" {
+                    // s3s keeps the raw string; the SDK input takes `DateTime`.
+                    g!("b = b.set_{aws_field_name}(expires_into_aws(input.{s3s_field_name})?);");
                     continue;
                 }
 

--- a/crates/s3s-aws/src/conv/generated.rs
+++ b/crates/s3s-aws/src/conv/generated.rs
@@ -1223,7 +1223,7 @@ impl AwsConversion for s3s::dto::CopyObjectInput {
             copy_source_sse_customer_key_md5: try_from_aws(x.copy_source_sse_customer_key_md5)?,
             expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
             expected_source_bucket_owner: try_from_aws(x.expected_source_bucket_owner)?,
-            expires: try_from_aws(x.expires)?,
+            expires: expires_from_aws(x.expires)?,
             grant_full_control: try_from_aws(x.grant_full_control)?,
             grant_read: try_from_aws(x.grant_read)?,
             grant_read_acp: try_from_aws(x.grant_read_acp)?,
@@ -1273,7 +1273,7 @@ impl AwsConversion for s3s::dto::CopyObjectInput {
             copy_source_sse_customer_key_md5: try_from_aws(x.copy_source_sse_customer_key_md5)?,
             expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
             expected_source_bucket_owner: try_from_aws(x.expected_source_bucket_owner)?,
-            expires: try_from_aws(x.expires)?,
+            expires: expires_from_aws(x.expires)?,
             grant_full_control: try_from_aws(x.grant_full_control)?,
             grant_read: try_from_aws(x.grant_read)?,
             grant_read_acp: try_from_aws(x.grant_read_acp)?,
@@ -1323,7 +1323,7 @@ impl AwsConversion for s3s::dto::CopyObjectInput {
         y = y.set_copy_source_sse_customer_key_md5(try_into_aws(x.copy_source_sse_customer_key_md5)?);
         y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
         y = y.set_expected_source_bucket_owner(try_into_aws(x.expected_source_bucket_owner)?);
-        y = y.set_expires(try_into_aws(x.expires)?);
+        y = y.set_expires(expires_into_aws(x.expires)?);
         y = y.set_grant_full_control(try_into_aws(x.grant_full_control)?);
         y = y.set_grant_read(try_into_aws(x.grant_read)?);
         y = y.set_grant_read_acp(try_into_aws(x.grant_read_acp)?);
@@ -1647,7 +1647,7 @@ impl AwsConversion for s3s::dto::CreateMultipartUploadInput {
             content_language: try_from_aws(x.content_language)?,
             content_type: try_from_aws(x.content_type)?,
             expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
-            expires: try_from_aws(x.expires)?,
+            expires: expires_from_aws(x.expires)?,
             grant_full_control: try_from_aws(x.grant_full_control)?,
             grant_read: try_from_aws(x.grant_read)?,
             grant_read_acp: try_from_aws(x.grant_read_acp)?,
@@ -1684,7 +1684,7 @@ impl AwsConversion for s3s::dto::CreateMultipartUploadInput {
             content_language: try_from_aws(x.content_language)?,
             content_type: try_from_aws(x.content_type)?,
             expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
-            expires: try_from_aws(x.expires)?,
+            expires: expires_from_aws(x.expires)?,
             grant_full_control: try_from_aws(x.grant_full_control)?,
             grant_read: try_from_aws(x.grant_read)?,
             grant_read_acp: try_from_aws(x.grant_read_acp)?,
@@ -1721,7 +1721,7 @@ impl AwsConversion for s3s::dto::CreateMultipartUploadInput {
         y = y.set_content_language(try_into_aws(x.content_language)?);
         y = y.set_content_type(try_into_aws(x.content_type)?);
         y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
-        y = y.set_expires(try_into_aws(x.expires)?);
+        y = y.set_expires(expires_into_aws(x.expires)?);
         y = y.set_grant_full_control(try_into_aws(x.grant_full_control)?);
         y = y.set_grant_read(try_into_aws(x.grant_read)?);
         y = y.set_grant_read_acp(try_into_aws(x.grant_read_acp)?);
@@ -4411,7 +4411,7 @@ impl AwsConversion for s3s::dto::GetObjectOutput {
             delete_marker: try_from_aws(x.delete_marker)?,
             e_tag: try_from_aws(x.e_tag)?,
             expiration: try_from_aws(x.expiration)?,
-            expires: try_from_aws(x.expires)?,
+            expires: try_from_aws(x.expires_string)?,
             last_modified: try_from_aws(x.last_modified)?,
             metadata: try_from_aws(x.metadata)?,
             missing_meta: try_from_aws(x.missing_meta)?,
@@ -4460,7 +4460,7 @@ impl AwsConversion for s3s::dto::GetObjectOutput {
         y = y.set_delete_marker(try_into_aws(x.delete_marker)?);
         y = y.set_e_tag(try_into_aws(x.e_tag)?);
         y = y.set_expiration(try_into_aws(x.expiration)?);
-        y = y.set_expires(try_into_aws(x.expires)?);
+        y = y.set_expires_string(try_into_aws(x.expires)?);
         y = y.set_last_modified(try_into_aws(x.last_modified)?);
         y = y.set_metadata(try_into_aws(x.metadata)?);
         y = y.set_missing_meta(try_into_aws(x.missing_meta)?);
@@ -4840,7 +4840,7 @@ impl AwsConversion for s3s::dto::HeadObjectOutput {
             delete_marker: try_from_aws(x.delete_marker)?,
             e_tag: try_from_aws(x.e_tag)?,
             expiration: try_from_aws(x.expiration)?,
-            expires: try_from_aws(x.expires)?,
+            expires: try_from_aws(x.expires_string)?,
             last_modified: try_from_aws(x.last_modified)?,
             metadata: try_from_aws(x.metadata)?,
             missing_meta: try_from_aws(x.missing_meta)?,
@@ -4889,7 +4889,7 @@ impl AwsConversion for s3s::dto::HeadObjectOutput {
         y = y.set_delete_marker(try_into_aws(x.delete_marker)?);
         y = y.set_e_tag(try_into_aws(x.e_tag)?);
         y = y.set_expiration(try_into_aws(x.expiration)?);
-        y = y.set_expires(try_into_aws(x.expires)?);
+        y = y.set_expires_string(try_into_aws(x.expires)?);
         y = y.set_last_modified(try_into_aws(x.last_modified)?);
         y = y.set_metadata(try_into_aws(x.metadata)?);
         y = y.set_missing_meta(try_into_aws(x.missing_meta)?);
@@ -8735,7 +8735,7 @@ impl AwsConversion for s3s::dto::PutObjectInput {
             content_md5: try_from_aws(x.content_md5)?,
             content_type: try_from_aws(x.content_type)?,
             expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
-            expires: try_from_aws(x.expires)?,
+            expires: expires_from_aws(x.expires)?,
             grant_full_control: try_from_aws(x.grant_full_control)?,
             grant_read: try_from_aws(x.grant_read)?,
             grant_read_acp: try_from_aws(x.grant_read_acp)?,
@@ -8787,7 +8787,7 @@ impl AwsConversion for s3s::dto::PutObjectInput {
             content_md5: try_from_aws(x.content_md5)?,
             content_type: try_from_aws(x.content_type)?,
             expected_bucket_owner: try_from_aws(x.expected_bucket_owner)?,
-            expires: try_from_aws(x.expires)?,
+            expires: expires_from_aws(x.expires)?,
             grant_full_control: try_from_aws(x.grant_full_control)?,
             grant_read: try_from_aws(x.grant_read)?,
             grant_read_acp: try_from_aws(x.grant_read_acp)?,
@@ -8839,7 +8839,7 @@ impl AwsConversion for s3s::dto::PutObjectInput {
         y = y.set_content_md5(try_into_aws(x.content_md5)?);
         y = y.set_content_type(try_into_aws(x.content_type)?);
         y = y.set_expected_bucket_owner(try_into_aws(x.expected_bucket_owner)?);
-        y = y.set_expires(try_into_aws(x.expires)?);
+        y = y.set_expires(expires_into_aws(x.expires)?);
         y = y.set_grant_full_control(try_into_aws(x.grant_full_control)?);
         y = y.set_grant_read(try_into_aws(x.grant_read)?);
         y = y.set_grant_read_acp(try_into_aws(x.grant_read_acp)?);
@@ -11041,7 +11041,7 @@ impl AwsConversion for s3s::dto::WriteGetObjectResponseInput {
             error_code: try_from_aws(x.error_code)?,
             error_message: try_from_aws(x.error_message)?,
             expiration: try_from_aws(x.expiration)?,
-            expires: try_from_aws(x.expires)?,
+            expires: expires_from_aws(x.expires)?,
             last_modified: try_from_aws(x.last_modified)?,
             metadata: try_from_aws(x.metadata)?,
             missing_meta: try_from_aws(x.missing_meta)?,
@@ -11092,7 +11092,7 @@ impl AwsConversion for s3s::dto::WriteGetObjectResponseInput {
         y = y.set_error_code(try_into_aws(x.error_code)?);
         y = y.set_error_message(try_into_aws(x.error_message)?);
         y = y.set_expiration(try_into_aws(x.expiration)?);
-        y = y.set_expires(try_into_aws(x.expires)?);
+        y = y.set_expires(expires_into_aws(x.expires)?);
         y = y.set_last_modified(try_into_aws(x.last_modified)?);
         y = y.set_metadata(try_into_aws(x.metadata)?);
         y = y.set_missing_meta(try_into_aws(x.missing_meta)?);

--- a/crates/s3s-aws/src/conv/mod.rs
+++ b/crates/s3s-aws/src/conv/mod.rs
@@ -43,3 +43,26 @@ pub fn string_from_integer(x: i32) -> String {
 pub fn integer_from_string(x: &str) -> S3Result<i32> {
     x.parse::<i32>().map_err(S3Error::internal_error)
 }
+
+/// Converts the SDK's `DateTime` (HTTP-date) back to the raw string kept by s3s.
+pub fn expires_from_aws(x: Option<aws_sdk_s3::primitives::DateTime>) -> S3Result<Option<String>> {
+    use aws_smithy_types::date_time::Format;
+    match x {
+        Some(v) => Ok(Some(v.fmt(Format::HttpDate).map_err(S3Error::internal_error)?)),
+        None => Ok(None),
+    }
+}
+
+/// Parses the raw s3s string into the SDK's `DateTime` (HTTP-date or RFC 3339).
+pub fn expires_into_aws(x: Option<String>) -> S3Result<Option<aws_sdk_s3::primitives::DateTime>> {
+    use aws_smithy_types::date_time::Format;
+    match x {
+        Some(s) => {
+            let v = aws_sdk_s3::primitives::DateTime::from_str(&s, Format::HttpDate)
+                .or_else(|_| aws_sdk_s3::primitives::DateTime::from_str(&s, Format::DateTime))
+                .map_err(S3Error::internal_error)?;
+            Ok(Some(v))
+        }
+        None => Ok(None),
+    }
+}

--- a/crates/s3s-aws/src/proxy/generated.rs
+++ b/crates/s3s-aws/src/proxy/generated.rs
@@ -5,7 +5,7 @@
 
 use super::*;
 
-use crate::conv::string_from_integer;
+use crate::conv::{expires_into_aws, string_from_integer};
 use crate::conv::{try_from_aws, try_into_aws};
 
 use s3s::S3;
@@ -110,7 +110,7 @@ impl S3 for Proxy {
         b = b.set_copy_source_sse_customer_key_md5(try_into_aws(input.copy_source_sse_customer_key_md5)?);
         b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
         b = b.set_expected_source_bucket_owner(try_into_aws(input.expected_source_bucket_owner)?);
-        b = b.set_expires(try_into_aws(input.expires)?);
+        b = b.set_expires(expires_into_aws(input.expires)?);
         b = b.set_grant_full_control(try_into_aws(input.grant_full_control)?);
         b = b.set_grant_read(try_into_aws(input.grant_read)?);
         b = b.set_grant_read_acp(try_into_aws(input.grant_read_acp)?);
@@ -246,7 +246,7 @@ impl S3 for Proxy {
         b = b.set_content_language(try_into_aws(input.content_language)?);
         b = b.set_content_type(try_into_aws(input.content_type)?);
         b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
-        b = b.set_expires(try_into_aws(input.expires)?);
+        b = b.set_expires(expires_into_aws(input.expires)?);
         b = b.set_grant_full_control(try_into_aws(input.grant_full_control)?);
         b = b.set_grant_read(try_into_aws(input.grant_read)?);
         b = b.set_grant_read_acp(try_into_aws(input.grant_read_acp)?);
@@ -2427,7 +2427,7 @@ impl S3 for Proxy {
         b = b.set_content_md5(try_into_aws(input.content_md5)?);
         b = b.set_content_type(try_into_aws(input.content_type)?);
         b = b.set_expected_bucket_owner(try_into_aws(input.expected_bucket_owner)?);
-        b = b.set_expires(try_into_aws(input.expires)?);
+        b = b.set_expires(expires_into_aws(input.expires)?);
         b = b.set_grant_full_control(try_into_aws(input.grant_full_control)?);
         b = b.set_grant_read(try_into_aws(input.grant_read)?);
         b = b.set_grant_read_acp(try_into_aws(input.grant_read_acp)?);
@@ -2979,7 +2979,7 @@ impl S3 for Proxy {
         b = b.set_error_code(try_into_aws(input.error_code)?);
         b = b.set_error_message(try_into_aws(input.error_message)?);
         b = b.set_expiration(try_into_aws(input.expiration)?);
-        b = b.set_expires(try_into_aws(input.expires)?);
+        b = b.set_expires(expires_into_aws(input.expires)?);
         b = b.set_last_modified(try_into_aws(input.last_modified)?);
         b = b.set_metadata(try_into_aws(input.metadata)?);
         b = b.set_missing_meta(try_into_aws(input.missing_meta)?);

--- a/crates/s3s-fs/src/fs.rs
+++ b/crates/s3s-fs/src/fs.rs
@@ -58,26 +58,6 @@ pub(crate) struct ObjectAttributes {
     pub checksum_type: Option<String>,
 }
 
-impl ObjectAttributes {
-    /// Convert expires Timestamp to String for storage
-    pub fn set_expires_timestamp(&mut self, expires: Option<dto::Timestamp>) {
-        self.expires = expires.and_then(|ts| {
-            let mut buf = Vec::new();
-            match ts.format(dto::TimestampFormat::DateTime, &mut buf) {
-                Ok(()) => Some(String::from_utf8_lossy(&buf).into_owned()),
-                Err(_) => None,
-            }
-        });
-    }
-
-    /// Parse expires String back to Timestamp
-    pub fn get_expires_timestamp(&self) -> Option<dto::Timestamp> {
-        self.expires
-            .as_ref()
-            .and_then(|s| dto::Timestamp::parse(dto::TimestampFormat::DateTime, s).ok())
-    }
-}
-
 fn clean_old_tmp_files(root: &Path) -> std::io::Result<()> {
     let entries = match std::fs::read_dir(root) {
         Ok(entries) => Ok(entries),

--- a/crates/s3s-fs/src/s3.rs
+++ b/crates/s3s-fs/src/s3.rs
@@ -309,7 +309,7 @@ impl S3 for FileSystem {
                 checksum_algorithm: None,
                 checksum_type: None,
             };
-            dst_attrs.set_expires_timestamp(input.expires);
+            dst_attrs.expires = input.expires;
             self.save_object_attributes(&input.bucket, &input.key, &dst_attrs, None)
                 .await?;
         } else {
@@ -502,7 +502,7 @@ impl S3 for FileSystem {
             content_disposition: obj_attrs.as_ref().and_then(|a| a.content_disposition.clone()),
             content_language: obj_attrs.as_ref().and_then(|a| a.content_language.clone()),
             cache_control: obj_attrs.as_ref().and_then(|a| a.cache_control.clone()),
-            expires: obj_attrs.as_ref().and_then(|a| a.get_expires_timestamp()),
+            expires: obj_attrs.as_ref().and_then(|a| a.expires.clone()),
             website_redirect_location: obj_attrs.as_ref().and_then(|a| a.website_redirect_location.clone()),
             e_tag: Some(ETag::Strong(md5_sum)),
             checksum_crc32: checksum.checksum_crc32,
@@ -573,7 +573,7 @@ impl S3 for FileSystem {
             content_disposition: obj_attrs.as_ref().and_then(|a| a.content_disposition.clone()),
             content_language: obj_attrs.as_ref().and_then(|a| a.content_language.clone()),
             cache_control: obj_attrs.as_ref().and_then(|a| a.cache_control.clone()),
-            expires: obj_attrs.as_ref().and_then(|a| a.get_expires_timestamp()),
+            expires: obj_attrs.as_ref().and_then(|a| a.expires.clone()),
             website_redirect_location: obj_attrs.as_ref().and_then(|a| a.website_redirect_location.clone()),
             last_modified: Some(last_modified),
             metadata: obj_attrs.as_ref().and_then(|a| a.user_metadata.clone()),
@@ -1009,7 +1009,7 @@ impl S3 for FileSystem {
             checksum_algorithm: None,
             checksum_type: None,
         };
-        obj_attrs.set_expires_timestamp(expires);
+        obj_attrs.expires = expires;
         self.save_object_attributes(&bucket, &key, &obj_attrs, None).await?;
 
         let mut info: InternalInfo = default();
@@ -1065,7 +1065,7 @@ impl S3 for FileSystem {
             checksum_algorithm,
             checksum_type,
         };
-        obj_attrs.set_expires_timestamp(input.expires);
+        obj_attrs.expires = input.expires;
         self.save_object_attributes(&input.bucket, &input.key, &obj_attrs, Some(upload_id))
             .await?;
 

--- a/crates/s3s/src/dto/generated.rs
+++ b/crates/s3s/src/dto/generated.rs
@@ -4805,6 +4805,9 @@ impl DtoExt for CopyObjectInput {
         if self.expected_source_bucket_owner.as_deref() == Some("") {
             self.expected_source_bucket_owner = None;
         }
+        if self.expires.as_deref() == Some("") {
+            self.expires = None;
+        }
         if self.grant_full_control.as_deref() == Some("") {
             self.grant_full_control = None;
         }
@@ -4918,6 +4921,9 @@ impl DtoExt for CopyObjectInput {
         }
         if self.expected_source_bucket_owner.as_deref() == Some("") {
             self.expected_source_bucket_owner = None;
+        }
+        if self.expires.as_deref() == Some("") {
+            self.expires = None;
         }
         if self.grant_full_control.as_deref() == Some("") {
             self.grant_full_control = None;
@@ -7020,6 +7026,9 @@ impl DtoExt for CreateMultipartUploadInput {
         if self.expected_bucket_owner.as_deref() == Some("") {
             self.expected_bucket_owner = None;
         }
+        if self.expires.as_deref() == Some("") {
+            self.expires = None;
+        }
         if self.grant_full_control.as_deref() == Some("") {
             self.grant_full_control = None;
         }
@@ -7111,6 +7120,9 @@ impl DtoExt for CreateMultipartUploadInput {
         }
         if self.expected_bucket_owner.as_deref() == Some("") {
             self.expected_bucket_owner = None;
+        }
+        if self.expires.as_deref() == Some("") {
+            self.expires = None;
         }
         if self.grant_full_control.as_deref() == Some("") {
             self.grant_full_control = None;
@@ -11815,7 +11827,7 @@ pub type ExpiredObjectAllVersions = bool;
 
 pub type ExpiredObjectDeleteMarker = bool;
 
-pub type Expires = Timestamp;
+pub type Expires = String;
 
 pub type ExposeHeader = String;
 
@@ -15000,6 +15012,9 @@ impl DtoExt for GetObjectOutput {
         if self.expiration.as_deref() == Some("") {
             self.expiration = None;
         }
+        if self.expires.as_deref() == Some("") {
+            self.expires = None;
+        }
         if let Some(ref val) = self.object_lock_legal_hold_status
             && val.as_str() == ""
         {
@@ -16331,6 +16346,9 @@ impl DtoExt for HeadObjectOutput {
         }
         if self.expiration.as_deref() == Some("") {
             self.expiration = None;
+        }
+        if self.expires.as_deref() == Some("") {
+            self.expires = None;
         }
         if let Some(ref val) = self.object_lock_legal_hold_status
             && val.as_str() == ""
@@ -24184,6 +24202,9 @@ impl DtoExt for PostObjectInput {
         if self.expected_bucket_owner.as_deref() == Some("") {
             self.expected_bucket_owner = None;
         }
+        if self.expires.as_deref() == Some("") {
+            self.expires = None;
+        }
         if self.grant_full_control.as_deref() == Some("") {
             self.grant_full_control = None;
         }
@@ -24303,6 +24324,9 @@ impl DtoExt for PostObjectInput {
         }
         if self.expected_bucket_owner.as_deref() == Some("") {
             self.expected_bucket_owner = None;
+        }
+        if self.expires.as_deref() == Some("") {
+            self.expires = None;
         }
         if self.grant_full_control.as_deref() == Some("") {
             self.grant_full_control = None;
@@ -27990,6 +28014,9 @@ impl DtoExt for PutObjectInput {
         if self.expected_bucket_owner.as_deref() == Some("") {
             self.expected_bucket_owner = None;
         }
+        if self.expires.as_deref() == Some("") {
+            self.expires = None;
+        }
         if self.grant_full_control.as_deref() == Some("") {
             self.grant_full_control = None;
         }
@@ -28109,6 +28136,9 @@ impl DtoExt for PutObjectInput {
         }
         if self.expected_bucket_owner.as_deref() == Some("") {
             self.expected_bucket_owner = None;
+        }
+        if self.expires.as_deref() == Some("") {
+            self.expires = None;
         }
         if self.grant_full_control.as_deref() == Some("") {
             self.grant_full_control = None;
@@ -33933,6 +33963,9 @@ impl DtoExt for WriteGetObjectResponseInput {
         }
         if self.expiration.as_deref() == Some("") {
             self.expiration = None;
+        }
+        if self.expires.as_deref() == Some("") {
+            self.expires = None;
         }
         if let Some(ref val) = self.object_lock_legal_hold_status
             && val.as_str() == ""

--- a/crates/s3s/src/ops/generated.rs
+++ b/crates/s3s/src/ops/generated.rs
@@ -793,7 +793,7 @@ impl CopyObject {
 
         let expected_source_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_SOURCE_EXPECTED_BUCKET_OWNER)?;
 
-        let expires: Option<Expires> = http::parse_opt_header_timestamp(req, &EXPIRES, TimestampFormat::HttpDate)?;
+        let expires: Option<Expires> = http::parse_opt_header(req, &EXPIRES)?;
 
         let grant_full_control: Option<GrantFullControl> = http::parse_opt_header(req, &X_AMZ_GRANT_FULL_CONTROL)?;
 
@@ -942,7 +942,7 @@ impl CopyObject {
 
         let expected_source_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_SOURCE_EXPECTED_BUCKET_OWNER)?;
 
-        let expires: Option<Expires> = http::parse_opt_header_timestamp(req, &EXPIRES, TimestampFormat::HttpDate)?;
+        let expires: Option<Expires> = http::parse_opt_header(req, &EXPIRES)?;
 
         let grant_full_control: Option<GrantFullControl> = http::parse_opt_header(req, &X_AMZ_GRANT_FULL_CONTROL)?;
 
@@ -1345,7 +1345,7 @@ impl CreateMultipartUpload {
 
         let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
 
-        let expires: Option<Expires> = http::parse_opt_header_timestamp(req, &EXPIRES, TimestampFormat::HttpDate)?;
+        let expires: Option<Expires> = http::parse_opt_header(req, &EXPIRES)?;
 
         let grant_full_control: Option<GrantFullControl> = http::parse_opt_header(req, &X_AMZ_GRANT_FULL_CONTROL)?;
 
@@ -1449,7 +1449,7 @@ impl CreateMultipartUpload {
 
         let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
 
-        let expires: Option<Expires> = http::parse_opt_header_timestamp(req, &EXPIRES, TimestampFormat::HttpDate)?;
+        let expires: Option<Expires> = http::parse_opt_header(req, &EXPIRES)?;
 
         let grant_full_control: Option<GrantFullControl> = http::parse_opt_header(req, &X_AMZ_GRANT_FULL_CONTROL)?;
 
@@ -4363,7 +4363,7 @@ impl GetObject {
         http::add_opt_header(&mut res, X_AMZ_DELETE_MARKER, x.delete_marker)?;
         http::add_opt_header(&mut res, ETAG, x.e_tag)?;
         http::add_opt_header(&mut res, X_AMZ_EXPIRATION, x.expiration)?;
-        http::add_opt_header_timestamp(&mut res, EXPIRES, x.expires, TimestampFormat::HttpDate)?;
+        http::add_opt_header(&mut res, EXPIRES, x.expires)?;
         http::add_opt_header_timestamp(&mut res, LAST_MODIFIED, x.last_modified, TimestampFormat::HttpDate)?;
         http::add_opt_metadata(&mut res, x.metadata)?;
         http::add_opt_header(&mut res, X_AMZ_MISSING_META, x.missing_meta)?;
@@ -5224,7 +5224,7 @@ impl HeadObject {
         http::add_opt_header(&mut res, X_AMZ_DELETE_MARKER, x.delete_marker)?;
         http::add_opt_header(&mut res, ETAG, x.e_tag)?;
         http::add_opt_header(&mut res, X_AMZ_EXPIRATION, x.expiration)?;
-        http::add_opt_header_timestamp(&mut res, EXPIRES, x.expires, TimestampFormat::HttpDate)?;
+        http::add_opt_header(&mut res, EXPIRES, x.expires)?;
         http::add_opt_header_timestamp(&mut res, LAST_MODIFIED, x.last_modified, TimestampFormat::HttpDate)?;
         http::add_opt_metadata(&mut res, x.metadata)?;
         http::add_opt_header(&mut res, X_AMZ_MISSING_META, x.missing_meta)?;
@@ -7550,7 +7550,7 @@ impl PutObject {
 
         let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
 
-        let expires: Option<Expires> = http::parse_opt_header_timestamp(req, &EXPIRES, TimestampFormat::HttpDate)?;
+        let expires: Option<Expires> = http::parse_opt_header(req, &EXPIRES)?;
 
         let grant_full_control: Option<GrantFullControl> = http::parse_opt_header(req, &X_AMZ_GRANT_FULL_CONTROL)?;
 
@@ -7703,7 +7703,7 @@ impl PutObject {
 
         let expected_bucket_owner: Option<AccountId> = http::parse_opt_header(req, &X_AMZ_EXPECTED_BUCKET_OWNER)?;
 
-        let expires: Option<Expires> = http::parse_opt_header_timestamp(req, &EXPIRES, TimestampFormat::HttpDate)?;
+        let expires: Option<Expires> = http::parse_opt_header(req, &EXPIRES)?;
 
         let grant_full_control: Option<GrantFullControl> = http::parse_opt_header(req, &X_AMZ_GRANT_FULL_CONTROL)?;
 
@@ -7868,7 +7868,7 @@ impl PutObject {
 
         let expected_bucket_owner: Option<AccountId> = http::parse_field_value(&m, "x-amz-expected-bucket-owner")?;
 
-        let expires: Option<Expires> = http::parse_field_value_timestamp(&m, "expires", TimestampFormat::HttpDate)?;
+        let expires: Option<Expires> = http::parse_field_value(&m, "expires")?;
 
         let grant_full_control: Option<GrantFullControl> = http::parse_field_value(&m, "x-amz-grant-full-control")?;
 
@@ -8041,7 +8041,7 @@ impl PutObject {
 
         let expected_bucket_owner: Option<AccountId> = http::parse_field_value(&m, "x-amz-expected-bucket-owner")?;
 
-        let expires: Option<Expires> = http::parse_field_value_timestamp(&m, "expires", TimestampFormat::HttpDate)?;
+        let expires: Option<Expires> = http::parse_field_value(&m, "expires")?;
 
         let grant_full_control: Option<GrantFullControl> = http::parse_field_value(&m, "x-amz-grant-full-control")?;
 
@@ -9668,8 +9668,7 @@ impl WriteGetObjectResponse {
 
         let expiration: Option<Expiration> = http::parse_opt_header(req, &X_AMZ_FWD_HEADER_X_AMZ_EXPIRATION)?;
 
-        let expires: Option<Expires> =
-            http::parse_opt_header_timestamp(req, &X_AMZ_FWD_HEADER_EXPIRES, TimestampFormat::HttpDate)?;
+        let expires: Option<Expires> = http::parse_opt_header(req, &X_AMZ_FWD_HEADER_EXPIRES)?;
 
         let last_modified: Option<LastModified> =
             http::parse_opt_header_timestamp(req, &X_AMZ_FWD_HEADER_LAST_MODIFIED, TimestampFormat::HttpDate)?;

--- a/data/s3.json
+++ b/data/s3.json
@@ -32612,7 +32612,7 @@
             "type": "boolean"
         },
         "com.amazonaws.s3#Expires": {
-            "type": "timestamp"
+            "type": "string"
         },
         "com.amazonaws.s3#ExposeHeader": {
             "type": "string"


### PR DESCRIPTION
## Summary

Change `Expires` from a `Timestamp` to a raw `String` in the S3 model, continuing the Smithy model refresh toward upstream `db89911` (see #676).

Upstream models `Expires` as a string (`Expires` is an HTTP-date header, RFC 7234 §5.3 / RFC 7231 §7.1.1.1). The old `Timestamp` representation only parses IMF-fixdate, so values like `Expires: 0` (which the RFCs require to be treated as "already expired") failed to parse. Keeping the raw string preserves whatever the wire carries.

This is a **breaking change**: the `s3s::dto::Expires` alias changes from `Timestamp` to `String`.

## Changes

### `data/s3.json`

- `com.amazonaws.s3#Expires` `timestamp` → `string` (byte-identical to upstream `db89911`)

### codegen

- `aws_conv.rs`: field-name mapping distinguishes SDK output vs input types. Output types (`GetObjectOutput`, `HeadObjectOutput`) map `expires` → `expires_string` (the SDK's raw, unparsed string — `expires` is deprecated there), a lossless passthrough. Input types keep `expires` on the SDK `DateTime` field, converted via `expires_from_aws` / `expires_into_aws`.
- `aws_proxy.rs`: `Expires` input fields use `expires_into_aws`.
- `conv/mod.rs`: new `expires_from_aws` (`DateTime` → HTTP-date string) and `expires_into_aws` (string → `DateTime`, HTTP-date or RFC 3339).

### Generated code (`just codegen`)

- dto: `pub type Expires = String`, six field types change to `Option<String>`, empty-string cleanup generated automatically.
- ops: HTTP deserialization/serialization uses raw header passthrough (`parse_opt_header` / `add_opt_header`) instead of the timestamp (`parse_opt_header_timestamp` with `HttpDate`).
- conv: output types wire to `expires_string`, input types use the converters.

### `s3s-fs`

- Remove `set_expires_timestamp` / `get_expires_timestamp` (the DTO is now a raw string, stored as-is); call sites assign `expires` directly.

## Breaking change / Migration

- `s3s::dto::Expires` is now a `String` alias (was `Timestamp`).
- Fields on `PutObjectRequest`, `CopyObjectRequest`, `CreateMultipartUploadRequest`, `WriteGetObjectResponseRequest`, `GetObjectOutput`, `HeadObjectOutput` change from `Option<dto::Timestamp>` to `Option<dto::Expires>` (`Option<String>`).
- Values are HTTP-date strings (e.g. `"Wed, 21 Oct 2015 07:28:00 GMT"`). To parse, use `dto::Timestamp::parse(dto::TimestampFormat::HttpDate, s)`.

## Verification

- `Expires` shape verified byte-identical to upstream `db89911`.
- `just codegen` idempotent (second run produces no diff).
- `just dev` all green.
- CI-style `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean.

Refs #676
