### PR TITLE
feat(s3s-multipart): initialize empty crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3510,6 +3510,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "s3s-multipart"
+version = "0.16.0-alpha.1"
+
+[[package]]
 name = "s3s-policy"
 version = "0.15.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ hex-simd = "0.8.0"
 itoa = "1.0.18"
 nom = "8.0.0"
 regex = "1.13.1"
+s3s-multipart = { path = "crates/s3s-multipart", version = "0.16.0-alpha.1" }
 s3s-rfc2047 = { path = "crates/s3s-rfc2047", version = "0.16.0-alpha.1" }
 
 # Date & time

--- a/crates/s3s-multipart/Cargo.toml
+++ b/crates/s3s-multipart/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "s3s-multipart"
+version = "0.16.0-alpha.1"
+description = "Async streaming parser for multipart/form-data"
+readme = "../../README.md"
+keywords = ["multipart", "form-data", "parser", "streaming"]
+categories = ["web-programming", "asynchronous"]
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/crates/s3s-multipart/src/lib.rs
+++ b/crates/s3s-multipart/src/lib.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-2026 The s3s Authors
+
+//! Asynchronous streaming parser for `multipart/form-data`.
+//!
+//! This crate is a placeholder; the parser implementation is under
+//! development.


### PR DESCRIPTION
### Summary

The `multipart/form-data` parsing currently implemented inside s3s will be extracted into a dedicated crate, `s3s-multipart`, in a follow-up series. This PR initializes that crate as an empty workspace member with complete package metadata, so the crate name can be reserved on crates.io before the parser implementation lands. It contains no functional code and does not change s3s behavior.

### Changes

- Add the `s3s-multipart` workspace member with package metadata (description, keywords, categories, readme, docs.rs configuration), versioned `0.16.0-alpha.1` alongside `s3s-sigv4` and `s3s-rfc2047`.
- Register `s3s-multipart` in the workspace dependency table, ready for the future integration.
- Add an empty `lib.rs` placeholder with crate documentation.

### Behavior notes

- No public API and no runtime behavior changes; the crate has no dependencies and `s3s` is untouched.

### Tests

- `cargo package -p s3s-multipart --list` packages the crate with the expected files (including the repository README) and the metadata required by crates.io.
- `just dev` passes.
- `just ci-rust` passes.

### Dependencies

- None.

Refs: #803 