### PR TITLE
feat(s3s-proxy)!: forward the MinIO admin API to the backend via a custom route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3523,6 +3523,7 @@ dependencies = [
 name = "s3s-proxy"
 version = "0.15.0"
 dependencies = [
+ "async-trait",
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",

--- a/crates/s3s-proxy/Cargo.toml
+++ b/crates/s3s-proxy/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 minio = ["s3s-aws/minio", "dep:minio"]
 
 [dependencies]
+async-trait.workspace = true
 aws-config = { workspace = true, features = ["behavior-version-latest"] }
 aws-credential-types.workspace = true
 aws-sdk-s3.workspace = true

--- a/crates/s3s-proxy/src/admin_route.rs
+++ b/crates/s3s-proxy/src/admin_route.rs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-2026 The s3s Authors
+
+//! `MinIO` admin API passthrough via an [`S3Route`].
+//!
+//! [`MinioAdminRoute`] forwards `/minio/admin/*` requests (the `mc admin`
+//! API surface) to the backend. Unlike the health/metrics passthrough in
+//! [`ProxyService`](crate::proxy_service), the admin API is protected by
+//! `SigV4` signatures: `mc` signs admin requests with the standard AWS
+//! `SigV4` (service `s3`), so they pass the S3 signature verification and
+//! reach this route with valid credentials. Implementing the passthrough as
+//! an [`S3Route`] reuses the S3 authentication machinery: the default
+//! [`check_access`](S3Route::check_access) rejects anonymous requests, so
+//! unsigned admin calls are denied before they reach the backend.
+
+use s3s::route::S3Route;
+use s3s::{Body, S3Request, S3Response, S3Result};
+
+use hyper::http::Extensions;
+use hyper::http::uri::PathAndQuery;
+use hyper::{HeaderMap, Method, StatusCode, Uri};
+
+/// Headers that must not be forwarded to the backend.
+///
+/// Only `transfer-encoding` is dropped: `hyper` manages chunked framing
+/// itself. The `host` header is part of the `SigV4` signature that `mc`
+/// computed against the proxy's address, and the backend verifies the
+/// signature against it. The `content-length` header is preserved too:
+/// `MinIO` admin endpoints require it even for empty bodies (e.g.
+/// `set-user-status`), and the aggregated body below has the exact same
+/// length.
+const HOP_BY_HOP_HEADERS: &[&str] = &["transfer-encoding"];
+
+/// Defensive cap for admin request bodies forwarded to the backend.
+///
+/// Admin requests (user/policy definitions) are small JSON documents; this
+/// cap is far above any realistic payload. The S3 service already enforces
+/// `custom_route_max_body_size` (default 1 MiB) before this route runs, so the
+/// effective limit is the stricter of the two.
+const MAX_ADMIN_BODY_SIZE: usize = 16 * 1024 * 1024;
+
+/// Forwards `MinIO` admin API requests (`/minio/admin/*`) to the backend.
+#[derive(Debug, Clone)]
+pub struct MinioAdminRoute {
+    /// Backend base URL (e.g. `http://localhost:9000`).
+    endpoint_url: reqwest::Url,
+    /// HTTP client used to forward requests.
+    client: reqwest::Client,
+}
+
+impl MinioAdminRoute {
+    /// Creates a new admin passthrough route targeting `endpoint_url`.
+    #[must_use]
+    pub fn new(endpoint_url: reqwest::Url, client: reqwest::Client) -> Self {
+        Self { endpoint_url, client }
+    }
+
+    /// Whether the request path targets a `MinIO` admin API endpoint.
+    #[must_use]
+    fn is_admin_path(path: &str) -> bool {
+        path.starts_with("/minio/admin/")
+    }
+
+    /// Builds the backend URL for a request path, preserving the path and
+    /// query verbatim. Returns `None` when the composed URL fails to parse.
+    #[must_use]
+    fn backend_url(endpoint_url: &reqwest::Url, path_and_query: Option<&str>) -> Option<reqwest::Url> {
+        let path_and_query = path_and_query?;
+        let base = endpoint_url.as_str().trim_end_matches('/');
+        reqwest::Url::parse(&format!("{base}{path_and_query}")).ok()
+    }
+
+    /// Whether `name` is a hop-by-hop header that `reqwest` manages itself.
+    #[must_use]
+    fn is_hop_by_hop(name: &str) -> bool {
+        HOP_BY_HOP_HEADERS.iter().any(|header| header.eq_ignore_ascii_case(name))
+    }
+}
+
+#[async_trait::async_trait]
+impl S3Route for MinioAdminRoute {
+    fn is_match(&self, _method: &Method, uri: &Uri, _headers: &HeaderMap, _extensions: &mut Extensions) -> bool {
+        // Any method on a `/minio/admin/` path is claimed: `mc admin` uses
+        // PUT/POST/GET across the v3 API.
+        Self::is_admin_path(uri.path())
+    }
+
+    async fn call(&self, req: S3Request<Body>) -> S3Result<S3Response<Body>> {
+        let Some(target) = Self::backend_url(&self.endpoint_url, req.uri.path_and_query().map(PathAndQuery::as_str)) else {
+            return Err(bad_gateway("invalid admin request URI"));
+        };
+
+        let mut body = req.input;
+        let bytes = body
+            .store_all_limited(MAX_ADMIN_BODY_SIZE)
+            .await
+            .map_err(bad_gateway_with_source)?;
+
+        let mut request = self.client.request(req.method.clone(), target.clone());
+        for (name, value) in &req.headers {
+            if Self::is_hop_by_hop(name.as_str()) {
+                continue;
+            }
+            request = request.header(name, value);
+        }
+        let request = request
+            .body(bytes)
+            .build()
+            .map_err(|e| bad_gateway_with_source(Box::new(e)))?;
+
+        tracing::debug!(target = %target, request_headers = ?request.headers(), "forwarding MinIO admin request");
+
+        let response = self
+            .client
+            .execute(request)
+            .await
+            .map_err(|e| bad_gateway_with_source(Box::new(e)))?;
+
+        let status = response.status();
+        let headers = response.headers().clone();
+        let resp_body = response.bytes().await.map_err(|e| bad_gateway_with_source(Box::new(e)))?;
+
+        let mut out = S3Response::new(Body::from(resp_body));
+        out.status = Some(status);
+        out.headers = headers;
+        Ok(out)
+    }
+}
+
+/// Builds a `502 Bad Gateway` error for a failed admin passthrough.
+#[must_use]
+fn bad_gateway(message: &'static str) -> s3s::S3Error {
+    let mut err = s3s::S3Error::with_message(s3s::S3ErrorCode::InternalError, message);
+    err.set_status_code(StatusCode::BAD_GATEWAY);
+    err
+}
+
+/// Builds a `502 Bad Gateway` error carrying the underlying source.
+#[must_use]
+fn bad_gateway_with_source(source: s3s::StdError) -> s3s::S3Error {
+    let mut err = s3s::S3Error::with_source(s3s::S3ErrorCode::InternalError, source);
+    err.set_status_code(StatusCode::BAD_GATEWAY);
+    err
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn admin_paths_match() {
+        // Prefix matching: any sub-path under `/minio/admin/` is forwarded.
+        for path in [
+            "/minio/admin/v3/add-user",
+            "/minio/admin/v3/list-users",
+            "/minio/admin/v3/set-user-status",
+            "/minio/admin/v3/update-policy",
+            "/minio/admin/v3/info",
+        ] {
+            assert!(MinioAdminRoute::is_admin_path(path), "{path} should match");
+        }
+    }
+
+    #[test]
+    fn non_admin_paths_do_not_match() {
+        for path in [
+            "/minio/admin",
+            "/minio/health/live",
+            "/minio/v2/metrics/cluster",
+            "/bucket/key",
+            "/",
+        ] {
+            assert!(!MinioAdminRoute::is_admin_path(path), "{path} should not match");
+        }
+    }
+
+    #[test]
+    fn match_accepts_any_method() {
+        let uri = Uri::from_static("/minio/admin/v3/add-user");
+        let headers = HeaderMap::new();
+        let mut extensions = Extensions::new();
+        let route = MinioAdminRoute {
+            endpoint_url: reqwest::Url::parse("http://localhost:9000").expect("valid base url"),
+            client: reqwest::Client::new(),
+        };
+        for method in [Method::GET, Method::PUT, Method::POST, Method::DELETE] {
+            assert!(route.is_match(&method, &uri, &headers, &mut extensions), "{method} should match");
+        }
+    }
+
+    #[test]
+    fn backend_url_joins_path_and_query() {
+        let endpoint = reqwest::Url::parse("http://localhost:9000").expect("valid base url");
+        let url = MinioAdminRoute::backend_url(&endpoint, Some("/minio/admin/v3/add-user?accessKey=foo")).expect("composed url");
+        assert_eq!(url.as_str(), "http://localhost:9000/minio/admin/v3/add-user?accessKey=foo");
+    }
+
+    #[test]
+    fn backend_url_trims_trailing_slash() {
+        let endpoint = reqwest::Url::parse("http://localhost:9000/").expect("valid base url");
+        let url = MinioAdminRoute::backend_url(&endpoint, Some("/minio/admin/v3/info")).expect("composed url");
+        assert_eq!(url.as_str(), "http://localhost:9000/minio/admin/v3/info");
+    }
+
+    #[test]
+    fn backend_url_without_path_and_query_is_none() {
+        let endpoint = reqwest::Url::parse("http://localhost:9000").expect("valid base url");
+        assert!(MinioAdminRoute::backend_url(&endpoint, None).is_none());
+    }
+
+    #[test]
+    fn hop_by_hop_headers_are_detected() {
+        for name in ["transfer-encoding", "Transfer-Encoding"] {
+            assert!(MinioAdminRoute::is_hop_by_hop(name), "{name} should be hop-by-hop");
+        }
+        // `host` (part of the `SigV4` signature) and `content-length` (required
+        // by MinIO admin endpoints even for empty bodies) are preserved.
+        for name in ["authorization", "host", "content-length", "accept", "x-test"] {
+            assert!(!MinioAdminRoute::is_hop_by_hop(name), "{name} should be forwarded");
+        }
+    }
+}

--- a/crates/s3s-proxy/src/main.rs
+++ b/crates/s3s-proxy/src/main.rs
@@ -19,6 +19,7 @@ use tracing::info;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder as ConnBuilder;
 
+mod admin_route;
 mod proxy_service;
 
 #[derive(Debug, Parser)]
@@ -42,13 +43,13 @@ struct Opt {
     #[clap(long)]
     enable_sig_v2: bool,
 
-    /// Forward `MinIO` health and metrics endpoints (`/minio/health/*` and
-    /// `/minio/v2/metrics/*`) to the backend.
+    /// Forward `MinIO` admin, health, and metrics endpoints (`/minio/admin/*`,
+    /// `/minio/health/*`, and `/minio/v2/metrics/*`) to the backend.
     ///
     /// Disabled by default; only meaningful when the backend is a `MinIO`
     /// server.
     #[clap(long)]
-    enable_minio_health_route: bool,
+    enable_minio_route: bool,
 }
 
 fn setup_tracing() {
@@ -95,6 +96,20 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     #[cfg(not(feature = "minio"))]
     let proxy = s3s_aws::Proxy::builder(client).build();
 
+    // HTTP client shared by the MinIO passthrough layers. The admin route
+    // (inside the S3 service) and the health/metrics passthrough (in the
+    // proxy service) both forward to the backend through it.
+    let minio_client = if opt.enable_minio_route {
+        Some(
+            reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(5))
+                .connect_timeout(std::time::Duration::from_secs(5))
+                .build()?,
+        )
+    } else {
+        None
+    };
+
     // Setup S3 service
     let service = {
         let mut b = S3ServiceBuilder::new(proxy);
@@ -112,6 +127,15 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
             b.set_config(Arc::new(StaticConfigProvider::new(Arc::new(config))));
         }
 
+        // Forward MinIO admin API requests to the backend through a custom
+        // route. Admin requests are SigV4-protected and pass the S3 signature
+        // verification, so routing them through the S3 service reuses its
+        // authentication: unsigned admin requests are denied before they
+        // reach the backend.
+        if let Some(client) = &minio_client {
+            b.set_route(admin_route::MinioAdminRoute::new(reqwest::Url::parse(&opt.endpoint_url)?, client.clone()));
+        }
+
         // Enable parsing virtual-hosted-style requests
         if let Some(domain) = opt.domain {
             b.set_host(SingleDomain::new(&domain)?);
@@ -124,11 +148,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // endpoints to the backend at the HTTP layer, bypassing the S3 service so
     // its signature verification never rejects the Bearer token the prometheus
     // endpoints require.
-    let service = if opt.enable_minio_health_route {
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(5))
-            .connect_timeout(std::time::Duration::from_secs(5))
-            .build()?;
+    let service = if let Some(client) = minio_client {
         proxy_service::ProxyService::with_minio_health(service, reqwest::Url::parse(&opt.endpoint_url)?, client)
     } else {
         proxy_service::ProxyService::new(service)

--- a/crates/s3s/src/ops/mod.rs
+++ b/crates/s3s/src/ops/mod.rs
@@ -922,7 +922,18 @@ async fn prepare(req: &mut Request, ccx: &CallContext<'_>) -> S3Result<Prepare> 
             }
         }
     };
-    let request_has_payload = resolved_op.as_ref().is_none_or(|op| op.has_request_payload());
+    let request_has_payload = if custom_route_hit {
+        // Custom routes have no modeled operation to declare whether they
+        // consume a payload; the `x-amz-content-sha256` header is
+        // authoritative instead. The empty-string hash marks a bodyless
+        // request — `mc admin` sends bodyless PUTs (e.g. `set-user-status`)
+        // without `Content-Length`, and treating them as payload-bearing here
+        // would make signature verification demand a `Content-Length` (411).
+        http::get_unique_header_str(&req.headers, header::X_AMZ_CONTENT_SHA256.as_str())
+            != Some(s3s_sigv4::EMPTY_STRING_SHA256_HASH)
+    } else {
+        resolved_op.as_ref().is_none_or(|op| op.has_request_payload())
+    };
     let content_length_for_signature = signature_content_length(req, content_length, request_has_payload);
     content_length = verify_signature(req, ccx, vh_bucket, vh_region.as_deref(), content_length_for_signature).await?;
 

--- a/crates/s3s/src/ops/route_skip_validation_tests.rs
+++ b/crates/s3s/src/ops/route_skip_validation_tests.rs
@@ -353,3 +353,82 @@ async fn valid_path_on_route_miss_resolves_operation_normally() {
         Prepare::CustomRoute => panic!("missed route must not claim S3 traffic"),
     }
 }
+
+/// Builds a correctly signed `SigV4` header-auth request with an empty body,
+/// mirroring `mc admin` bodyless PUTs (e.g. `set-user-status`): the
+/// `x-amz-content-sha256` header carries the empty-string hash and no
+/// `Content-Length` is sent.
+fn signed_empty_body_request(method: Method, path: &str) -> Request {
+    let now = time::OffsetDateTime::now_utc();
+    let date_fmt = time::macros::format_description!("[year][month][day]T[hour][minute][second]Z");
+    let scope_fmt = time::macros::format_description!("[year][month][day]");
+    let date = now.format(&date_fmt).expect("format");
+    let scope_date = now.format(&scope_fmt).expect("format");
+    let region = "us-east-1";
+    let host = "localhost";
+
+    let amz_date = AmzDate::parse(date.as_str()).expect("valid date");
+
+    let signed_headers = [
+        ("host", host),
+        ("x-amz-content-sha256", s3s_sigv4::EMPTY_STRING_SHA256_HASH),
+        ("x-amz-date", date.as_str()),
+    ];
+
+    let canonical_request = s3s_sigv4::create_canonical_request(
+        method.as_str(),
+        path,
+        &[] as &[(&str, &str)],
+        signed_headers,
+        s3s_sigv4::Payload::SingleChunk(s3s_sigv4::EMPTY_STRING_SHA256_HASH),
+    );
+    let string_to_sign = s3s_sigv4::create_string_to_sign(&canonical_request, &amz_date, region, "s3");
+    let signature =
+        s3s_sigv4::calculate_signature(&string_to_sign, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", &amz_date, region, "s3");
+
+    let authorization = format!(
+        "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/{scope_date}/{region}/s3/aws4_request, \
+         SignedHeaders=host;x-amz-content-sha256;x-amz-date, \
+         Signature={}",
+        signature.as_str()
+    );
+
+    let mut builder = hyper::Request::builder()
+        .method(method)
+        .uri(format!("http://{host}{path}"))
+        .header(crate::header::HOST, host)
+        .header("x-amz-date", hyper::header::HeaderValue::from_str(date.as_str()).unwrap())
+        .header(
+            "x-amz-content-sha256",
+            hyper::header::HeaderValue::from_static(s3s_sigv4::EMPTY_STRING_SHA256_HASH),
+        );
+    builder = builder.header("authorization", authorization);
+    Request::from(builder.body(Body::empty()).unwrap())
+}
+
+#[tokio::test]
+async fn signed_bodyless_custom_route_request_needs_no_content_length() {
+    // `mc admin` bodyless PUTs (e.g. set-user-status) carry the empty-string
+    // payload hash and no `Content-Length`. A matched custom route must not
+    // demand a `Content-Length` for these: the empty hash declares the
+    // request has no payload, so signature verification passes and the
+    // request reaches the route.
+    let parts = ctx();
+    let route = MatchAllRoute::new();
+    let ccx = ccx(&parts, true, false, Some(&route));
+
+    let mut req = signed_empty_body_request(Method::PUT, "/minio/admin/v3/set-user-status");
+    let ans = prepare(&mut req, &ccx)
+        .await
+        .unwrap_or_else(|e| panic!("bodyless custom route request: unexpected {e:?}"));
+    assert!(matches!(ans, Prepare::CustomRoute));
+
+    // The empty body must survive signature verification intact: the route
+    // handler reads it back as zero bytes.
+    let mut req = signed_empty_body_request(Method::PUT, "/minio/admin/v3/set-user-status");
+    let resp = crate::ops::call(&mut req, &ccx)
+        .await
+        .expect("route handles bodyless request");
+    assert_eq!(resp.status, hyper::StatusCode::OK);
+    assert_eq!(route.call_count(), 1);
+}

--- a/scripts/e2e-s3tests.sh
+++ b/scripts/e2e-s3tests.sh
@@ -118,7 +118,8 @@ s3s-proxy \
     --host          localhost       \
     --port          8014            \
     --domain        localhost:8014  \
-    --endpoint-url  http://localhost:9000 > "$TARGET_DIR/s3s-proxy.log" 2>&1 &
+    --endpoint-url  http://localhost:9000 \
+    --enable-minio-route > "$TARGET_DIR/s3s-proxy.log" 2>&1 &
 S3S_PROXY_PID=$!
 
 wait_for_proxy

--- a/scripts/report-mint.py
+++ b/scripts/report-mint.py
@@ -53,10 +53,11 @@ EXPECTED_FAILURES: dict[str, dict[str, int]] = {
     "aws-sdk-ruby": {
         "presignedPost(bucket_name,file_name,expires_in_sec,max_byte_size)": 1,
     },
-    "healthcheck": {
-        "testLivenessEndpoint": 1,
-    },
     "mc": {
+        # s3s-proxy authenticates with a single static key and re-signs
+        # forwarded requests with it; the dynamically created user in
+        # test_admin_users cannot be signed in (`NotSignedUp`), so its S3
+        # operations never reach the backend.
         "test_admin_users": 1,
     },
     "minio-java": {

--- a/scripts/s3s-proxy.sh
+++ b/scripts/s3s-proxy.sh
@@ -25,4 +25,5 @@ s3s-proxy \
     --port          8014                    \
     --domain        localhost:8014          \
     --endpoint-url  http://localhost:9000   \
+    --enable-minio-route                    \
     --enable-sig-v2


### PR DESCRIPTION
### Summary

s3s-proxy treats every request as an S3 operation, so MinIO-only endpoints are either rejected by the S3 signature machinery (health/metrics with a Bearer token) or mis-routed to S3 operations (admin, e.g. `mc admin`). This PR extends the MinIO passthrough introduced in #797 to the admin API and fixes signature verification for bodyless custom-route requests.

`MinioAdminRoute` (an `S3Route`) forwards `/minio/admin/*` requests to the backend. Admin requests are SigV4-protected and pass the S3 signature verification, so the route reuses the S3 authentication machinery: unsigned admin requests are denied (`AccessDenied`) before they reach the backend. The `host` and `content-length` headers are preserved when forwarding — `host` is part of the SigV4 signature `mc` computed against the proxy address, and MinIO admin endpoints require `content-length` even for empty bodies.

In `s3s`, custom-route requests with an empty payload no longer require a `Content-Length`: `mc admin` sends bodyless PUTs (e.g. `set-user-status`) carrying the empty-string `x-amz-content-sha256` hash without a `Content-Length`, and such requests previously failed with a 411 `MissingContentLength` before the route handler ran. The payload-presence hint for custom routes now comes from that header.

### Changes

- `crates/s3s-proxy`: add `MinioAdminRoute` and register it when `--enable-minio-route` is set; forward `/minio/admin/*` requests to the backend with method, query, headers, and body preserved.
- `crates/s3s`: derive the payload-presence hint for custom-route requests from `x-amz-content-sha256` in `prepare`, so bodyless signed requests reach the route; add a regression test.
- `scripts`: start the e2e proxy with `--enable-minio-route` in the mint and s3-tests scripts.
- `scripts/report-mint.py`: drop the `healthcheck.testLivenessEndpoint` expected failure (fixed by #797); keep `mc.test_admin_users` and annotate the reason.

### Breaking change

The `--enable-minio-health-route` flag is renamed to `--enable-minio-route`, which additionally forwards the MinIO admin API (`/minio/admin/*`) to the backend. Existing users must update the flag name; the health/metrics forwarding behavior is unchanged.

### Tests

- `just ci-rust` is green: fmt check, clippy `-D warnings`, the full suite, codegen idempotency, and a clean tree.
- Manual verification against a MinIO backend: `mc admin info`, `mc admin user add/list/disable/enable/remove`, `mc admin policy attach/detach`, and object operations with a `readwrite` user all succeed; unsigned admin requests are denied with `AccessDenied`.
- e2e-mint: `healthcheck` 6/6 pass; `mc` 28 pass with `test_admin_users` still failing because s3s-proxy authenticates with a single static key (`SimpleAuth`) and re-signs forwarded requests with it, so the dynamically created user's S3 operations never reach the backend; the mint gate passes with the updated expectations.

Refs #797
