### PR TITLE
bench(s3s): compare legacy multipart parser against multer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +49,12 @@ checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -973,6 +988,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,7 +1081,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1154,7 +1196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
  "digest 0.10.7",
- "spin",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -1173,6 +1215,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1396,6 +1492,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "env_filter"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,7 +1536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1709,6 +1814,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2080,6 +2196,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,6 +2363,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,6 +2464,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2412,6 +2555,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.5.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin 0.9.9",
+ "version_check",
 ]
 
 [[package]]
@@ -2660,6 +2820,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2797,6 +2967,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2932,7 +3130,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2983,6 +3181,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3244,7 +3462,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3302,7 +3520,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3351,6 +3569,7 @@ dependencies = [
  "chrono",
  "clap",
  "crc-fast",
+ "criterion",
  "futures",
  "hex-simd",
  "hmac 0.13.0",
@@ -3364,14 +3583,17 @@ dependencies = [
  "jiff",
  "md-5",
  "memchr",
+ "mimalloc",
  "mime",
  "minstant",
+ "multer",
  "nom",
  "numeric_cast",
  "openssl",
  "phf",
  "pin-project-lite",
  "quick-xml 0.42.0",
+ "rand",
  "regex",
  "s3s-rfc2047",
  "s3s-sigv2",
@@ -3876,6 +4098,12 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
+name = "spin"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
@@ -3987,7 +4215,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4066,6 +4294,16 @@ checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4594,13 +4832,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -4797,6 +5057,26 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,12 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter", "time"] }
 # CLI
 clap = { version = "4.6.2", features = ["derive"] }
 
+# Benchmarks
+criterion = "0.8"
+mimalloc = "0.1"
+multer = "3.1.0"
+rand = "0.10"
+
 # Storage backends
 opendal = { version = "0.58.0", default-features = false }
 

--- a/crates/s3s/Cargo.toml
+++ b/crates/s3s/Cargo.toml
@@ -80,10 +80,19 @@ zeroize.workspace = true
 [dev-dependencies]
 axum.workspace = true
 clap.workspace = true
+criterion.workspace = true
+futures = { workspace = true, features = ["executor", "std"] }
 hyper-util = { workspace = true, features = ["server-auto", "server-graceful", "http1", "http2", "tokio"] }
+mimalloc.workspace = true
 minstant.workspace = true
+multer.workspace = true
+rand.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-rustls.workspace = true
 tokio-util = { workspace = true, features = ["io"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+[[bench]]
+name = "multipart_legacy_vs_multer"
+harness = false

--- a/crates/s3s/benches/multipart_legacy_vs_multer.rs
+++ b/crates/s3s/benches/multipart_legacy_vs_multer.rs
@@ -1,0 +1,547 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-2026 The s3s Authors
+
+//! Throughput comparison between the legacy s3s multipart parser
+//! (`transform_multipart`) and `multer`, the most widely used Rust multipart
+//! crate (axum's official choice).
+//!
+//! The two implementations have different feature sets: the legacy parser is
+//! S3 POST Object shaped (aggregated form fields, a single streamed `file`
+//! part, exact content length derivation, strict closing trailer validation),
+//! while `multer` is a generic streaming parser without trailer validation.
+//! Comparisons therefore hold only for the overlapping surface: header
+//! parsing, form field consumption, and large file part streaming.
+//!
+//! Fairness protocol:
+//! - both sides consume the exact same body bytes, split into the exact same
+//!   `Bytes` chunk sequence (pre-computed outside the timed region);
+//! - `total_len` is always `Some` (canonical POST Object with Content-Length);
+//!   the chunked (`None`) degradation path is measured only in `reference`;
+//! - consumption reaches the same application endpoint: form fields are
+//!   aggregated, the file part is drained as a stream on both sides;
+//! - both run on the same single-threaded executor, registered alternately,
+//!   under the same allocator;
+//! - at startup each parser's consumed byte totals are checked against
+//!   construction expectations, and the two parsers' outputs (field
+//!   name/value pairs and file content) are checked for byte-for-byte
+//!   equality (differential guard); the unknown-total-length path is checked
+//!   to produce identical output too.
+//!
+//! Run with:
+//! ```bash
+//! RUSTFLAGS='--cfg fuzzing' cargo bench -p s3s --bench multipart_legacy_vs_multer
+//! ```
+//!
+//! The legacy parser is exposed only through the `cfg(fuzzing)` test-support
+//! surface (the same mechanism the external fuzz workspace uses to drive
+//! otherwise-private internals). Under a normal build the `harness` module
+//! and its `main` are cfg'd out, leaving an empty stub target.
+
+#![allow(clippy::cast_possible_truncation)]
+
+#[cfg(fuzzing)]
+mod harness {
+    // Uniform allocator for both parsers: mimalloc's arena behavior is far less
+    // sensitive to prior allocation churn than the system allocator, whose
+    // mmap/arena state otherwise contaminates later benchmarks with the memory
+    // history of earlier ones.
+    #[global_allocator]
+    static BENCH_ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+    use rand::rngs::StdRng;
+    use rand::{Rng, RngExt, SeedableRng};
+    use std::hint::black_box;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use bytes::Bytes;
+    use criterion::measurement::Measurement;
+    use criterion::{BenchmarkGroup, BenchmarkId, Criterion, Throughput, criterion_group};
+    use futures::StreamExt;
+    use futures::executor::block_on;
+    use futures::pin_mut;
+    use futures::stream::{self, Stream};
+    use multer::{Constraints, SizeLimit};
+    use s3s::{MultipartLimits, StdError, transform_multipart};
+
+    const BOUNDARY: &[u8] = b"----s3s-bench-boundary-7f3a";
+
+    const CHUNK_SIZES: &[usize] = &[1024, 4 * 1024, 16 * 1024, 64 * 1024];
+
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    /// A prepared request body with its consumption accounting expectations.
+    struct Load {
+        /// Canonical multipart/form-data body (fields first, `file` part last)
+        body: Vec<u8>,
+        /// Total expected data bytes (field values + file content)
+        expected_data_bytes: usize,
+    }
+
+    /// Deterministic ASCII value generation from a fixed-seed `StdRng`.
+    fn ascii(rng: &mut StdRng, len: usize) -> String {
+        const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        (0..len)
+            .map(|_| CHARSET[rng.random_range(0..CHARSET.len())] as char)
+            .collect()
+    }
+
+    fn build_load(fields: &[(String, String)], file_len: usize, file_rng: &mut StdRng) -> Load {
+        let mut body = Vec::new();
+        let mut data_bytes = 0usize;
+
+        for (name, value) in fields {
+            data_bytes += value.len();
+            body.extend_from_slice(b"--");
+            body.extend_from_slice(BOUNDARY);
+            body.extend_from_slice(b"\r\nContent-Disposition: form-data; name=\"");
+            body.extend_from_slice(name.as_bytes());
+            body.extend_from_slice(b"\"\r\n\r\n");
+            body.extend_from_slice(value.as_bytes());
+            body.extend_from_slice(b"\r\n");
+        }
+
+        body.extend_from_slice(b"--");
+        body.extend_from_slice(BOUNDARY);
+        body.extend_from_slice(b"\r\nContent-Disposition: form-data; name=\"file\"; filename=\"bench.bin\"\r\n");
+        body.extend_from_slice(b"Content-Type: application/octet-stream\r\n\r\n");
+
+        // Full-range pseudo-random content: matches the ~1/256 CR density of real
+        // binary uploads. (A repeating-value ramp would concentrate runs of b'\r'
+        // -- the byte the legacy parser's boundary scan probes on -- and skew the
+        // comparison.)
+        let file_start = body.len();
+        body.resize(file_start + file_len, 0);
+        file_rng.fill_bytes(&mut body[file_start..]);
+        data_bytes += file_len;
+
+        body.extend_from_slice(b"\r\n--");
+        body.extend_from_slice(BOUNDARY);
+        body.extend_from_slice(b"--\r\n");
+
+        Load {
+            body,
+            expected_data_bytes: data_bytes,
+        }
+    }
+
+    fn load_f() -> Load {
+        let mut rng = StdRng::seed_from_u64(0xfeed_beef);
+        let fields: Vec<(String, String)> = (0..16).map(|i| (format!("field_{i:02}"), ascii(&mut rng, 1024))).collect();
+        build_load(&fields, 64, &mut rng)
+    }
+
+    fn load_l(file_len: usize) -> Load {
+        let mut rng = StdRng::seed_from_u64(0x1111_2222);
+        build_load(&[("key".to_owned(), "bench-key".to_owned())], file_len, &mut rng)
+    }
+
+    fn load_m() -> Load {
+        let mut rng = StdRng::seed_from_u64(0x5eed_5eed);
+        let fields = vec![
+            ("key".to_owned(), "uploads/2026/09/bench.bin".to_owned()),
+            ("policy".to_owned(), ascii(&mut rng, 1024)),
+            ("x-amz-signature".to_owned(), ascii(&mut rng, 64)),
+            ("content-type".to_owned(), "application/octet-stream".to_owned()),
+        ];
+        build_load(&fields, 1024 * 1024, &mut rng)
+    }
+
+    /// Diagnostic load: large fields region + tiny file, exposes the legacy
+    /// parser's re-parse of the accumulated buffer while hunting for the file
+    /// part (the signal-gated fix is not merged to main yet).
+    fn load_diag(field_count: usize, field_len: usize) -> Load {
+        let mut rng = StdRng::seed_from_u64(0xd1a9_0001);
+        let fields: Vec<(String, String)> = (0..field_count)
+            .map(|i| (format!("field_{i:04}"), ascii(&mut rng, field_len)))
+            .collect();
+        build_load(&fields, 64, &mut rng)
+    }
+
+    /// Pre-split the body into shared `Bytes` chunks (outside the timed region).
+    fn chunk_cache(body: &[u8], chunk_size: usize) -> Arc<Vec<Bytes>> {
+        Arc::new(body.chunks(chunk_size.max(1)).map(Bytes::copy_from_slice).collect())
+    }
+
+    /// Owning iterator over the pre-split chunks; sharing `Bytes` clones keeps
+    /// per-iteration setup at refcount bumps instead of body copies.
+    struct ChunkStream {
+        chunks: Arc<Vec<Bytes>>,
+        index: usize,
+    }
+
+    impl Iterator for ChunkStream {
+        type Item = Result<Bytes, StdError>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            let item = self.chunks.get(self.index).cloned();
+            self.index += 1;
+            item.map(Ok)
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            let remaining = self.chunks.len().saturating_sub(self.index);
+            (remaining, Some(remaining))
+        }
+    }
+
+    /// Build the input stream over shared chunks; the `Arc` is owned by the
+    /// stream, satisfying the `'static` bound of both parsers.
+    fn body_stream(chunks: Arc<Vec<Bytes>>) -> impl Stream<Item = Result<Bytes, StdError>> + Send + Sync + 'static {
+        stream::iter(ChunkStream { chunks, index: 0 })
+    }
+
+    fn fold(hash: u64, bytes: &[u8]) -> u64 {
+        bytes.iter().fold(hash, |h, b| (h ^ u64::from(*b)).wrapping_mul(FNV_PRIME))
+    }
+
+    fn fold_len(hash: u64, len: usize) -> u64 {
+        fold(hash, &(len as u64).to_le_bytes())
+    }
+
+    /// Small data-dependent fingerprint: first/last bytes of a consumed value.
+    fn fold_ends(hash: u64, data: &[u8]) -> u64 {
+        let mut h = hash;
+        if let Some(&first) = data.first() {
+            h = fold(h, &[first]);
+        }
+        if let Some(&last) = data.last() {
+            h = fold(h, &[last]);
+        }
+        h
+    }
+
+    fn chunk_fingerprint(hash: u64, chunk: &Bytes) -> u64 {
+        fold_len(fold(hash, &chunk[..chunk.len().min(8)]), chunk.len())
+    }
+
+    /// Drive the legacy parser to the application endpoint: fields aggregated,
+    /// file part drained as a stream. Returns consumed data bytes.
+    fn drive_legacy(chunks: &Arc<Vec<Bytes>>, total_len: Option<u64>) -> u64 {
+        block_on(async {
+            let mut multipart =
+                transform_multipart(body_stream(Arc::clone(chunks)), BOUNDARY, MultipartLimits::default(), total_len)
+                    .await
+                    .expect("legacy: parse error");
+
+            let mut hash = FNV_OFFSET;
+            let mut total = 0usize;
+            for (name, value) in multipart.fields() {
+                total += value.len();
+                hash = fold_ends(fold(hash, name.as_bytes()), value.as_bytes());
+                hash = fold_len(hash, value.len());
+            }
+            black_box(multipart.fields());
+
+            let file = multipart.take_file_stream().expect("legacy: missing file stream");
+            pin_mut!(file);
+            while let Some(item) = file.next().await {
+                let chunk = item.expect("legacy: file stream error");
+                total += chunk.len();
+                hash = chunk_fingerprint(hash, &chunk);
+                black_box(&chunk);
+            }
+            black_box(hash);
+            black_box(total as u64)
+        })
+    }
+
+    /// Drive `multer` to the same application endpoint.
+    #[derive(Clone, Copy)]
+    enum MulterMode {
+        /// Aggregate every non-file field (`Field::bytes`, canonical consumer)
+        Aggregate,
+        /// Drain every field chunk by chunk without aggregation (raw parser cost)
+        RawDrain,
+    }
+
+    fn drive_multer(chunks: &Arc<Vec<Bytes>>, body_len: u64, mode: MulterMode) -> u64 {
+        block_on(async {
+            let boundary = std::str::from_utf8(BOUNDARY).expect("boundary is ASCII");
+            let constraints = Constraints::new().size_limit(SizeLimit::new().whole_stream(body_len).per_field(body_len));
+            let mut multipart = multer::Multipart::with_constraints(body_stream(Arc::clone(chunks)), boundary, constraints);
+
+            let mut hash = FNV_OFFSET;
+            let mut total = 0usize;
+            while let Some(mut field) = multipart.next_field().await.expect("multer: stream error") {
+                hash = fold(hash, field.name().unwrap_or_default().as_bytes());
+                if field.file_name().is_some() || matches!(mode, MulterMode::RawDrain) {
+                    while let Some(chunk) = field.chunk().await.expect("multer: field error") {
+                        total += chunk.len();
+                        hash = chunk_fingerprint(hash, &chunk);
+                        black_box(&chunk);
+                    }
+                } else {
+                    let data = field.bytes().await.expect("multer: field error");
+                    total += data.len();
+                    hash = fold_ends(hash, &data);
+                    hash = fold_len(hash, data.len());
+                    black_box(&data);
+                }
+            }
+            black_box(hash);
+            black_box(total as u64)
+        })
+    }
+
+    /// One (load, chunk) configuration with pre-computed chunk caches.
+    struct Case {
+        label: String,
+        load: Load,
+        caches: Vec<(usize, Arc<Vec<Bytes>>)>,
+    }
+
+    fn build_case(label: &str, load: Load) -> Case {
+        let caches = CHUNK_SIZES.iter().map(|&c| (c, chunk_cache(&load.body, c))).collect();
+        Case {
+            label: label.to_owned(),
+            load,
+            caches,
+        }
+    }
+
+    /// Parse a body with the legacy parser and return the aggregated fields
+    /// and the full file content (startup verification only, never timed).
+    fn collect_legacy(chunks: &Arc<Vec<Bytes>>, total_len: Option<u64>) -> (Vec<(String, String)>, Vec<u8>) {
+        block_on(async {
+            let mut multipart =
+                transform_multipart(body_stream(Arc::clone(chunks)), BOUNDARY, MultipartLimits::default(), total_len)
+                    .await
+                    .expect("legacy: parse error");
+
+            let file = multipart.take_file_stream().expect("legacy: missing file stream");
+            pin_mut!(file);
+            let mut content = Vec::new();
+            while let Some(item) = file.next().await {
+                content.extend_from_slice(&item.expect("legacy: file stream error"));
+            }
+            (multipart.fields().to_vec(), content)
+        })
+    }
+
+    /// Parse a body with `multer` and return the aggregated fields and the
+    /// full file content (startup verification only, never timed).
+    fn collect_multer(chunks: &Arc<Vec<Bytes>>, body_len: u64) -> (Vec<(String, String)>, Vec<u8>) {
+        block_on(async {
+            let boundary = std::str::from_utf8(BOUNDARY).expect("boundary is ASCII");
+            let constraints = Constraints::new().size_limit(SizeLimit::new().whole_stream(body_len).per_field(body_len));
+            let mut multipart = multer::Multipart::with_constraints(body_stream(Arc::clone(chunks)), boundary, constraints);
+
+            let mut fields = Vec::new();
+            let mut content = Vec::new();
+            while let Some(mut field) = multipart.next_field().await.expect("multer: stream error") {
+                let name = field.name().unwrap_or_default().to_owned();
+                if field.file_name().is_some() {
+                    while let Some(chunk) = field.chunk().await.expect("multer: field error") {
+                        content.extend_from_slice(&chunk);
+                    }
+                } else {
+                    let data = field.bytes().await.expect("multer: field error");
+                    fields.push((name, String::from_utf8(data.to_vec()).expect("field value is UTF-8")));
+                }
+            }
+            (fields, content)
+        })
+    }
+
+    /// The legacy parser lowercases field names and sorts them by name; both
+    /// sides are normalized the same way before comparison.
+    fn normalize_fields(mut fields: Vec<(String, String)>) -> Vec<(String, String)> {
+        for (name, _) in &mut fields {
+            *name = name.to_lowercase();
+        }
+        fields.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
+        fields
+    }
+
+    /// Startup differential guard: byte totals against construction
+    /// expectations, plus byte-for-byte equality of the two parsers' outputs
+    /// (field name/value pairs and file content).
+    fn verify(case: &Case) {
+        for (chunk, cache) in &case.caches {
+            let body_len = case.load.body.len() as u64;
+            let (legacy_fields, legacy_file) = collect_legacy(cache, Some(body_len));
+            let (multer_fields, multer_file) = collect_multer(cache, body_len);
+
+            let legacy_total: usize = legacy_fields.iter().map(|(_, v)| v.len()).sum::<usize>() + legacy_file.len();
+            let multer_total: usize = multer_fields.iter().map(|(_, v)| v.len()).sum::<usize>() + multer_file.len();
+            let expected = case.load.expected_data_bytes as usize;
+            assert_eq!(legacy_total, expected, "legacy byte accounting mismatch: {} chunk {chunk}", case.label);
+            assert_eq!(multer_total, expected, "multer byte accounting mismatch: {} chunk {chunk}", case.label);
+
+            assert_eq!(
+                normalize_fields(legacy_fields),
+                normalize_fields(multer_fields),
+                "field name/value mismatch between parsers: {} chunk {chunk}",
+                case.label
+            );
+            assert_eq!(
+                legacy_file, multer_file,
+                "file content mismatch between parsers: {} chunk {chunk}",
+                case.label
+            );
+        }
+    }
+
+    /// The unknown-total-length path (`total_len = None`) must yield the same
+    /// output as the exact-length path; it only skips strict validation.
+    fn verify_none_degradation(case: &Case, cache: &Arc<Vec<Bytes>>) {
+        let body_len = case.load.body.len() as u64;
+        let (some_fields, some_file) = collect_legacy(cache, Some(body_len));
+        let (none_fields, none_file) = collect_legacy(cache, None);
+        assert_eq!(
+            normalize_fields(some_fields),
+            normalize_fields(none_fields),
+            "fields changed under unknown total length: {}",
+            case.label
+        );
+        assert_eq!(some_file, none_file, "file content changed under unknown total length: {}", case.label);
+    }
+
+    #[derive(Clone, Copy)]
+    enum Settings {
+        Default,
+        Heavy,
+        Diagnostic,
+    }
+
+    impl Settings {
+        const fn warm_up(self) -> Duration {
+            match self {
+                Self::Default => Duration::from_millis(1_000),
+                Self::Heavy | Self::Diagnostic => Duration::from_millis(500),
+            }
+        }
+
+        const fn measurement(self) -> Duration {
+            match self {
+                Self::Default => Duration::from_secs(2),
+                Self::Heavy | Self::Diagnostic => Duration::from_secs(1),
+            }
+        }
+
+        const fn samples(self) -> usize {
+            match self {
+                Self::Default => 40,
+                Self::Heavy => 20,
+                Self::Diagnostic => 10,
+            }
+        }
+    }
+
+    fn apply_settings<M: Measurement>(group: &mut BenchmarkGroup<'_, M>, level: Settings) {
+        group.warm_up_time(level.warm_up());
+        group.measurement_time(level.measurement());
+        group.sample_size(level.samples());
+    }
+
+    fn register_pair<M: Measurement>(group: &mut BenchmarkGroup<'_, M>, case: &Case, chunk: usize) {
+        let cache = case
+            .caches
+            .iter()
+            .find(|(c, _)| *c == chunk)
+            .map(|(_, cache)| Arc::clone(cache))
+            .expect("chunk cache missing");
+        let name = format!("{}/{chunk}", case.label);
+        let body_len = case.load.body.len() as u64;
+
+        group.throughput(Throughput::Bytes(body_len));
+        group.bench_with_input(BenchmarkId::new("legacy", &name), &(), |b, &()| {
+            b.iter(|| drive_legacy(&cache, Some(body_len)))
+        });
+        group.bench_with_input(BenchmarkId::new("multer", &name), &(), |b, &()| {
+            b.iter(|| drive_multer(&cache, body_len, MulterMode::Aggregate))
+        });
+    }
+
+    fn bench_main_matrix(c: &mut Criterion) {
+        let cases = [
+            build_case("F", load_f()),
+            build_case("L-64KiB", load_l(64 * 1024)),
+            build_case("L-1MiB", load_l(1024 * 1024)),
+            build_case("M", load_m()),
+        ];
+        for case in &cases {
+            verify(case);
+        }
+
+        let mut group = c.benchmark_group("multipart/legacy_vs_multer");
+        apply_settings(&mut group, Settings::Default);
+        for case in &cases {
+            for &chunk in CHUNK_SIZES {
+                register_pair(&mut group, case, chunk);
+            }
+        }
+        group.finish();
+    }
+
+    fn bench_heavy_matrix(c: &mut Criterion) {
+        let case = build_case("L-16MiB", load_l(16 * 1024 * 1024));
+        verify(&case);
+
+        let mut group = c.benchmark_group("multipart/legacy_vs_multer_heavy");
+        apply_settings(&mut group, Settings::Heavy);
+        for &chunk in CHUNK_SIZES {
+            register_pair(&mut group, &case, chunk);
+        }
+        group.finish();
+    }
+
+    /// Reference group: legacy behavior with unknown total length (the parser
+    /// streams without strict validation; whole-file aggregation happens in
+    /// the ops layer, not here) and multer's raw drain mode.
+    fn bench_reference(c: &mut Criterion) {
+        let case = build_case("L-1MiB", load_l(1024 * 1024));
+        verify(&case);
+        let chunk = 16 * 1024;
+        let cache = case
+            .caches
+            .iter()
+            .find(|(c, _)| *c == chunk)
+            .map(|(_, cache)| Arc::clone(cache))
+            .expect("chunk cache missing");
+        verify_none_degradation(&case, &cache);
+        let body_len = case.load.body.len() as u64;
+
+        let mut group = c.benchmark_group("multipart/reference");
+        apply_settings(&mut group, Settings::Default);
+        group.throughput(Throughput::Bytes(body_len));
+
+        group.bench_function("legacy/some_total_len", |b| b.iter(|| drive_legacy(&cache, Some(body_len))));
+        group.bench_function("legacy/none_total_len", |b| b.iter(|| drive_legacy(&cache, None)));
+        group.bench_function("multer/raw_drain", |b| b.iter(|| drive_multer(&cache, body_len, MulterMode::RawDrain)));
+        group.bench_function("multer/aggregate", |b| b.iter(|| drive_multer(&cache, body_len, MulterMode::Aggregate)));
+        group.finish();
+    }
+
+    /// Diagnostic group: large fields region amplifies the legacy parser's
+    /// per-chunk re-parse of the accumulated buffer (O(n²/c) until the file part
+    /// signal arrives); multer scans forward.
+    fn bench_diagnostic(c: &mut Criterion) {
+        let cases = [
+            build_case("D-fields-64KiB", load_diag(64, 1024)),
+            build_case("D-fields-4MiB", load_diag(64, 64 * 1024)),
+        ];
+        for case in &cases {
+            verify(case);
+        }
+
+        let mut group = c.benchmark_group("multipart/diagnostic_fields_rescan");
+        apply_settings(&mut group, Settings::Diagnostic);
+        for case in &cases {
+            for &chunk in &[1024, 16 * 1024] {
+                register_pair(&mut group, case, chunk);
+            }
+        }
+        group.finish();
+    }
+
+    criterion_group!(benches, bench_main_matrix, bench_heavy_matrix, bench_reference, bench_diagnostic);
+}
+
+#[cfg(fuzzing)]
+criterion::criterion_main!(harness::benches);
+
+#[cfg(not(fuzzing))]
+fn main() {}


### PR DESCRIPTION
### Summary

Issue #803 rewrites the multipart form parser as a standalone crate. To position that work and to answer "why not adopt multer directly", we need reproducible evidence of how the legacy in-tree parser (`transform_multipart`, the parser s3s ships today) compares against multer, the most widely used Rust multipart crate. This PR adds a criterion benchmark that measures both parsers on identical inputs with a documented fairness protocol and differential output checks. It intentionally contains no production code changes.

### Changes

- Add `crates/s3s/benches/multipart_legacy_vs_multer.rs`. The harness lives behind the existing `cfg(fuzzing)` test-support surface (the same mechanism the external fuzz workspace uses to reach non-public internals), because `transform_multipart` is intentionally not part of the public API. Under a normal build the target compiles to an empty stub, so lint gates still cover the file with zero impact on published builds.
- Workload matrix: field-heavy loads (F), single-file loads (L: 64 KiB / 1 MiB / 16 MiB), a POST-Object-shaped load (M), each across 1/4/16/64 KiB chunkings; a 16 MiB heavy group; a reference group (unknown total length, and multer raw-drain consumption); and a diagnostic group with large pre-file field regions that exposes the legacy parser's per-chunk re-parse of the accumulated buffer (the pending signal-gating fix addresses exactly this).
- Fairness protocol: both parsers consume the exact same body bytes split into the exact same `Bytes` chunk sequence, with body and chunk caches built outside the timed region; `total_len` is always `Some` except in the reference group; multer's `Constraints` are set to the body length to avoid default-limit semantics; consumption reaches the same application endpoint (form fields aggregated, file part drained as a stream); both run on one thread under one allocator with alternating registration and `black_box` guards against dead-code elimination.
- Differential output checks at startup (outside the timed region): for every load and chunking, both parsers parse the same input and the harness asserts consumed byte totals against construction expectations plus byte-for-byte equality of the two parsers' outputs (field name/value pairs, normalized identically since the legacy parser lowercases and sorts field names, and file content). The reference group additionally asserts that the unknown-total-length path produces output identical to the exact-length path.
- Deterministic loads from a fixed-seed `StdRng`: field values are alphanumeric and file content is full-range pseudo-random, matching the roughly 1/256 CR byte density of real binary uploads (content with concentrated CR runs would skew the legacy parser's boundary scan).
- The benchmark process runs under mimalloc so both parsers share an allocator whose behavior does not depend on the memory history of earlier benchmarks.

### Performance results

Measured with criterion on an Intel i9-13900H, medians across seven full independent runs; both parsers consumed identical bytes split into identical chunks under one allocator, with startup differential output checks. Throughput is body bytes per second; `legacy/multer` is the ratio of medians. Workload labels follow the matrix described under Changes (F = field-heavy, L = single file part, M = POST-Object-shaped).

Main matrix and 16 MiB heavy group (throughput, GiB/s):

| case | chunk | legacy | multer | legacy/multer |
|---|---|---|---|---|
| F | 1 KiB | 0.86 | 1.69 | 0.51x |
| F | 4 KiB | 1.88 | 1.73 | 1.08x |
| F | 16 KiB | 3.06 | 1.74 | 1.74x |
| F | 64 KiB | 5.26 | 1.79 | 2.93x |
| L-64KiB | 1 KiB | 12.49 | 9.81 | 1.28x |
| L-64KiB | 4 KiB | 18.27 | 10.81 | 1.70x |
| L-64KiB | 16 KiB | 18.42 | 11.37 | 1.58x |
| L-64KiB | 64 KiB | 13.05 | 13.37 | 0.99x |
| L-1MiB | 1 KiB | 8.55 | 7.49 | 1.15x |
| L-1MiB | 4 KiB | 11.10 | 7.57 | 1.45x |
| L-1MiB | 16 KiB | 11.98 | 7.98 | 1.50x |
| L-1MiB | 64 KiB | 11.97 | 7.84 | 1.52x |
| M | 1 KiB | 8.68 | 7.29 | 1.18x |
| M | 4 KiB | 11.36 | 7.38 | 1.55x |
| M | 16 KiB | 12.17 | 7.63 | 1.59x |
| M | 64 KiB | 12.03 | 7.85 | 1.56x |
| L-16MiB | 1 KiB | 6.92 | 3.01 | 2.33x |
| L-16MiB | 4 KiB | 9.49 | 3.00 | 3.19x |
| L-16MiB | 16 KiB | 10.03 | 3.13 | 3.18x |
| L-16MiB | 64 KiB | 10.44 | 3.12 | 3.26x |

multer is flat at ~3.0-3.2 GiB/s on the 16 MiB file part regardless of chunk size - its byte-at-a-time internal buffer accumulation collapses on large parts - while the legacy streaming path reaches 6.9-10.4 GiB/s. multer is ahead only on the field-heavy load with 1 KiB chunks (~2x), reflecting the legacy parser's per-chunk state machine cost on many small chunks; the legacy parser is ahead at 16-64 KiB chunks (1.6-2.9x), on the mixed POST-Object-shaped load (1.2-1.6x), and on file parts at every size measured (1.0-1.7x at 64 KiB/1 MiB, 2.3-3.3x at 16 MiB).

Diagnostic group (large pre-file field regions; median time per parse):

| case | chunk | legacy | multer | legacy/multer |
|---|---|---|---|---|
| D-fields-64KiB | 1 KiB | 289 µs | 36.2 µs | 8.0x slower |
| D-fields-64KiB | 16 KiB | 30.6 µs | 36.6 µs | 1.16x faster |
| D-fields-4MiB | 1 KiB | 506 ms | 865 µs | ~585x slower |
| D-fields-4MiB | 16 KiB | 32.9 ms | 793 µs | ~41x slower |

The legacy parser degrades superlinearly with the pre-file field region - the per-chunk re-parse of the accumulated buffer that the pending signal-gating fix addresses - while multer scans forward and does not degrade.

Reference group (L-1MiB @ 16 KiB chunks, run after the full matrix):

| variant | median time | throughput |
|---|---|---|
| legacy/some_total_len | 81.8 µs | 11.94 GiB/s |
| legacy/none_total_len | 79.9 µs | 12.22 GiB/s |
| multer/aggregate | 127.6 µs | 7.66 GiB/s |
| multer/raw_drain | 129.9 µs | 7.52 GiB/s |

Parsing with unknown total length matches the exact-length path within 2.4% at the parser level, and multer raw-drain versus aggregate consumption differ by ~2%, confirming the consumption equivalence of the harness.

Fairness caveats travel with the numbers: the legacy parser additionally derives exact content length and validates the closing trailer - work multer does not perform - and its forced field aggregation is API surface rather than parser cost, so conclusions are stated only for the overlapping functional surface. Nothing in this PR depends on these numbers; they document the positioning of #803.

### Behavior notes

- No production code changes: the only source addition is the bench target, which is empty under normal builds; no public API changes, no semver impact.
- New dev-dependencies on the s3s crate only; published crate metadata is unaffected.
- The bench requires `RUSTFLAGS='--cfg fuzzing'` to build its real body, documented in the bench module docs.

### Tests

- `just dev` (fmt, codegen idempotency, clippy with `--all-targets`, full test suite): all green.
- The bench target compiles under both cfg variants (normal build: empty stub; `--cfg fuzzing`: full harness).
- Every bench run executes the startup differential checks first; all load and chunking configurations pass (any parser divergence or accounting error fails the run before measurement).

### Dependencies

- `criterion 0.8`, `multer 3.1.0`, `rand 0.10`, and `mimalloc 0.1` are declared in `[workspace.dependencies]` (new "Benchmarks" section) and referenced from s3s dev-dependencies via `workspace = true`. `rand` is already present transitively; the rest are new but dev-only.

Refs #803
